### PR TITLE
Use more idiomatic Single.fromCallable() in RxRoom

### DIFF
--- a/room/rxjava2/src/main/java/androidx/room/RxRoom.java
+++ b/room/rxjava2/src/main/java/androidx/room/RxRoom.java
@@ -222,16 +222,7 @@ public class RxRoom {
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     public static <T> Single<T> createSingle(final Callable<T> callable) {
-        return Single.create(new SingleOnSubscribe<T>() {
-            @Override
-            public void subscribe(SingleEmitter<T> emitter) throws Exception {
-                try {
-                    emitter.onSuccess(callable.call());
-                } catch (EmptyResultSetException e) {
-                    emitter.tryOnError(e);
-                }
-            }
-        });
+        return Single.fromCallable(callable);
     }
 
     private static Executor getExecutor(RoomDatabase database, boolean inTransaction) {

--- a/room/rxjava2/src/main/java/androidx/room/RxRoom.java
+++ b/room/rxjava2/src/main/java/androidx/room/RxRoom.java
@@ -33,8 +33,6 @@ import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.Scheduler;
 import io.reactivex.Single;
-import io.reactivex.SingleEmitter;
-import io.reactivex.SingleOnSubscribe;
 import io.reactivex.disposables.Disposables;
 import io.reactivex.functions.Action;
 import io.reactivex.functions.Function;

--- a/room/rxjava3/src/main/java/androidx/room/rxjava3/RxRoom.java
+++ b/room/rxjava3/src/main/java/androidx/room/rxjava3/RxRoom.java
@@ -171,13 +171,7 @@ public final class RxRoom {
     @NonNull
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     public static <T> Single<T> createSingle(@NonNull final Callable<T> callable) {
-        return Single.create(emitter -> {
-            try {
-                emitter.onSuccess(callable.call());
-            } catch (EmptyResultSetException e) {
-                emitter.tryOnError(e);
-            }
-        });
+        return Single.fromCallable(callable);
     }
 
     private static Executor getExecutor(@NonNull RoomDatabase database, boolean inTransaction) {


### PR DESCRIPTION
This is a more idiomatic built-in API from RxJava for creating a `Single` from a given `Callable`. Functionally it's the same, but with more pedantic internal checks and adherence to RxJava's conventional plugin system. `Single.create()` is more for bridging from non-first-class-APIs like external listeners, other concurrency frameworks, etc.

(this is also helping test a PR flow! CC @yigit) 