### PR TITLE
Change the name of Android SDK environment variable in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We have tried to make contributing to androidx a lot easier with this new setup.
   ```bash
   # You could also add this to your .{bash|zsh}rc file.
   export JAVA_HOME="location of JDK 11 folder"
-  export ANDROID_SDK_HOME="location of the Android SDK folder"
+  export ANDROID_SDK_ROOT="location of the Android SDK folder"
   ```
 
 ### Checkout & Importing a Project


### PR DESCRIPTION
Fix Android SDK env variable name in contribution guide.

Contributing guide used wrong env variable name in **One Time Setup** section. It should be `ANDROID_SDK_ROOT` instead of `ANDROID_SDK_HOME`. This change fixes it.

Test: not applicable
Fixes: not applicable