### PR TITLE
Fix Javadoc so that List<NameAndLastName> is not considered to be HTML

### DIFF
--- a/room/common/src/main/java/androidx/room/RewriteQueriesToDropUnusedColumns.java
+++ b/room/common/src/main/java/androidx/room/RewriteQueriesToDropUnusedColumns.java
@@ -35,8 +35,8 @@ import java.lang.annotation.Target;
  * <pre>
  * {@literal @}Dao
  * interface MyDao {
- *     {@literal @}Query("SELECT * FROM User")
- *     public List<NameAndLastName> getAll();
+ *     {@literal @Query("SELECT * FROM User")}
+ *     {@literal public List<NameAndLastName> getAll();}
  * }
  * class NameAndLastName {
  *     public String name;
@@ -51,9 +51,9 @@ import java.lang.annotation.Target;
  * <pre>
  * {@literal @}Dao
  * interface MyDao {
- *     {@literal @}RewriteQueriesToDropUnusedColumns
- *     {@literal @}Query("SELECT * FROM User")
- *     public List<NameAndLastName> getAll();
+ *     {@literal @RewriteQueriesToDropUnusedColumns}
+ *     {@literal @Query("SELECT * FROM User")}
+ *     {@literal public List<NameAndLastName> getAll();}
  * }
  * </pre>
  * At compile time, Room will convert this query to {@code SELECT name, lastName FROM (SELECT *


### PR DESCRIPTION
## Proposed Changes

  - Fix Javadoc so that List<NameAndLastName> is not considered to be HTML
  - Also simplify the {@literal} usage so that the javadoc is easier to read in code

## Testing

Test: `javadoc` command
