### PR TITLE
set androidx property via gradlew

### DIFF
--- a/playground-common/gradlew
+++ b/playground-common/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS="-Dorg.gradle.jvmargs=-Xmx3g"
+DEFAULT_JVM_OPTS="-Dorg.gradle.jvmargs=-Xmx3g -Dorg.gradle.project.android.useAndroidX=true"
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
This is a quick hack to fix the build.

The way we are currently copying gradle.properties is not fast
enough for configuration time. On the other hand, we cannot move
them into a real gradle.properties file because the main androidx
build ends up reading them.

I'm sending this PR to at least fix the workflow build until
finding a better solution than copying them in settings gradle
file

Test: ./gradlew bOS

