### PR TITLE
Trigger the workflows on push.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,5 +1,6 @@
 name: AndroidX Presubmits
 on:
+  push:
   pull_request:
     types: [opened, synchronize, reopened]
   pull_request_review:


### PR DESCRIPTION
* This will ensure that we catch breakages faster.
* `push`  ensures that pushes to `androidx-master-dev` builds everytime copybara merges commits. If they fail at least we when. 

Test: Workflows.
