### PR TITLE
Add support for `pull_request_target` events.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,6 +1,8 @@
 name: AndroidX Presubmits
 on:
   push:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
   pull_request:
     types: [opened, synchronize, reopened]
   pull_request_review:


### PR DESCRIPTION
* This allows us to share secrets with actions, because the workflow
  gets triggered in the `base` context.

Test: Will need to run additional tests after the PR lands.
