### PR TITLE
Update build.gradle

### DIFF
--- a/security/security-crypto-ktx/build.gradle
+++ b/security/security-crypto-ktx/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
 android {
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 21
     }
 }
 


### PR DESCRIPTION
Since the main java library is bumped to API 21 this can too because when using this version the manifest wants to override the library's SDK if using < 23

Whereas the https://github.com/androidx/androidx/blob/androidx-master-dev/security/crypto/build.gradle
uses minSdkVersion 21

Test: ./gradlew bOS