### PR TITLE
Fix OUT_DIR default to path that exists within GH checkout

### DIFF
--- a/playground-common/out.gradle
+++ b/playground-common/out.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 The Android Open Source Project
+ * Copyright (C) 2020 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/playground-common/out.gradle
+++ b/playground-common/out.gradle
@@ -21,15 +21,9 @@ def chooseOutDir(subdir = "") {
     /*
      * The OUT_DIR is a temporary directory you can use to put things during the build.
      */
-    def outDir = System.env.OUT_DIR
-    if (outDir == null) {
-        outDir = new File("${buildscript.getSourceFile().parent}/../out${subdir}")
-    } else {
-        outDir = new File(outDir)
-    }
+    def outDir = new File("${buildscript.getSourceFile().parent}/../out${subdir}")
     project.ext.outDir = outDir
-    buildDir = new File(outDir, "$project.name/build")
-                .getCanonicalFile()
+    buildDir = new File(outDir, "$project.name/build").getCanonicalFile()
     subprojects {
         // Change buildDir first so that all plugins pick up the new value.
         project.buildDir = new File("$project.parent.buildDir/../$project.name/build")

--- a/playground-common/out.gradle
+++ b/playground-common/out.gradle
@@ -18,9 +18,6 @@ def init = new Properties()
 ext.init = init
 
 def chooseOutDir(subdir = "") {
-    /*
-     * The OUT_DIR is a temporary directory you can use to put things during the build.
-     */
     def outDir = new File("${buildscript.getSourceFile().parent}/../out${subdir}")
     project.ext.outDir = outDir
     buildDir = new File(outDir, "$project.name/build").getCanonicalFile()

--- a/playground-common/out.gradle
+++ b/playground-common/out.gradle
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+def init = new Properties()
+ext.init = init
+
+def chooseOutDir(subdir = "") {
+    /*
+     * The OUT_DIR is a temporary directory you can use to put things during the build.
+     */
+    def outDir = System.env.OUT_DIR
+    if (outDir == null) {
+        outDir = new File("${buildscript.getSourceFile().parent}/../out${subdir}")
+    } else {
+        outDir = new File(outDir)
+    }
+    project.ext.outDir = outDir
+    buildDir = new File(outDir, "$project.name/build")
+                .getCanonicalFile()
+    subprojects {
+        // Change buildDir first so that all plugins pick up the new value.
+        project.buildDir = new File("$project.parent.buildDir/../$project.name/build")
+    }
+}
+
+ext.init.chooseOutDir = this.&chooseOutDir

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -61,9 +61,9 @@ buildscript {
         classpath "com.github.jengelman.gradle.plugins:shadow:5.2.0"
     }
 }
-apply from: "../buildSrc/dependencies.gradle"
 
-apply from: "../buildSrc/out.gradle"
+apply from: "../buildSrc/dependencies.gradle"
+apply from: "../playground-common/out.gradle"
 init.chooseOutDir("/${rootProject.name}")
 
 apply plugin: AndroidXRootPlugin


### PR DESCRIPTION
Previously, `OUT_DIR` defaulted to a path that exists outside of the root folder for github checkout (it assumes this repo is nested in frameworks/support). This allows playground projects to ensure the OUT_DIR is writable when it is not specified.

Test: cd room && ./gradlew bOS