### PR TITLE
hide deprecated internal api

### DIFF
--- a/room/runtime/src/main/java/androidx/room/RoomDatabase.java
+++ b/room/runtime/src/main/java/androidx/room/RoomDatabase.java
@@ -90,8 +90,9 @@ public abstract class RoomDatabase {
     boolean mWriteAheadLoggingEnabled;
 
     /**
-     * @deprecated Will be hidden in the next release.
+     * @hide
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     @Nullable
     @Deprecated
     protected List<Callback> mCallbacks;


### PR DESCRIPTION
## Proposed Changes

* `RoomDatabase.java` has protected `mCallbacks` field which is leaking in the API docs, we should @Hide it.

## Testing

Test: ran unit tests locally

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/76109329
