### PR TITLE
Switch to using labels to retrigger a workflow.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,9 +2,7 @@ name: AndroidX Presubmits
 on:
   push:
   pull_request_target:
-    types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted, edited]
+    types: [opened, synchronize, reopened, 'labeled']
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
* `pull_request_review_comment`s happen a lot more frequently than labelling a PR.
* This method is easier than having to write an action that invokes a `bot`.

Test: Workflows run on GitHub.
