### PR TITLE
Set Gradle project group from AndroidXExtension

### DIFF
--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXExtension.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXExtension.kt
@@ -33,7 +33,9 @@ open class AndroidXExtension(val project: Project) {
         }
     var mavenGroup: LibraryGroup? = null
         set(value) {
+            check(value != null)
             field = value
+            project.group = value.group
             chooseProjectVersion()
         }
 


### PR DESCRIPTION
Previously, setting AndroidXExtension.mavenGroup did not set the
group attribute of the Gradle project instance. Thus Gradle would
compute a default group name, which could differ from the intended
group name declared via androidx.mavenGroup.

For example, running `./gradlew buildOnServer` in the work/ directory
would result in a group name of 'work-playground.work'. This caused
several Lint errors related to the @RestrictTo annotation, because
Lint was seeing the wrong maven groupId.

There are many other suppressed @RestrictTo errors in other modules
as well. They can probably be revisited after this commit.

Test: run `./gradlew buildOnServer` in the `work/` directory
Bug: not filed