### PR TITLE
Replace ConcurrentHashMap with Collections.synchronizedMap()

### DIFF
--- a/room/runtime/src/main/java/androidx/room/RoomDatabase.java
+++ b/room/runtime/src/main/java/androidx/room/RoomDatabase.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -129,7 +128,8 @@ public abstract class RoomDatabase {
     }
 
 
-    private final Map<String, Object> mBackingFieldMap = new ConcurrentHashMap<>();
+    private final Map<String, Object> mBackingFieldMap =
+            Collections.synchronizedMap(new HashMap<>());
 
     /**
      * Gets the map for storing extension properties of Kotlin type.


### PR DESCRIPTION
## Proposed Changes

  - Replace the `ConcurrentHashMap` inside `RoomDatabase` with `Collections.synchronizedMap()` to avoid issues on Android Lollipop
## Testing

Test: N/A, only switched out a class

## Issues Fixed

Fixes: 162431855
