### PR TITLE
PagingData transformation functions

### DIFF
--- a/paging/common/src/main/kotlin/androidx/paging/PagingData.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/PagingData.kt
@@ -17,12 +17,7 @@
 package androidx.paging
 
 import androidx.annotation.CheckResult
-import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
@@ -109,13 +104,6 @@ class PagingData<T : Any> internal constructor(
     @CheckResult
     fun insertFooterItem(item: T) = insertSeparators { _, after ->
         if (after == null) item else null
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    suspend fun getFirstPageData(): List<T> {
-        val pageEvent = flow.filterIsInstance<PageEvent.Insert<T>>().firstOrNull()
-        return pageEvent?.pages?.firstOrNull()?.data ?: emptyList()
     }
 
     companion object {

--- a/paging/common/src/main/kotlin/androidx/paging/PagingData.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/PagingData.kt
@@ -17,7 +17,12 @@
 package androidx.paging
 
 import androidx.annotation.CheckResult
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
@@ -104,6 +109,13 @@ class PagingData<T : Any> internal constructor(
     @CheckResult
     fun insertFooterItem(item: T) = insertSeparators { _, after ->
         if (after == null) item else null
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    suspend fun getFirstPageData(): List<T> {
+        val pageEvent = flow.filterIsInstance<PageEvent.Insert<T>>().firstOrNull()
+        return pageEvent?.pages?.firstOrNull()?.data ?: emptyList()
     }
 
     companion object {

--- a/paging/guava/api/current.txt
+++ b/paging/guava/api/current.txt
@@ -25,10 +25,10 @@ package androidx.paging {
   }
 
   public final class PagingDataFutures {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/current.txt
+++ b/paging/guava/api/current.txt
@@ -1,6 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
+  public final class ListenableFuturePagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  }
+
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public ListenableFuturePagingSource();
     method public suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> p, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> $completion);

--- a/paging/guava/api/current.txt
+++ b/paging/guava/api/current.txt
@@ -1,11 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ListenableFuturePagingDataKt {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  public final class ElementPair<T> {
+    ctor public ElementPair(T? before, T? after);
+    method public T? component1();
+    method public T? component2();
+    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public T? getAfter();
+    method public T? getBefore();
   }
 
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
@@ -20,6 +22,13 @@ package androidx.paging {
     method public com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.InitializeAction> initializeFuture();
     method public final suspend Object? load(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state, kotlin.coroutines.Continuation<? super androidx.paging.RemoteMediator.MediatorResult> p);
     method public abstract com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.MediatorResult> loadFuture(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state);
+  }
+
+  public final class PagingDataFutures {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/current.txt
+++ b/paging/guava/api/current.txt
@@ -1,11 +1,11 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ElementPair<T> {
-    ctor public ElementPair(T? before, T? after);
+  public final class AdjacentItems<T> {
+    ctor public AdjacentItems(T? before, T? after);
     method public T? component1();
     method public T? component2();
-    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public androidx.paging.AdjacentItems<T> copy(T? before, T? after);
     method public T? getAfter();
     method public T? getBefore();
   }
@@ -27,7 +27,7 @@ package androidx.paging {
   public final class PagingDataFutures {
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 

--- a/paging/guava/api/public_plus_experimental_current.txt
+++ b/paging/guava/api/public_plus_experimental_current.txt
@@ -25,10 +25,10 @@ package androidx.paging {
   }
 
   public final class PagingDataFutures {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/public_plus_experimental_current.txt
+++ b/paging/guava/api/public_plus_experimental_current.txt
@@ -1,6 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
+  public final class ListenableFuturePagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  }
+
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public ListenableFuturePagingSource();
     method public suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> p, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> $completion);

--- a/paging/guava/api/public_plus_experimental_current.txt
+++ b/paging/guava/api/public_plus_experimental_current.txt
@@ -1,11 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ListenableFuturePagingDataKt {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  public final class ElementPair<T> {
+    ctor public ElementPair(T? before, T? after);
+    method public T? component1();
+    method public T? component2();
+    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public T? getAfter();
+    method public T? getBefore();
   }
 
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
@@ -20,6 +22,13 @@ package androidx.paging {
     method public com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.InitializeAction> initializeFuture();
     method public final suspend Object? load(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state, kotlin.coroutines.Continuation<? super androidx.paging.RemoteMediator.MediatorResult> p);
     method public abstract com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.MediatorResult> loadFuture(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state);
+  }
+
+  public final class PagingDataFutures {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/public_plus_experimental_current.txt
+++ b/paging/guava/api/public_plus_experimental_current.txt
@@ -1,11 +1,11 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ElementPair<T> {
-    ctor public ElementPair(T? before, T? after);
+  public final class AdjacentItems<T> {
+    ctor public AdjacentItems(T? before, T? after);
     method public T? component1();
     method public T? component2();
-    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public androidx.paging.AdjacentItems<T> copy(T? before, T? after);
     method public T? getAfter();
     method public T? getBefore();
   }
@@ -27,7 +27,7 @@ package androidx.paging {
   public final class PagingDataFutures {
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 

--- a/paging/guava/api/restricted_current.txt
+++ b/paging/guava/api/restricted_current.txt
@@ -25,10 +25,10 @@ package androidx.paging {
   }
 
   public final class PagingDataFutures {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/restricted_current.txt
+++ b/paging/guava/api/restricted_current.txt
@@ -1,6 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
+  public final class ListenableFuturePagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  }
+
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public ListenableFuturePagingSource();
     method public suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> p, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> $completion);

--- a/paging/guava/api/restricted_current.txt
+++ b/paging/guava/api/restricted_current.txt
@@ -1,11 +1,13 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ListenableFuturePagingDataKt {
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<java.lang.Iterable<R>>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapFuture(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends com.google.common.util.concurrent.ListenableFuture<R>> transform);
+  public final class ElementPair<T> {
+    ctor public ElementPair(T? before, T? after);
+    method public T? component1();
+    method public T? component2();
+    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public T? getAfter();
+    method public T? getBefore();
   }
 
   public abstract class ListenableFuturePagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
@@ -20,6 +22,13 @@ package androidx.paging {
     method public com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.InitializeAction> initializeFuture();
     method public final suspend Object? load(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state, kotlin.coroutines.Continuation<? super androidx.paging.RemoteMediator.MediatorResult> p);
     method public abstract com.google.common.util.concurrent.ListenableFuture<androidx.paging.RemoteMediator.MediatorResult> loadFuture(androidx.paging.LoadType loadType, androidx.paging.PagingState<Key,Value> state);
+  }
+
+  public final class PagingDataFutures {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 
 }

--- a/paging/guava/api/restricted_current.txt
+++ b/paging/guava/api/restricted_current.txt
@@ -1,11 +1,11 @@
 // Signature format: 3.0
 package androidx.paging {
 
-  public final class ElementPair<T> {
-    ctor public ElementPair(T? before, T? after);
+  public final class AdjacentItems<T> {
+    ctor public AdjacentItems(T? before, T? after);
     method public T? component1();
     method public T? component2();
-    method public androidx.paging.ElementPair<T> copy(T? before, T? after);
+    method public androidx.paging.AdjacentItems<T> copy(T? before, T? after);
     method public T? getAfter();
     method public T? getBefore();
   }
@@ -27,7 +27,7 @@ package androidx.paging {
   public final class PagingDataFutures {
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Boolean> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,java.lang.Iterable<R>> transform);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.ElementPair<T>,R> generator);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<androidx.paging.AdjacentItems<T>,R> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapAsync(androidx.paging.PagingData<T>, com.google.common.util.concurrent.AsyncFunction<T,R> transform);
   }
 

--- a/paging/guava/build.gradle
+++ b/paging/guava/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     api("androidx.concurrent:concurrent-futures-ktx:1.1.0-alpha01")
 
     testImplementation(project(":internal-testutils-common"))
+    testImplementation(project(":internal-testutils-paging"))
     testImplementation(JUNIT)
     testImplementation(KOTLIN_TEST)
     testImplementation(KOTLIN_COROUTINES_TEST)

--- a/paging/guava/build.gradle
+++ b/paging/guava/build.gradle
@@ -31,7 +31,6 @@ plugins {
 dependencies {
     api(project(":paging:paging-common"))
     api(KOTLIN_STDLIB)
-    api("androidx.concurrent:concurrent-futures-ktx:1.1.0-alpha01")
     api(GUAVA_ANDROID)
 
     testImplementation(project(":internal-testutils-common"))

--- a/paging/guava/build.gradle
+++ b/paging/guava/build.gradle
@@ -31,6 +31,7 @@ plugins {
 dependencies {
     api(project(":paging:paging-common"))
     api(KOTLIN_STDLIB)
+    api("androidx.concurrent:concurrent-futures-ktx:1.1.0-alpha01")
     api(GUAVA_ANDROID)
 
     testImplementation(project(":internal-testutils-common"))

--- a/paging/guava/build.gradle
+++ b/paging/guava/build.gradle
@@ -31,8 +31,8 @@ plugins {
 dependencies {
     api(project(":paging:paging-common"))
     api(KOTLIN_STDLIB)
-    api("androidx.concurrent:concurrent-futures-ktx:1.1.0-alpha01")
     api(GUAVA_ANDROID)
+    implementation(KOTLIN_COROUTINES_GUAVA)
 
     testImplementation(project(":internal-testutils-common"))
     testImplementation(project(":internal-testutils-paging"))

--- a/paging/guava/build.gradle
+++ b/paging/guava/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     api(project(":paging:paging-common"))
     api(KOTLIN_STDLIB)
     api("androidx.concurrent:concurrent-futures-ktx:1.1.0-alpha01")
+    api(GUAVA_ANDROID)
 
     testImplementation(project(":internal-testutils-common"))
     testImplementation(project(":internal-testutils-paging"))

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.AsyncFunction
  * Returns a [PagingData] containing the result of applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("map")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.mapAsync(
     transform: AsyncFunction<T, R>
@@ -35,6 +36,7 @@ fun <T : Any, R : Any> PagingData<T>.mapAsync(
  * Returns a [PagingData] of all elements returned from applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("flatMap")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.flatMapAsync(
     transform: AsyncFunction<T, Iterable<R>>
@@ -43,6 +45,7 @@ fun <T : Any, R : Any> PagingData<T>.flatMapAsync(
 /**
  * Returns a [PagingData] containing only elements matching the given [predicate].
  */
+@JvmName("filter")
 @CheckResult
 fun <T : Any> PagingData<T>.filterAsync(
     predicate: AsyncFunction<T, Boolean>
@@ -58,6 +61,7 @@ fun <T : Any> PagingData<T>.filterAsync(
  * @sample androidx.paging.samples.insertSeparatorsFutureSample
  * @sample androidx.paging.samples.insertSeparatorsUiModelFutureSample
  */
+@JvmName("insertSeparators")
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsAsync(
     generator: AsyncFunction<AdjacentItems<T>, R?>

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -60,13 +60,12 @@ fun <T : Any> PagingData<T>.filterAsync(
  */
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsAsync(
-    generator: AsyncFunction<ElementPair<T>, R?>
+    generator: AsyncFunction<AdjacentItems<T>, R?>
 ): PagingData<R> = insertSeparators { before, after ->
-    generator.apply(ElementPair(before, after)).await()
+    generator.apply(AdjacentItems(before, after)).await()
 }
 
 /**
- * Represents a pair of elements that are next to each other. Null values are used to signal
- * boundary conditions.
+ * Represents a pair of adjacent items, null values are used to signal boundary conditions.
  */
-data class ElementPair<T>(val before: T?, val after: T?)
+data class AdjacentItems<T>(val before: T?, val after: T?)

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -19,8 +19,8 @@
 package androidx.paging
 
 import androidx.annotation.CheckResult
-import androidx.concurrent.futures.await
 import com.google.common.util.concurrent.AsyncFunction
+import kotlinx.coroutines.guava.await
 
 /**
  * Returns a [PagingData] containing the result of applying the given [transform] to each

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -14,39 +14,39 @@
  * limitations under the License.
  */
 
-@file:JvmName("PagingFuture")
+@file:JvmName("PagingDataFutures")
 
 package androidx.paging
 
 import androidx.annotation.CheckResult
 import androidx.concurrent.futures.await
-import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.AsyncFunction
 
 /**
  * Returns a [PagingData] containing the result of applying the given [transform] to each
  * element, as it is loaded.
  */
 @CheckResult
-fun <T : Any, R : Any> PagingData<T>.mapFuture(
-    transform: (T) -> ListenableFuture<R>
-): PagingData<R> = map { transform(it).await() }
+fun <T : Any, R : Any> PagingData<T>.mapAsync(
+    transform: AsyncFunction<T, R>
+): PagingData<R> = map { transform.apply(it).await() }
 
 /**
  * Returns a [PagingData] of all elements returned from applying the given [transform] to each
  * element, as it is loaded.
  */
 @CheckResult
-fun <T : Any, R : Any> PagingData<T>.flatMapFuture(
-    transform: (T) -> ListenableFuture<Iterable<R>>
-): PagingData<R> = flatMap { transform(it).await() }
+fun <T : Any, R : Any> PagingData<T>.flatMapAsync(
+    transform: AsyncFunction<T, Iterable<R>>
+): PagingData<R> = flatMap { transform.apply(it).await() }
 
 /**
  * Returns a [PagingData] containing only elements matching the given [predicate].
  */
 @CheckResult
-fun <T : Any> PagingData<T>.filterFuture(
-    predicate: (T) -> ListenableFuture<Boolean>
-): PagingData<T> = filter { predicate(it).await() }
+fun <T : Any> PagingData<T>.filterAsync(
+    predicate: AsyncFunction<T, Boolean>
+): PagingData<T> = filter { predicate.apply(it).await() }
 
 /**
  * Returns a [PagingData] containing each original element, with an optional separator generated
@@ -59,6 +59,14 @@ fun <T : Any> PagingData<T>.filterFuture(
  * @sample androidx.paging.samples.insertSeparatorsUiModelFutureSample
  */
 @CheckResult
-fun <T : R, R : Any> PagingData<T>.insertSeparatorsFuture(
-    generator: (T?, T?) -> ListenableFuture<R?>
-): PagingData<R> = insertSeparators { before, after -> generator(before, after).await() }
+fun <T : R, R : Any> PagingData<T>.insertSeparatorsAsync(
+    generator: AsyncFunction<ElementPair<T>, R?>
+): PagingData<R> = insertSeparators { before, after ->
+    generator.apply(ElementPair(before, after)).await()
+}
+
+/**
+ * Represents a pair of elements that are next to each other. Null values are used to signal
+ * boundary conditions.
+ */
+data class ElementPair<T>(val before: T?, val after: T?)

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:JvmName("PagingFuture")
+
 package androidx.paging
 
 import androidx.annotation.CheckResult
@@ -53,10 +55,10 @@ fun <T : Any> PagingData<T>.filterFuture(
  * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
  * between pages are only computed once both pages are loaded.
  *
- * @sample androidx.paging.samples.insertSeparatorsSample
- * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ * @sample androidx.paging.samples.insertSeparatorsFutureSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelFutureSample
  */
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsFuture(
     generator: (T?, T?) -> ListenableFuture<R?>
-): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }
+): PagingData<R> = insertSeparators { before, after -> generator(before, after).await() }

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingData.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging
+
+import androidx.annotation.CheckResult
+import androidx.concurrent.futures.await
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * Returns a [PagingData] containing the result of applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.mapFuture(
+    transform: (T) -> ListenableFuture<R>
+): PagingData<R> = map { transform(it).await() }
+
+/**
+ * Returns a [PagingData] of all elements returned from applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.flatMapFuture(
+    transform: (T) -> ListenableFuture<Iterable<R>>
+): PagingData<R> = flatMap { transform(it).await() }
+
+/**
+ * Returns a [PagingData] containing only elements matching the given [predicate].
+ */
+@CheckResult
+fun <T : Any> PagingData<T>.filterFuture(
+    predicate: (T) -> ListenableFuture<Boolean>
+): PagingData<T> = filter { predicate(it).await() }
+
+/**
+ * Returns a [PagingData] containing each original element, with an optional separator generated
+ * by [generator], given the elements before and after (or null, in boundary conditions).
+ *
+ * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
+ * between pages are only computed once both pages are loaded.
+ *
+ * @sample androidx.paging.samples.insertSeparatorsSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ */
+@CheckResult
+fun <T : R, R : Any> PagingData<T>.insertSeparatorsFuture(
+    generator: (T?, T?) -> ListenableFuture<R?>
+): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }

--- a/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingSource.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFuturePagingSource.kt
@@ -16,8 +16,8 @@
 
 package androidx.paging
 
-import androidx.concurrent.futures.await
 import com.google.common.util.concurrent.ListenableFuture
+import kotlinx.coroutines.guava.await
 
 /**
  * [ListenableFuture]-based compatibility wrapper around [PagingSource]'s suspending APIs.

--- a/paging/guava/src/main/java/androidx/paging/ListenableFutureRemoteMediator.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFutureRemoteMediator.kt
@@ -17,8 +17,8 @@
 package androidx.paging
 
 import androidx.paging.RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH
+import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.guava.await
 
 /**
@@ -75,8 +75,7 @@ abstract class ListenableFutureRemoteMediator<Key : Any, Value : Any> :
      *  refresh request from the UI before dispatching a [load] with load type [LoadType.REFRESH].
      */
     open fun initializeFuture(): ListenableFuture<InitializeAction> {
-        return SettableFuture.create<InitializeAction>()
-            .also { it.set(LAUNCH_INITIAL_REFRESH) }
+        return Futures.immediateFuture(LAUNCH_INITIAL_REFRESH)
     }
 
     final override suspend fun load(

--- a/paging/guava/src/main/java/androidx/paging/ListenableFutureRemoteMediator.kt
+++ b/paging/guava/src/main/java/androidx/paging/ListenableFutureRemoteMediator.kt
@@ -16,10 +16,10 @@
 
 package androidx.paging
 
-import androidx.concurrent.futures.ResolvableFuture
-import androidx.concurrent.futures.await
 import androidx.paging.RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import kotlinx.coroutines.guava.await
 
 /**
  * [ListenableFuture]-based  compatibility wrapper around [RemoteMediator]'s suspending APIs.
@@ -75,7 +75,7 @@ abstract class ListenableFutureRemoteMediator<Key : Any, Value : Any> :
      *  refresh request from the UI before dispatching a [load] with load type [LoadType.REFRESH].
      */
     open fun initializeFuture(): ListenableFuture<InitializeAction> {
-        return ResolvableFuture.create<InitializeAction>()
+        return SettableFuture.create<InitializeAction>()
             .also { it.set(LAUNCH_INITIAL_REFRESH) }
     }
 

--- a/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingDataTest.kt
+++ b/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingDataTest.kt
@@ -63,10 +63,12 @@ class ListenableFuturePagingDataTest {
 
     @Test
     fun insertSeparators() = testDispatcher.runBlockingTest {
-        val separated = original.insertSeparatorsAsync(AsyncFunction<ElementPair<String>, String?> {
-            val (before, after) = it!!
-            Futures.immediateFuture(if (before == null || after == null) null else "|")
-        })
+        val separated = original.insertSeparatorsAsync(
+            AsyncFunction<AdjacentItems<String>, String?> {
+                val (before, after) = it!!
+                Futures.immediateFuture(if (before == null || after == null) null else "|")
+            }
+        )
         differ.collectFrom(separated)
         assertEquals(listOf("a", "|", "b", "|", "c"), differ.currentList)
     }

--- a/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingDataTest.kt
+++ b/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingDataTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging
+
+import androidx.concurrent.futures.CallbackToFutureAdapter
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ListenableFuturePagingDataTest {
+    private val original = PagingData.from(listOf("a", "b", "c"))
+
+    @Test
+    fun map() = runBlocking {
+        val transformed = original.mapFuture {
+            CallbackToFutureAdapter.getFuture<String> { completer -> completer.set(it + it) }
+        }
+        assertEquals(listOf("aa", "bb", "cc"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun flatMap() = runBlocking {
+        val transformed = original.flatMapFuture {
+            CallbackToFutureAdapter.getFuture<Iterable<String>> { completer ->
+                completer.set(listOf(it, it)) }
+        }
+        assertEquals(listOf("a", "a", "b", "b", "c", "c"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun filter() = runBlocking {
+        val filtered = original.filterFuture {
+            CallbackToFutureAdapter.getFuture { completer -> completer.set(it != "b") }
+        }
+        assertEquals(listOf("a", "c"), filtered.getFirstPageData())
+    }
+
+    @Test
+    fun insertSeparators() = runBlocking {
+        val separated = original.insertSeparatorsFuture { left, right ->
+            CallbackToFutureAdapter.getFuture<String?> { completer ->
+                completer.set(if (left == null || right == null) null else "|")
+            }
+        }
+        assertEquals(listOf("a", "|", "b", "|", "c"), separated.getFirstPageData())
+    }
+}

--- a/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingSourceTest.kt
+++ b/paging/guava/src/test/java/androidx/paging/ListenableFuturePagingSourceTest.kt
@@ -16,10 +16,10 @@
 
 package androidx.paging
 
-import androidx.concurrent.futures.ResolvableFuture
 import androidx.paging.PagingSource.LoadParams
 import androidx.paging.PagingSource.LoadResult.Page
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,7 +48,7 @@ class ListenableFuturePagingSourceTest {
 
     private val listenableFuturePagingSource = object : ListenableFuturePagingSource<Int, Int>() {
         override fun loadFuture(params: LoadParams<Int>): ListenableFuture<LoadResult<Int, Int>> {
-            val future = ResolvableFuture.create<LoadResult<Int, Int>>()
+            val future = SettableFuture.create<LoadResult<Int, Int>>()
             try {
                 future.set(loadInternal(params))
             } catch (e: IllegalArgumentException) {

--- a/paging/guava/src/test/java/androidx/paging/ListenableFutureRemoteMediatorTest.kt
+++ b/paging/guava/src/test/java/androidx/paging/ListenableFutureRemoteMediatorTest.kt
@@ -16,10 +16,10 @@
 
 package androidx.paging
 
-import androidx.concurrent.futures.ResolvableFuture
 import androidx.paging.RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH
 import androidx.paging.RemoteMediator.InitializeAction.SKIP_INITIAL_REFRESH
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -41,7 +41,7 @@ class ListenableFutureRemoteMediatorTest {
                 fail("Unexpected call")
             }
 
-            override fun initializeFuture() = ResolvableFuture.create<InitializeAction>()
+            override fun initializeFuture() = SettableFuture.create<InitializeAction>()
                 .also { it.set(SKIP_INITIAL_REFRESH) }
         }
 

--- a/paging/guava/src/test/java/androidx/paging/ListenableFutureRemoteMediatorTest.kt
+++ b/paging/guava/src/test/java/androidx/paging/ListenableFutureRemoteMediatorTest.kt
@@ -18,8 +18,8 @@ package androidx.paging
 
 import androidx.paging.RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH
 import androidx.paging.RemoteMediator.InitializeAction.SKIP_INITIAL_REFRESH
+import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import com.google.common.util.concurrent.SettableFuture
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
@@ -41,8 +41,7 @@ class ListenableFutureRemoteMediatorTest {
                 fail("Unexpected call")
             }
 
-            override fun initializeFuture() = SettableFuture.create<InitializeAction>()
-                .also { it.set(SKIP_INITIAL_REFRESH) }
+            override fun initializeFuture() = Futures.immediateFuture(SKIP_INITIAL_REFRESH)
         }
 
         assertEquals(SKIP_INITIAL_REFRESH, remoteMediator.initialize())

--- a/paging/rxjava2/api/current.txt
+++ b/paging/rxjava2/api/current.txt
@@ -30,15 +30,23 @@ package androidx.paging {
 package androidx.paging.rxjava2 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }

--- a/paging/rxjava2/api/current.txt
+++ b/paging/rxjava2/api/current.txt
@@ -36,6 +36,13 @@ package androidx.paging.rxjava2 {
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava2/api/current.txt
+++ b/paging/rxjava2/api/current.txt
@@ -32,23 +32,23 @@ package androidx.paging.rxjava2 {
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava2/api/public_plus_experimental_current.txt
+++ b/paging/rxjava2/api/public_plus_experimental_current.txt
@@ -30,15 +30,23 @@ package androidx.paging {
 package androidx.paging.rxjava2 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }

--- a/paging/rxjava2/api/public_plus_experimental_current.txt
+++ b/paging/rxjava2/api/public_plus_experimental_current.txt
@@ -36,6 +36,13 @@ package androidx.paging.rxjava2 {
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava2/api/public_plus_experimental_current.txt
+++ b/paging/rxjava2/api/public_plus_experimental_current.txt
@@ -32,23 +32,23 @@ package androidx.paging.rxjava2 {
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava2/api/restricted_current.txt
+++ b/paging/rxjava2/api/restricted_current.txt
@@ -30,15 +30,23 @@ package androidx.paging {
 package androidx.paging.rxjava2 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }

--- a/paging/rxjava2/api/restricted_current.txt
+++ b/paging/rxjava2/api/restricted_current.txt
@@ -36,6 +36,13 @@ package androidx.paging.rxjava2 {
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava2/api/restricted_current.txt
+++ b/paging/rxjava2/api/restricted_current.txt
@@ -32,23 +32,23 @@ package androidx.paging.rxjava2 {
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava2/src/main/java/androidx/paging/rxjava2/PagingRx.kt
+++ b/paging/rxjava2/src/main/java/androidx/paging/rxjava2/PagingRx.kt
@@ -15,6 +15,7 @@
  */
 
 @file:JvmName("PagingRx")
+@file:JvmMultifileClass
 
 package androidx.paging.rxjava2
 

--- a/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
+++ b/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.rxjava2
+
+import androidx.annotation.CheckResult
+import androidx.paging.PagingData
+import androidx.paging.filter
+import androidx.paging.flatMap
+import androidx.paging.insertSeparators
+import androidx.paging.map
+import io.reactivex.Maybe
+import io.reactivex.Single
+import kotlinx.coroutines.rx2.await
+
+/**
+ * Returns a [PagingData] containing the result of applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.mapRx(
+    transform: (T) -> Single<R>
+): PagingData<R> = map { transform(it).await() }
+
+/**
+ * Returns a [PagingData] of all elements returned from applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.flatMapRx(
+    transform: (T) -> Single<Iterable<R>>
+): PagingData<R> = flatMap { transform(it).await() }
+
+/**
+ * Returns a [PagingData] containing only elements matching the given [predicate].
+ */
+@CheckResult
+fun <T : Any> PagingData<T>.filterRx(
+    predicate: (T) -> Single<Boolean>
+): PagingData<T> = filter { predicate(it).await() }
+
+/**
+ * Returns a [PagingData] containing each original element, with an optional separator generated
+ * by [generator], given the elements before and after (or null, in boundary conditions).
+ *
+ * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
+ * between pages are only computed once both pages are loaded.
+ *
+ * @sample androidx.paging.samples.insertSeparatorsSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ */
+@CheckResult
+fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
+    generator: (T?, T?) -> Maybe<R>
+): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }

--- a/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
+++ b/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.rx2.await
  * Returns a [PagingData] containing the result of applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("map")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.mapRx(
     transform: (T) -> Single<R>
@@ -42,6 +43,7 @@ fun <T : Any, R : Any> PagingData<T>.mapRx(
  * Returns a [PagingData] of all elements returned from applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("flatMap")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.flatMapRx(
     transform: (T) -> Single<Iterable<R>>
@@ -50,6 +52,7 @@ fun <T : Any, R : Any> PagingData<T>.flatMapRx(
 /**
  * Returns a [PagingData] containing only elements matching the given [predicate].
  */
+@JvmName("filter")
 @CheckResult
 fun <T : Any> PagingData<T>.filterRx(
     predicate: (T) -> Single<Boolean>
@@ -65,6 +68,7 @@ fun <T : Any> PagingData<T>.filterRx(
  * @sample androidx.paging.samples.insertSeparatorsRxSample
  * @sample androidx.paging.samples.insertSeparatorsUiModelRxSample
  */
+@JvmName("insertSeparators")
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
     generator: (T?, T?) -> Maybe<R>

--- a/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
+++ b/paging/rxjava2/src/main/java/androidx/paging/rxjava2/RxPagingData.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("PagingRx")
+@file:JvmMultifileClass
+
 package androidx.paging.rxjava2
 
 import androidx.annotation.CheckResult
@@ -59,10 +62,10 @@ fun <T : Any> PagingData<T>.filterRx(
  * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
  * between pages are only computed once both pages are loaded.
  *
- * @sample androidx.paging.samples.insertSeparatorsSample
- * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ * @sample androidx.paging.samples.insertSeparatorsRxSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelRxSample
  */
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
     generator: (T?, T?) -> Maybe<R>
-): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }
+): PagingData<R> = insertSeparators { before, after -> generator(before, after).await() }

--- a/paging/rxjava2/src/test/java/androidx/paging/rxjava2/RxPagingDataTest.kt
+++ b/paging/rxjava2/src/test/java/androidx/paging/rxjava2/RxPagingDataTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.rxjava2
+
+import androidx.paging.PagingData
+import io.reactivex.Maybe
+import io.reactivex.Single
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class RxPagingDataTest {
+    private val original = PagingData.from(listOf("a", "b", "c"))
+
+    @Test
+    fun map() = runBlocking {
+        val transformed = original.mapRx { Single.just(it + it) }
+        assertEquals(listOf("aa", "bb", "cc"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun flatMap() = runBlocking {
+        val transformed = original.flatMapRx { Single.just(listOf(it, it) as Iterable<String>) }
+        assertEquals(listOf("a", "a", "b", "b", "c", "c"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun filter() = runBlocking {
+        val filtered = original.filterRx { Single.just(it != "b") }
+        assertEquals(listOf("a", "c"), filtered.getFirstPageData())
+    }
+
+    @Test
+    fun insertSeparators() = runBlocking {
+        val separated = original.insertSeparatorsRx { left, right ->
+            if (left == null || right == null) Maybe.empty() else Maybe.just("|")
+        }
+        assertEquals(listOf("a", "|", "b", "|", "c"), separated.getFirstPageData())
+    }
+}

--- a/paging/rxjava3/api/current.txt
+++ b/paging/rxjava3/api/current.txt
@@ -4,23 +4,23 @@ package androidx.paging.rxjava3 {
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava3/api/current.txt
+++ b/paging/rxjava3/api/current.txt
@@ -8,6 +8,13 @@ package androidx.paging.rxjava3 {
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava3/api/current.txt
+++ b/paging/rxjava3/api/current.txt
@@ -2,15 +2,23 @@
 package androidx.paging.rxjava3 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }

--- a/paging/rxjava3/api/public_plus_experimental_current.txt
+++ b/paging/rxjava3/api/public_plus_experimental_current.txt
@@ -4,23 +4,23 @@ package androidx.paging.rxjava3 {
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava3/api/public_plus_experimental_current.txt
+++ b/paging/rxjava3/api/public_plus_experimental_current.txt
@@ -8,6 +8,13 @@ package androidx.paging.rxjava3 {
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava3/api/public_plus_experimental_current.txt
+++ b/paging/rxjava3/api/public_plus_experimental_current.txt
@@ -2,15 +2,23 @@
 package androidx.paging.rxjava3 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }

--- a/paging/rxjava3/api/restricted_current.txt
+++ b/paging/rxjava3/api/restricted_current.txt
@@ -4,23 +4,23 @@ package androidx.paging.rxjava3 {
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public final class PagingRx {
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filter(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMap(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
     method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
-    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparators(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> map(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }
 
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {

--- a/paging/rxjava3/api/restricted_current.txt
+++ b/paging/rxjava3/api/restricted_current.txt
@@ -8,6 +8,13 @@ package androidx.paging.rxjava3 {
     method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
   }
 
+  public final class RxPagingDataKt {
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
   public abstract class RxPagingSource<Key, Value> extends androidx.paging.PagingSource<Key,Value> {
     ctor public RxPagingSource();
     method public final suspend Object? load(androidx.paging.PagingSource.LoadParams<Key> params, kotlin.coroutines.Continuation<? super androidx.paging.PagingSource.LoadResult<Key,Value>> p);

--- a/paging/rxjava3/api/restricted_current.txt
+++ b/paging/rxjava3/api/restricted_current.txt
@@ -2,15 +2,23 @@
 package androidx.paging.rxjava3 {
 
   public final class PagingRx {
-    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
-    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
-  }
-
-  public final class RxPagingDataKt {
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
     method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
+    method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
+  }
+
+  public final class PagingRx {
+    method public static <T> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method public static <T> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>> cachedIn(io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<T>>, kotlinx.coroutines.CoroutineScope scope);
+    method @CheckResult public static <T> androidx.paging.PagingData<T> filterRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Boolean>> predicate);
+    method @CheckResult public static <T, R> androidx.paging.PagingData<R> flatMapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<java.lang.Iterable<R>>> transform);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Flowable<androidx.paging.PagingData<Value>> getFlowable(androidx.paging.Pager<Key,Value>);
+    method public static <Key, Value> io.reactivex.rxjava3.core.Observable<androidx.paging.PagingData<Value>> getObservable(androidx.paging.Pager<Key,Value>);
     method @CheckResult public static <T extends R, R> androidx.paging.PagingData<R> insertSeparatorsRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function2<? super T,? super T,? extends io.reactivex.rxjava3.core.Maybe<R>> generator);
     method @CheckResult public static <T, R> androidx.paging.PagingData<R> mapRx(androidx.paging.PagingData<T>, kotlin.jvm.functions.Function1<? super T,? extends io.reactivex.rxjava3.core.Single<R>> transform);
   }

--- a/paging/rxjava3/src/main/java/androidx/paging/rxjava3/PagingRx.kt
+++ b/paging/rxjava3/src/main/java/androidx/paging/rxjava3/PagingRx.kt
@@ -15,6 +15,7 @@
  */
 
 @file:JvmName("PagingRx")
+@file:JvmMultifileClass
 
 package androidx.paging.rxjava3
 

--- a/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
+++ b/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.rxjava3
+
+import androidx.annotation.CheckResult
+import androidx.paging.PagingData
+import androidx.paging.filter
+import androidx.paging.flatMap
+import androidx.paging.insertSeparators
+import androidx.paging.map
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Single
+import kotlinx.coroutines.rx3.await
+
+/**
+ * Returns a [PagingData] containing the result of applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.mapRx(
+    transform: (T) -> Single<R>
+): PagingData<R> = map { transform(it).await() }
+
+/**
+ * Returns a [PagingData] of all elements returned from applying the given [transform] to each
+ * element, as it is loaded.
+ */
+@CheckResult
+fun <T : Any, R : Any> PagingData<T>.flatMapRx(
+    transform: (T) -> Single<Iterable<R>>
+): PagingData<R> = flatMap { transform(it).await() }
+
+/**
+ * Returns a [PagingData] containing only elements matching the given [predicate].
+ */
+@CheckResult
+fun <T : Any> PagingData<T>.filterRx(
+    predicate: (T) -> Single<Boolean>
+): PagingData<T> = filter { predicate(it).await() }
+
+/**
+ * Returns a [PagingData] containing each original element, with an optional separator generated
+ * by [generator], given the elements before and after (or null, in boundary conditions).
+ *
+ * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
+ * between pages are only computed once both pages are loaded.
+ *
+ * @sample androidx.paging.samples.insertSeparatorsSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ */
+@CheckResult
+fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
+    generator: (T?, T?) -> Maybe<R>
+): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }

--- a/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
+++ b/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.rx3.await
  * Returns a [PagingData] containing the result of applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("map")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.mapRx(
     transform: (T) -> Single<R>
@@ -42,6 +43,7 @@ fun <T : Any, R : Any> PagingData<T>.mapRx(
  * Returns a [PagingData] of all elements returned from applying the given [transform] to each
  * element, as it is loaded.
  */
+@JvmName("flatMap")
 @CheckResult
 fun <T : Any, R : Any> PagingData<T>.flatMapRx(
     transform: (T) -> Single<Iterable<R>>
@@ -50,6 +52,7 @@ fun <T : Any, R : Any> PagingData<T>.flatMapRx(
 /**
  * Returns a [PagingData] containing only elements matching the given [predicate].
  */
+@JvmName("filter")
 @CheckResult
 fun <T : Any> PagingData<T>.filterRx(
     predicate: (T) -> Single<Boolean>
@@ -65,6 +68,7 @@ fun <T : Any> PagingData<T>.filterRx(
  * @sample androidx.paging.samples.insertSeparatorsRxSample
  * @sample androidx.paging.samples.insertSeparatorsUiModelRxSample
  */
+@JvmName("insertSeparators")
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
     generator: (T?, T?) -> Maybe<R>

--- a/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
+++ b/paging/rxjava3/src/main/java/androidx/paging/rxjava3/RxPagingData.kt
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+@file:JvmName("PagingRx")
+@file:JvmMultifileClass
+
 package androidx.paging.rxjava3
 
 import androidx.annotation.CheckResult
@@ -59,10 +62,10 @@ fun <T : Any> PagingData<T>.filterRx(
  * Note that this transform is applied asynchronously, as pages are loaded. Potential separators
  * between pages are only computed once both pages are loaded.
  *
- * @sample androidx.paging.samples.insertSeparatorsSample
- * @sample androidx.paging.samples.insertSeparatorsUiModelSample
+ * @sample androidx.paging.samples.insertSeparatorsRxSample
+ * @sample androidx.paging.samples.insertSeparatorsUiModelRxSample
  */
 @CheckResult
 fun <T : R, R : Any> PagingData<T>.insertSeparatorsRx(
     generator: (T?, T?) -> Maybe<R>
-): PagingData<R> = insertSeparators { left, right -> generator(left, right).await() }
+): PagingData<R> = insertSeparators { before, after -> generator(before, after).await() }

--- a/paging/rxjava3/src/test/java/androidx/paging/rxjava3/RxPagingDataTest.kt
+++ b/paging/rxjava3/src/test/java/androidx/paging/rxjava3/RxPagingDataTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging.rxjava3
+
+import androidx.paging.PagingData
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Single
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class RxPagingDataTest {
+    private val original = PagingData.from(listOf("a", "b", "c"))
+
+    @Test
+    fun map() = runBlocking {
+        val transformed = original.mapRx { Single.just(it + it) }
+        assertEquals(listOf("aa", "bb", "cc"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun flatMap() = runBlocking {
+        val transformed = original.flatMapRx { Single.just(listOf(it, it) as Iterable<String>) }
+        assertEquals(listOf("a", "a", "b", "b", "c", "c"), transformed.getFirstPageData())
+    }
+
+    @Test
+    fun filter() = runBlocking {
+        val filtered = original.filterRx { Single.just(it != "b") }
+        assertEquals(listOf("a", "c"), filtered.getFirstPageData())
+    }
+
+    @Test
+    fun insertSeparators() = runBlocking {
+        val separated = original.insertSeparatorsRx { left, right ->
+            if (left == null || right == null) Maybe.empty() else Maybe.just("|")
+        }
+        assertEquals(listOf("a", "|", "b", "|", "c"), separated.getFirstPageData())
+    }
+}

--- a/paging/rxjava3/src/test/java/androidx/paging/rxjava3/RxPagingDataTest.kt
+++ b/paging/rxjava3/src/test/java/androidx/paging/rxjava3/RxPagingDataTest.kt
@@ -17,41 +17,52 @@
 package androidx.paging.rxjava3
 
 import androidx.paging.PagingData
+import androidx.paging.TestPagingDataDiffer
 import io.reactivex.rxjava3.core.Maybe
 import io.reactivex.rxjava3.core.Single
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 class RxPagingDataTest {
     private val original = PagingData.from(listOf("a", "b", "c"))
 
+    private val testDispatcher = TestCoroutineDispatcher()
+    private val differ = TestPagingDataDiffer<String>(testDispatcher)
+
     @Test
-    fun map() = runBlocking {
+    fun map() = testDispatcher.runBlockingTest {
         val transformed = original.mapRx { Single.just(it + it) }
-        assertEquals(listOf("aa", "bb", "cc"), transformed.getFirstPageData())
+        differ.collectFrom(transformed)
+        assertEquals(listOf("aa", "bb", "cc"), differ.currentList)
     }
 
     @Test
-    fun flatMap() = runBlocking {
+    fun flatMap() = testDispatcher.runBlockingTest {
         val transformed = original.flatMapRx { Single.just(listOf(it, it) as Iterable<String>) }
-        assertEquals(listOf("a", "a", "b", "b", "c", "c"), transformed.getFirstPageData())
+        differ.collectFrom(transformed)
+        assertEquals(listOf("a", "a", "b", "b", "c", "c"), differ.currentList)
     }
 
     @Test
-    fun filter() = runBlocking {
+    fun filter() = testDispatcher.runBlockingTest {
         val filtered = original.filterRx { Single.just(it != "b") }
-        assertEquals(listOf("a", "c"), filtered.getFirstPageData())
+        differ.collectFrom(filtered)
+        assertEquals(listOf("a", "c"), differ.currentList)
     }
 
     @Test
-    fun insertSeparators() = runBlocking {
+    fun insertSeparators() = testDispatcher.runBlockingTest {
         val separated = original.insertSeparatorsRx { left, right ->
             if (left == null || right == null) Maybe.empty() else Maybe.just("|")
         }
-        assertEquals(listOf("a", "|", "b", "|", "c"), separated.getFirstPageData())
+        differ.collectFrom(separated)
+        assertEquals(listOf("a", "|", "b", "|", "c"), differ.currentList)
     }
 }

--- a/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsSample.kt
+++ b/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsSample.kt
@@ -19,7 +19,7 @@
 package androidx.paging.samples
 
 import androidx.annotation.Sampled
-import androidx.paging.ElementPair
+import androidx.paging.AdjacentItems
 import androidx.paging.PagingData
 import androidx.paging.insertSeparators
 import androidx.paging.insertSeparatorsAsync
@@ -103,7 +103,7 @@ fun insertSeparatorsFutureSample() {
      */
     pagingDataStream.map { pagingData ->
         // map outer stream, so we can perform transformations on each paging generation
-        pagingData.insertSeparatorsAsync(AsyncFunction<ElementPair<String>, String?> {
+        pagingData.insertSeparatorsAsync(AsyncFunction<AdjacentItems<String>, String?> {
             Futures.submit(Callable<String?> {
                 val (before, after) = it!!
                 if (after != null && before?.first() != after.first()) {

--- a/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsSample.kt
+++ b/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsSample.kt
@@ -19,8 +19,12 @@
 package androidx.paging.samples
 
 import androidx.annotation.Sampled
+import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.paging.PagingData
 import androidx.paging.insertSeparators
+import androidx.paging.insertSeparatorsFuture
+import androidx.paging.rxjava2.insertSeparatorsRx
+import io.reactivex.Maybe
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -46,6 +50,62 @@ fun insertSeparatorsSample() {
             } else {
                 // no separator - either end of list, or first letters of before/after are the same
                 null
+            }
+        }
+    }
+}
+
+@Sampled
+fun insertSeparatorsRxSample() {
+    /*
+     * Create letter separators in an alphabetically sorted list.
+     *
+     * For example, if the input is:
+     *     "apple", "apricot", "banana", "carrot"
+     *
+     * The operator would output:
+     *     "A", "apple", "apricot", "B", "banana", "C", "carrot"
+     */
+    pagingDataStream.map { pagingData ->
+        // map outer stream, so we can perform transformations on each paging generation
+        pagingData.insertSeparatorsRx { before: String?, after: String? ->
+            // normally Maybe generation would be more sophisticated
+            Maybe.fromCallable<String> {
+                if (after != null && before?.first() != after.first()) {
+                    // separator - after is first item that starts with its first letter
+                    after.first().toUpperCase().toString()
+                } else {
+                    // no separator - either end of list, or first letters of before/after are the same
+                    null
+                }
+            }
+        }
+    }
+}
+
+@Sampled
+fun insertSeparatorsFutureSample() {
+    /*
+     * Create letter separators in an alphabetically sorted list.
+     *
+     * For example, if the input is:
+     *     "apple", "apricot", "banana", "carrot"
+     *
+     * The operator would output:
+     *     "A", "apple", "apricot", "B", "banana", "C", "carrot"
+     */
+    pagingDataStream.map { pagingData ->
+        // map outer stream, so we can perform transformations on each paging generation
+        pagingData.insertSeparatorsFuture { before: String?, after: String? ->
+            // normally ListenableFuture generation would be more sophisticated
+            CallbackToFutureAdapter.getFuture { completer ->
+                if (after != null && before?.first() != after.first()) {
+                    // separator - after is first item that starts with its first letter
+                    completer.set(after.first().toUpperCase().toString())
+                } else {
+                    // no separator - either end of list, or first letters of before/after are the same
+                    completer.set(null)
+                }
             }
         }
     }

--- a/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsUiModelSample.kt
+++ b/paging/samples/src/main/java/androidx/paging/samples/InsertSeparatorsUiModelSample.kt
@@ -19,7 +19,7 @@
 package androidx.paging.samples
 
 import androidx.annotation.Sampled
-import androidx.paging.ElementPair
+import androidx.paging.AdjacentItems
 import androidx.paging.PagingData
 import androidx.paging.insertSeparators
 import androidx.paging.insertSeparatorsAsync
@@ -135,7 +135,7 @@ fun insertSeparatorsUiModelFutureSample() {
             .map { item ->
                 ItemUiModel(item) // convert items in stream to ItemUiModel
             }
-            .insertSeparatorsAsync(AsyncFunction<ElementPair<ItemUiModel>, UiModel?> {
+            .insertSeparatorsAsync(AsyncFunction<AdjacentItems<ItemUiModel>, UiModel?> {
                 Futures.submit(Callable<UiModel> {
                     val (before, after) = it!!
                     if (after != null && before?.item?.label?.first() != after.item.label.first()) {

--- a/testutils/testutils-paging/src/main/java/androidx/paging/TestPagingDataDiffer.kt
+++ b/testutils/testutils-paging/src/main/java/androidx/paging/TestPagingDataDiffer.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+class TestPagingDataDiffer<T : Any>(mainDispatcher: CoroutineDispatcher = Dispatchers.Main) :
+    PagingDataDiffer<T>(noopDifferCallback, mainDispatcher) {
+
+    val currentList: List<T> get() = List(size) { i -> get(i)!! }
+
+    override suspend fun presentNewList(
+        previousList: NullPaddedList<T>,
+        newList: NullPaddedList<T>,
+        newCombinedLoadStates: CombinedLoadStates,
+        lastAccessedIndex: Int
+    ): Int? = null
+
+    companion object {
+        private val noopDifferCallback = object : DifferCallback {
+            override fun onChanged(position: Int, count: Int) {}
+            override fun onInserted(position: Int, count: Int) {}
+            override fun onRemoved(position: Int, count: Int) {}
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

  - Add RxJava2 transformation functions for `PagingData`
  - Add RxJava3 transformation functions for `PagingData`
  - Add Guava transformation functions for `PagingData`

Note: We can't reuse `map`, `flatMap`, ... for these functions, as this would lead to name clashes with the suspending ones.

## Testing

Test: Added unit tests for all new functions

## Issues Fixed

Fixes: 160170341
