### PR TITLE
Decouple clearing of Notifications from stopping of SystemForegroundService

### DIFF
--- a/development/build_log_simplifier/messages.ignore
+++ b/development/build_log_simplifier/messages.ignore
@@ -1092,6 +1092,7 @@ src/main/java/androidx/appcompat/widget/Toolbar\.java:[0-9]+: warning: Parameter
 \$SUPPORT/core/core\-appdigest/src/androidTest/AndroidManifest\.xml Warning:
 Package name 'androidx\.core\.appdigest\.test' used in: AndroidManifest\.xml, manifestMerger[0-9]+\.xml\.
 # > Task :core:core:generateApi
+src\/main\/java\/androidx\/core\/app\/NotificationCompat\.java\:[0-9]+\: warning\: Builder constructor arguments must be mandatory \(i\.e\. not \@Nullable\)\: parameter title in androidx\.core\.app\.NotificationCompat\.Action\.Builder\(int icon\, CharSequence title\, android\.app\.PendingIntent intent\) \[OptionalBuilderConstructorArgument\]See tools\/metalava\/API\-LINT\.md for how to handle these\.
 src/main/java/androidx/core/app/NotificationCompat\.java:[0-9]+: warning: Builder constructor arguments must be mandatory \(i\.e\. not @Nullable\): parameter title in androidx\.core\.app\.NotificationCompat\.Action\.Builder\(int icon, CharSequence title, android\.app\.PendingIntent intent\) \[OptionalBuilderConstructorArgument\]
 src/main/java/androidx/core/app/NotificationCompat\.java:[0-9]+: warning: Builder constructor arguments must be mandatory \(i\.e\. not @Nullable\): parameter intent in androidx\.core\.app\.NotificationCompat\.Action\.Builder\(int icon, CharSequence title, android\.app\.PendingIntent intent\) \[OptionalBuilderConstructorArgument\]
 [0-9]+ new API lint issues were found\.
@@ -1141,3 +1142,6 @@ src/main/java/androidx/transition/TransitionSet\.java:[0-9]+: warning: Parameter
 Package name 'androidx\.activity\.integration\.testapp\.test' used in: AndroidManifest\.xml, manifestMerger[0-9]+\.xml\.
 # > Task :room:integration-tests:room-testapp-autovalue:compileDebugAndroidTestJavaWithJavac
 Stream closed
+# > Task :benchmark:benchmark-macro:processDebugAndroidTestManifest
+\$SUPPORT\/benchmark\/macro\/src\/androidTest\/AndroidManifest\.xml Warning\:
+Package name \'androidx\.benchmark\.macro\.test\' used in\: AndroidManifest\.xml\, manifestMerger[0-9]+\.xml\.

--- a/work/workmanager/src/androidTest/java/androidx/work/impl/foreground/SystemForegroundDispatcherTest.kt
+++ b/work/workmanager/src/androidTest/java/androidx/work/impl/foreground/SystemForegroundDispatcherTest.kt
@@ -55,6 +55,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.reset
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
@@ -201,7 +202,7 @@ class SystemForegroundDispatcherTest {
         verify(dispatcherCallback, times(1))
             .cancelNotification(secondId)
         assertThat(dispatcher.mForegroundInfoById.count(), `is`(1))
-
+        reset(dispatcherCallback)
         dispatcher.onExecuted(secondWorkSpecId, false)
         verify(dispatcherCallback, times(1))
             .cancelNotification(secondId)


### PR DESCRIPTION
* When WorkerWrapper resolves the `ListenableFuture`, it calls `stopForeground()` if the Workers lifecycle was bound to a Foreground service.
* `Processor` performs `stopForeground()` on the task executor thread. This in turn triggers a `stopForegroundService()` if there is no more pending foreground work.
*  Meanwhile on the main thread, `SystemForegroundDispatcher`'s `onExecuted()` is responsible for tracking foreground 
   notifications that need to be removed. This is the race condition because this might happen _after_ `stopForeground()` is 
   completed.
* This change makes `onExecuted()` the owner of the lifcycle of all notifications - that way everything is consistent.

Test: Ran integraton tests.
Fixes: b/168502234
