### PR TITLE
Fix appCompat Lint problem

### DIFF
--- a/appcompat/appcompat-lint/build.gradle
+++ b/appcompat/appcompat-lint/build.gradle
@@ -43,3 +43,11 @@ androidx {
     inceptionYear = "2019"
     description = "AppCompat Lint Checks"
 }
+
+jar {
+    manifest {
+        // Only use the "-v2" key here if your checks have been updated to the
+        // new 3.0 APIs (including UAST)
+        attributes("Lint-Registry-v2": "androidx.appcompat.AppCompatIssueRegistry")
+    }
+}


### PR DESCRIPTION
There is a lintPublish Lint rule in build.Gradle of the Appcompat Module

```groovy
// Uncomment once we want to start publishing the lint rules.
lintPublish project(":appcompat:appcompat-lint")
```

But Appcompat-lint module build.gradle does not specify lint-registrie-v2, causing GradleLintTask to occur a problem and invalidate other custom Lints

So you need to add a Lint-registrie-v2 in the build.Gradle of the AppCompat-Lint Module to point to issueRegister

```groovy
jar {
    manifest {
        // Only use the "-v2" key here if your checks have been updated to the
        // new 3.0 APIs (including UAST)
        attributes("Lint-Registry-v2": "androidx.appcompat.AppCompatIssueRegistry")
    }
}
```

Will solve the problem