### PR TITLE
Minor changes to work multiprocess.

### DIFF
--- a/work/workmanager-multiprocess/proguard-rules.pro
+++ b/work/workmanager-multiprocess/proguard-rules.pro
@@ -1,0 +1,4 @@
+# This is necessary so that RemoteWorkManager can be initialized (also marked with @Keep)
+-keep class androidx.work.multiprocess.RemoteWorkManagerClient {
+    public <init>(...);
+}

--- a/work/workmanager-multiprocess/src/main/java/androidx/work/multiprocess/RemoteWorkContinuationImpl.java
+++ b/work/workmanager-multiprocess/src/main/java/androidx/work/multiprocess/RemoteWorkContinuationImpl.java
@@ -19,6 +19,7 @@ package androidx.work.multiprocess;
 import android.annotation.SuppressLint;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkContinuation;
 
@@ -29,7 +30,10 @@ import java.util.List;
 
 /**
  * An implementation of {@link RemoteWorkContinuation}.
+ *
+ * @hide
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class RemoteWorkContinuationImpl extends RemoteWorkContinuation {
     private final RemoteWorkManagerClient mClient;
     private final WorkContinuation mContinuation;

--- a/work/workmanager-multiprocess/src/main/java/androidx/work/multiprocess/RemoteWorkManagerClient.java
+++ b/work/workmanager-multiprocess/src/main/java/androidx/work/multiprocess/RemoteWorkManagerClient.java
@@ -28,6 +28,7 @@ import android.content.ServiceConnection;
 import android.os.IBinder;
 import android.os.RemoteException;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
@@ -76,6 +77,7 @@ public class RemoteWorkManagerClient extends RemoteWorkManager {
 
     private Session mSession;
 
+    @Keep
     public RemoteWorkManagerClient(@NonNull Context context, @NonNull WorkManagerImpl workManager) {
         mContext = context.getApplicationContext();
         mWorkManager = workManager;


### PR DESCRIPTION
* Explicitly @hide RemoteWorkContinuationImpl. Even though the package has a @hide at the package level
  this class shows up in the public documentation.

* Add proguard-rules.pro for :work:multiprocess.

Test: Build the obfuscated APK which looks correct.

Here is a snippet:java -jar ~/Workspace/Tools/bin/diffuse-0.1.0-binary.jar members --methods ./out/work-playground/work-playground/work/integration-tests/testapp/build/outputs/apk/release/testapp-release.apk

```
androidx.work.multiprocess.RemoteWorkManagerClient <clinit>()
androidx.work.multiprocess.RemoteWorkManagerClient <init>(Context, j)
androidx.work.multiprocess.RemoteWorkManagerClient b(List) → e
androidx.work.multiprocess.RemoteWorkManagerClient c() → a
androidx.work.multiprocess.RemoteWorkManagerClient d(String) → a
androidx.work.multiprocess.RemoteWorkManagerClient e(List) → a
androidx.work.multiprocess.RemoteWorkManagerClient g(z) → a
androidx.work.multiprocess.RemoteWorkManagerClient h()
androidx.work.multiprocess.RemoteWorkManagerClient i(w) → a
```
