### PR TITLE
Don't cache fragment classes across different class loaders

### DIFF
--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentFactory.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentFactory.java
@@ -29,7 +29,8 @@ import java.lang.reflect.InvocationTargetException;
  * @see FragmentManager#setFragmentFactory(FragmentFactory)
  */
 public class FragmentFactory {
-    private static final SimpleArrayMap<String, Class<?>> sClassMap = new SimpleArrayMap<>();
+    private static final SimpleArrayMap<ClassLoader, SimpleArrayMap<String, Class<?>>>
+            sClassCacheMap = new SimpleArrayMap<>();
 
     /**
      * Determine if the given fragment name is a support library fragment class.
@@ -41,11 +42,16 @@ public class FragmentFactory {
     @NonNull
     private static Class<?> loadClass(@NonNull ClassLoader classLoader,
             @NonNull String className) throws ClassNotFoundException {
-        Class<?> clazz = sClassMap.get(className);
+        SimpleArrayMap<String, Class<?>> classMap = sClassCacheMap.get(classLoader);
+        if (classMap == null) {
+            classMap = new SimpleArrayMap<>();
+            sClassCacheMap.put(classLoader, classMap);
+        }
+        Class<?> clazz = classMap.get(className);
         if (clazz == null) {
             // Class not found in the cache, see if it's real, and try to add it
             clazz = Class.forName(className, false, classLoader);
-            sClassMap.put(className, clazz);
+            classMap.put(className, clazz);
         }
         return clazz;
     }

--- a/fragment/fragment/src/test/java/androidx/fragment/app/FragmentFactoryTest.kt
+++ b/fragment/fragment/src/test/java/androidx/fragment/app/FragmentFactoryTest.kt
@@ -16,7 +16,7 @@
 
 package androidx.fragment.app
 
-import org.junit.Assert.assertEquals
+import com.google.common.truth.Truth.assertWithMessage
 import org.junit.Test
 
 class FragmentFactoryTest {
@@ -27,7 +27,10 @@ class FragmentFactoryTest {
         val classLoader = CountingClassLoader()
         factory.instantiate(classLoader, TestFragment::class.java.name)
         factory.instantiate(classLoader, TestFragment::class.java.name)
-        assertEquals(1, classLoader.loadCount)
+
+        assertWithMessage("Fragment class should only be looked up once")
+            .that(classLoader.loadCount)
+            .isEqualTo(1)
     }
 
     @Test
@@ -36,8 +39,14 @@ class FragmentFactoryTest {
         val secondClassLoader = CountingClassLoader()
         factory.instantiate(firstClassLoader, TestFragment::class.java.name)
         factory.instantiate(secondClassLoader, TestFragment::class.java.name)
-        assertEquals(1, firstClassLoader.loadCount)
-        assertEquals(1, secondClassLoader.loadCount)
+
+        assertWithMessage("Fragment class should only be looked up once")
+            .that(firstClassLoader.loadCount)
+            .isEqualTo(1)
+
+        assertWithMessage("Fragment class should be looked up again for different class loaders")
+            .that(secondClassLoader.loadCount)
+            .isEqualTo(1)
     }
 
     class TestFragment : Fragment()

--- a/fragment/fragment/src/test/java/androidx/fragment/app/FragmentFactoryTest.kt
+++ b/fragment/fragment/src/test/java/androidx/fragment/app/FragmentFactoryTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.fragment.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FragmentFactoryTest {
+    private val factory = FragmentFactory()
+
+    @Test
+    fun `Fragment classes are cached`() {
+        val classLoader = CountingClassLoader()
+        factory.instantiate(classLoader, TestFragment::class.java.name)
+        factory.instantiate(classLoader, TestFragment::class.java.name)
+        assertEquals(1, classLoader.loadCount)
+    }
+
+    @Test
+    fun `Cached fragment classes are not shared across different class loaders`() {
+        val firstClassLoader = CountingClassLoader()
+        val secondClassLoader = CountingClassLoader()
+        factory.instantiate(firstClassLoader, TestFragment::class.java.name)
+        factory.instantiate(secondClassLoader, TestFragment::class.java.name)
+        assertEquals(1, firstClassLoader.loadCount)
+        assertEquals(1, secondClassLoader.loadCount)
+    }
+
+    class TestFragment : Fragment()
+
+    class CountingClassLoader : ClassLoader() {
+        var loadCount = 0
+
+        override fun loadClass(name: String?): Class<*> {
+            loadCount++
+            return super.loadClass(name)
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

  - Don't cache fragment classes across different class loaders inside `FragmentFactory`.

## Testing

Test: Added tests to verify the change

## Issues Fixed

Fixes: 113886460
