### PR TITLE
Fix docs about new contributable projects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,9 @@ The list of folders that can be contributed to, using the GitHub repository are:
 
 ```
 androidx
+  -- activity
+  -- fragment
+  -- navigation
   -- paging
   -- room
   -- work

--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -15,7 +15,7 @@
  */
 
 // see ../playground-common/README.md for details on how this works
-rootProject.name = "paging-playground"
+rootProject.name = "activity-playground"
 apply from: "../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "..")
 selectProjectsFromAndroidX({ name ->

--- a/fragment/settings.gradle
+++ b/fragment/settings.gradle
@@ -15,7 +15,7 @@
  */
 
 // see ../playground-common/README.md for details on how this works
-rootProject.name = "paging-playground"
+rootProject.name = "fragment-playground"
 apply from: "../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "..")
 selectProjectsFromAndroidX({ name ->


### PR DESCRIPTION
## Proposed Changes

  - Add `activity`, `fragment` and `navigation` to the list of folders open for contribution
  - Fix wrong root project names for `activity` and `fragment`

## Testing

Test: N/A

## Issues Fixed

Fixes: N/A
