### PR TITLE
Exclude compose navigation from navigation playground

### DIFF
--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -19,6 +19,8 @@ rootProject.name = "navigation-playground"
 apply from: "../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "..")
 selectProjectsFromAndroidX({ name ->
+    // Compose projects are not supported in playground yet
+    if (name.startsWith(":navigation:navigation-compose")) return false
     if (name.startsWith(":navigation")) return true
     if (name.startsWith(":internal-testutils-navigation")) return true
     if (name.startsWith(":internal-testutils-runtime")) return true


### PR DESCRIPTION
Compose projects are not supported in playground yet so this
PR excludes compose-navigation and its sub-projects from
the navigation playground setup.

Bug: 171017446
Test: cd navigation && ./gradlew buildOnServer