### PR TITLE
exclude compose from paging playground

### DIFF
--- a/paging/settings.gradle
+++ b/paging/settings.gradle
@@ -19,6 +19,7 @@ rootProject.name = "paging-playground"
 apply from: "../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "..")
 selectProjectsFromAndroidX({ name ->
+    if (name.startsWith(":paging:paging-compose")) return false
     if (name.startsWith(":paging")) return true
     return false
 })


### PR DESCRIPTION
Compose projects are not yet supported in playground.

Bug: 171017446
Test: cd paging && ./gradlew bOS
