### PR TITLE
Delegate to beginTransactionNonExclusive when in WAL mode

### DIFF
--- a/room/runtime/src/main/java/androidx/room/InvalidationTracker.java
+++ b/room/runtime/src/main/java/androidx/room/InvalidationTracker.java
@@ -309,7 +309,7 @@ public class InvalidationTracker {
         return tables.toArray(new String[tables.size()]);
     }
 
-    private void beginTransactionInternal(SupportSQLiteDatabase database) {
+    private static void beginTransactionInternal(SupportSQLiteDatabase database) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
                 && database.isWriteAheadLoggingEnabled()) {
             database.beginTransactionNonExclusive();

--- a/room/runtime/src/main/java/androidx/room/InvalidationTracker.java
+++ b/room/runtime/src/main/java/androidx/room/InvalidationTracker.java
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteException;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -308,6 +309,15 @@ public class InvalidationTracker {
         return tables.toArray(new String[tables.size()]);
     }
 
+    private void beginTransactionInternal(SupportSQLiteDatabase database) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && database.isWriteAheadLoggingEnabled()) {
+            database.beginTransactionNonExclusive();
+        } else {
+            database.beginTransaction();
+        }
+    }
+
     /**
      * Adds an observer but keeps a weak reference back to it.
      * <p>
@@ -389,7 +399,7 @@ public class InvalidationTracker {
                     // This transaction has to be on the underlying DB rather than the RoomDatabase
                     // in order to avoid a recursive loop after endTransaction.
                     SupportSQLiteDatabase db = mDatabase.getOpenHelper().getWritableDatabase();
-                    db.beginTransaction();
+                    db.beginTransactionNonExclusive();
                     try {
                         invalidatedTableIds = checkUpdatedTable();
                         db.setTransactionSuccessful();
@@ -501,7 +511,7 @@ public class InvalidationTracker {
                         return;
                     }
                     final int limit = tablesToSync.length;
-                    database.beginTransaction();
+                    beginTransactionInternal(database);
                     try {
                         for (int tableId = 0; tableId < limit; tableId++) {
                             switch (tablesToSync[tableId]) {

--- a/room/runtime/src/main/java/androidx/room/RoomDatabase.java
+++ b/room/runtime/src/main/java/androidx/room/RoomDatabase.java
@@ -425,7 +425,12 @@ public abstract class RoomDatabase {
         assertNotMainThread();
         SupportSQLiteDatabase database = mOpenHelper.getWritableDatabase();
         mInvalidationTracker.syncTriggers(database);
-        database.beginTransaction();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN
+                && database.isWriteAheadLoggingEnabled()) {
+            database.beginTransactionNonExclusive();
+        } else {
+            database.beginTransaction();
+        }
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

As discussed in the ticket, I'm just delegating to `beginTransactionNonExclusive` when WAL mode is enabled.

## Testing

Test:
Executed
```
./gradlew \
    test connectedCheck \
    -x :room:room-benchmark:cC \
    -x :room:integration-tests:room-incremental-annotation-processing:test
```
and nothing was broken, please inform me if you'd like to add a specific test case.

## Issues Fixed
Fixes: 126258791
