### PR TITLE
Fix GitHub org name in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Our tooling currently supports **macOS and Linux**. This new setup is a **work-i
 
 ## Getting Started
 
-We have tried to make contributing to androidx a lot easier with this new setup. Just start by creating a fork of the [AndroidX/androidx](https://github.com/AndroidX/androidx) GitHub repository.
+We have tried to make contributing to androidx a lot easier with this new setup. Just start by creating a fork of the [androidx/androidx](https://github.com/androidx/androidx) GitHub repository.
 
 ### One Time Setup
 
@@ -54,7 +54,7 @@ androidx
 
 **Note:** For other projects, you will still need to use the Gerrit workflow used by the Android Open Source Project (AOSP). For more information, please look at the [README](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-master-dev:README.md).
 
-Fork the [AndroidX/androidx](https://github.com/AndroidX/androidx) repository.
+Fork the [androidx/androidx](https://github.com/androidx/androidx) repository.
 
 We recommend cloning using blob filter to reduce checkout size:
 ```bash
@@ -120,7 +120,7 @@ Once your changes look good, you can push them to your fork of the repository. N
 ./gradlew updateApi
 ```
 
-If you are adding new APIs, then you might **additionally need to update** [LibraryVersions.kt](https://github.com/AndroidX/androidx/blob/androidx-master-dev/buildSrc/src/main/kotlin/androidx/build/LibraryVersions.kt) as well, before running the updateApi task. This is **relevant when the library’s API is frozen** (betas, rc’s and stable versions). For alpha versions, you don’t have to update this file.
+If you are adding new APIs, then you might **additionally need to update** [LibraryVersions.kt](https://github.com/androidx/androidx/blob/androidx-master-dev/buildSrc/src/main/kotlin/androidx/build/LibraryVersions.kt) as well, before running the updateApi task. This is **relevant when the library’s API is frozen** (betas, rc’s and stable versions). For alpha versions, you don’t have to update this file.
 
 This helps the AndroidX project keep track of API changes and avoid inadvertently adding APIs or introduce backwards incompatible changes.
 
@@ -130,7 +130,7 @@ This helps the AndroidX project keep track of API changes and avoid inadvertentl
 
 ### Making a Pull Request
 
-To create a pull request click on [this](https://github.com/AndroidX/androidx/pulls) link and then click on New Pull Request.
+To create a pull request click on [this](https://github.com/androidx/androidx/pulls) link and then click on New Pull Request.
 
 Then click on the compare across forks and select your forked repository as the HEAD repository. Then click Create.
 


### PR DESCRIPTION
## Proposed Changes

A minor capitalization fix in the GitHub organization name referenced in CONTRIBUTING.md (`AndroidX` -> `androidx`).

## Testing

Test: No testing required
