### PR TITLE
A PagingSource Factory that can be invalidated

### DIFF
--- a/paging/common/api/current.txt
+++ b/paging/common/api/current.txt
@@ -53,10 +53,8 @@ package androidx.paging {
 
   public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
     ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
-    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
     method public final void invalidate();
     method public final androidx.paging.PagingSource<Key,Value> invoke();
-    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
   }
 
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {

--- a/paging/common/api/current.txt
+++ b/paging/common/api/current.txt
@@ -51,6 +51,14 @@ package androidx.paging {
   @kotlin.RequiresOptIn public @interface ExperimentalPagingApi {
   }
 
+  public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
+    ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
+    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
+    method public final void invalidate();
+    method public final androidx.paging.PagingSource<Key,Value> invoke();
+    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
+  }
+
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {
     ctor @Deprecated public ItemKeyedDataSource();
     method @Deprecated public abstract Key getKey(Value item);

--- a/paging/common/api/public_plus_experimental_current.txt
+++ b/paging/common/api/public_plus_experimental_current.txt
@@ -52,6 +52,14 @@ package androidx.paging {
   @kotlin.RequiresOptIn public @interface ExperimentalPagingApi {
   }
 
+  public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
+    ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
+    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
+    method public final void invalidate();
+    method public final androidx.paging.PagingSource<Key,Value> invoke();
+    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
+  }
+
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {
     ctor @Deprecated public ItemKeyedDataSource();
     method @Deprecated public abstract Key getKey(Value item);

--- a/paging/common/api/public_plus_experimental_current.txt
+++ b/paging/common/api/public_plus_experimental_current.txt
@@ -54,10 +54,8 @@ package androidx.paging {
 
   public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
     ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
-    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
     method public final void invalidate();
     method public final androidx.paging.PagingSource<Key,Value> invoke();
-    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
   }
 
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {

--- a/paging/common/api/restricted_current.txt
+++ b/paging/common/api/restricted_current.txt
@@ -53,10 +53,8 @@ package androidx.paging {
 
   public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
     ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
-    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
     method public final void invalidate();
     method public final androidx.paging.PagingSource<Key,Value> invoke();
-    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
   }
 
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {

--- a/paging/common/api/restricted_current.txt
+++ b/paging/common/api/restricted_current.txt
@@ -51,6 +51,14 @@ package androidx.paging {
   @kotlin.RequiresOptIn public @interface ExperimentalPagingApi {
   }
 
+  public abstract class InvalidatingPagingSourceFactory<Key, Value> implements kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> {
+    ctor public InvalidatingPagingSourceFactory(kotlin.jvm.functions.Function0<? extends androidx.paging.PagingSource<Key,Value>> pagingSourceFactory);
+    method public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> getPagingSourceFactory();
+    method public final void invalidate();
+    method public final androidx.paging.PagingSource<Key,Value> invoke();
+    property public final kotlin.jvm.functions.Function0<androidx.paging.PagingSource<Key,Value>> pagingSourceFactory;
+  }
+
   @Deprecated public abstract class ItemKeyedDataSource<Key, Value> extends androidx.paging.DataSource<Key,Value> {
     ctor @Deprecated public ItemKeyedDataSource();
     method @Deprecated public abstract Key getKey(Value item);

--- a/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
@@ -51,7 +51,8 @@ abstract class InvalidatingPagingSourceFactory<Key : Any, Value : Any>(
         while (pagingSources.isNotEmpty()) {
             pagingSources.removeFirst().also {
                 if (!it.invalid) {
-                    it.invalidate() }
+                    it.invalidate()
+                }
             }
         }
     }

--- a/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * A PagingSource Factory that can be kept as a reference and stores a list of paging sources
+ * created with the factory. Includes invalidate() function to invalidate the list of [PagingSource]
+ * when data changes.
+ */
+abstract class InvalidatingPagingSourceFactory<Key: Any, Value: Any> : () ->  PagingSource<Key, Value>{
+
+    @VisibleForTesting
+    internal val listOfPagingSources = mutableListOf<PagingSource<Key, Value>>();
+
+    /**
+     * Returns a PagingSource
+     *
+     * Implement the logic to create a PagingSource
+     */
+    abstract fun create() : PagingSource<Key, Value>;
+
+    /**
+     * Returns a PagingSource which will also be stored into listOfPagingSources.
+     */
+    final override fun invoke(): PagingSource<Key, Value> {
+        return create(). also {listOfPagingSources.add(it)};
+    }
+
+    /**
+     * Calls [PagingSource] invalidate() on each PagingSource stored within listOfPagingSources
+     * and removes it from the list
+     *
+     * Invalidated [PagingSource] will have its invalid status equal 'true'
+     */
+    fun invalidate() {
+        while (listOfPagingSources.isNotEmpty()) {
+            listOfPagingSources.removeFirst().invalidate();
+        }
+    }
+}

--- a/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
@@ -36,19 +36,22 @@ abstract class InvalidatingPagingSourceFactory<Key : Any, Value : Any>(
     internal val pagingSources = mutableListOf<PagingSource<Key, Value>>()
 
     /**
-     * @return [PagingSource] which will also be stored into [pagingSources].
+     * @return [PagingSource] which will be invalidated when this factory's [invalidate] method
+     * is called
      */
     final override fun invoke(): PagingSource<Key, Value> {
         return pagingSourceFactory().also { pagingSources.add(it) }
     }
 
     /**
-     * Calls [PagingSource.invalidate] on each [PagingSource] stored within [pagingSources]
-     * and removes it from [pagingSources]
+     * Calls [PagingSource.invalidate] on each [PagingSource] that was produced by this
+     * [InvalidatingPagingSourceFactory]
      */
     fun invalidate() {
         while (pagingSources.isNotEmpty()) {
-            pagingSources.removeFirst().invalidate()
+            pagingSources.removeFirst().also {
+                if (!it.invalid) it.invalidate()
+            }
         }
     }
 }

--- a/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
@@ -29,7 +29,7 @@ import androidx.annotation.VisibleForTesting
  * @param pagingSourceFactory The [PagingSource] factory that returns a PagingSource when called
  */
 abstract class InvalidatingPagingSourceFactory<Key : Any, Value : Any>(
-    val pagingSourceFactory: () -> PagingSource<Key, Value>
+    private val pagingSourceFactory: () -> PagingSource<Key, Value>
 ) : () -> PagingSource<Key, Value> {
 
     @VisibleForTesting

--- a/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
+++ b/paging/common/src/main/kotlin/androidx/paging/InvalidatingPagingSourceFactory.kt
@@ -50,7 +50,8 @@ abstract class InvalidatingPagingSourceFactory<Key : Any, Value : Any>(
     fun invalidate() {
         while (pagingSources.isNotEmpty()) {
             pagingSources.removeFirst().also {
-                if (!it.invalid) it.invalidate()
+                if (!it.invalid) {
+                    it.invalidate() }
             }
         }
     }

--- a/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.paging
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+
+class InvalidatingPagingSourceFactoryTest {
+
+    @Test
+    fun getPagingSource() {
+
+        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
+            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        }
+
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+
+        assertEquals(testFactory.listOfPagingSources.size, 4)
+    }
+
+    @Test
+    fun invalidateRemoveFromList() {
+
+        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
+            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        }
+
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+
+        assertEquals(testFactory.listOfPagingSources.size, 4)
+
+        testFactory.invalidate()
+
+        assertEquals(testFactory.listOfPagingSources.size, 0)
+
+    }
+
+    @Test
+    fun invalidatePagingSource() {
+
+        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
+            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        }
+
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+        testFactory.invoke()
+
+        testFactory.listOfPagingSources.forEach {
+            it.registerInvalidatedCallback {
+                assertEquals(it.invalid, true)
+            }
+        }
+
+        testFactory.invalidate()
+    }
+}
+

--- a/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
@@ -19,63 +19,58 @@ package androidx.paging
 import org.junit.Test
 import kotlin.test.assertEquals
 
-
 class InvalidatingPagingSourceFactoryTest {
 
     @Test
     fun getPagingSource() {
 
-        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
-            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        val testFactory = getFactory()
+
+        for (i in 0..3) {
+            testFactory.invoke()
         }
 
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-
-        assertEquals(testFactory.listOfPagingSources.size, 4)
+        assertEquals(4, testFactory.pagingSources.size)
     }
 
     @Test
     fun invalidateRemoveFromList() {
 
-        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
-            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        val testFactory = getFactory()
+
+        for (i in 0..3) {
+            testFactory.invoke()
         }
 
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-
-        assertEquals(testFactory.listOfPagingSources.size, 4)
+        assertEquals(4, testFactory.pagingSources.size)
 
         testFactory.invalidate()
 
-        assertEquals(testFactory.listOfPagingSources.size, 0)
-
+        assertEquals(0, testFactory.pagingSources.size)
     }
 
     @Test
     fun invalidatePagingSource() {
 
-        val testFactory = object : InvalidatingPagingSourceFactory<Int, Int>() {
-            override fun create(): PagingSource<Int, Int> = TestPagingSource();
+        val testFactory = getFactory()
+
+        for (i in 0..3) {
+            testFactory.invoke()
         }
 
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-        testFactory.invoke()
-
-        testFactory.listOfPagingSources.forEach {
+        testFactory.pagingSources.forEach {
             it.registerInvalidatedCallback {
-                assertEquals(it.invalid, true)
+                assertEquals(true, it.invalid)
             }
         }
 
         testFactory.invalidate()
     }
-}
 
+    private fun getFactory(): InvalidatingPagingSourceFactory<Int, Int> {
+
+        val pagingSourceFactory = { TestPagingSource() }
+
+        return object : InvalidatingPagingSourceFactory<Int, Int>(pagingSourceFactory) {}
+    }
+}

--- a/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/InvalidatingPagingSourceFactoryTest.kt
@@ -18,6 +18,7 @@ package androidx.paging
 
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class InvalidatingPagingSourceFactoryTest {
 
@@ -26,7 +27,7 @@ class InvalidatingPagingSourceFactoryTest {
 
         val testFactory = getFactory()
 
-        for (i in 0..3) {
+        repeat(4) {
             testFactory.invoke()
         }
 
@@ -38,7 +39,7 @@ class InvalidatingPagingSourceFactoryTest {
 
         val testFactory = getFactory()
 
-        for (i in 0..3) {
+        repeat(4) {
             testFactory.invoke()
         }
 
@@ -54,7 +55,7 @@ class InvalidatingPagingSourceFactoryTest {
 
         val testFactory = getFactory()
 
-        for (i in 0..3) {
+        repeat(4) {
             testFactory.invoke()
         }
 
@@ -65,6 +66,33 @@ class InvalidatingPagingSourceFactoryTest {
         }
 
         testFactory.invalidate()
+    }
+
+    @Test
+    fun skipInvalidatedPagingSources () {
+
+        val testFactory = getFactory()
+
+        repeat(4) {
+            testFactory.invoke()
+        }
+
+        val pagingSource = testFactory.pagingSources[0]
+        pagingSource.invalidate()
+
+        assertTrue(pagingSource.invalid)
+
+        var invalidateCount = 0
+
+        testFactory.pagingSources.forEach {
+            it.registerInvalidatedCallback {
+                invalidateCount++
+            }
+        }
+
+        testFactory.invalidate()
+
+        assertEquals(3, invalidateCount)
     }
 
     private fun getFactory(): InvalidatingPagingSourceFactory<Int, Int> {


### PR DESCRIPTION
## Proposed Changes

A PagingSource Factory that stores references to PagingSources for PagingSource invalidation

## Testing

Test: ./gradlew paging:paging-common:test