### PR TITLE
Add playground support for androidx.lifecycle

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,6 +9,9 @@ contact_links:
   - name: Fragment
     url: https://issuetracker.google.com/issues/new?component=460964&template=1182267
     about: File a bug or feature request for Fragment
+  - name: Lifecycle
+    url: https://issuetracker.google.com/issues/new?component=413132&template=1096619
+    about: File a bug or feature request for Lifecycle
   - name: Navigation
     url: https://issuetracker.google.com/issues/new?component=409828&template=1093757
     about: File a bug or feature request for Navigation

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -479,6 +479,7 @@ jobs:
           if [ "${{ needs.lint.outputs.status }}" == "success" ]            && \
             [ "${{ needs.build-activity.outputs.status }}" == "success" ]   && \
             [ "${{ needs.build-fragment.outputs.status }}" == "success" ]   && \
+            [ "${{ needs.build-lifecycle.outputs.status }}" == "success" ]  && \
             [ "${{ needs.build-navigation.outputs.status }}" == "success" ] && \
             [ "${{ needs.build-paging.outputs.status }}" == "success" ]     && \
             [ "${{ needs.build-room.outputs.status }}" == "success" ]       && \

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -191,6 +191,59 @@ jobs:
         if: always()
         run: echo ::set-output name=status::${{ job.status }}
 
+  build-lifecycle:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    needs: [setup, lint]
+    outputs:
+      status: ${{ steps.output-status.outputs.status }}
+    env:
+      group-id: "lifecycle"
+    steps:
+      - name: "Checkout androidx repo"
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: "Setup JDK 11"
+        id: setup-java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+
+      - name: "Set environment variables"
+        shell: bash
+        run: |
+          set -x
+          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
+          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
+
+      - name: "./gradlew buildOnServer"
+        uses: eskatos/gradle-command-action@v1
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+        with:
+          arguments: buildOnServer
+          build-root-directory: ${{ env.group-id }}
+          gradle-executable: ${{ env.group-id }}/gradlew
+          wrapper-directory: ${{ env.group-id }}/gradle/wrapper
+
+      - name: "Upload build artifacts"
+        continue-on-error: true
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts_${{ env.group-id }}
+          path: ~/dist
+
+      - name: "Report job status"
+        id: output-status
+        if: always()
+        run: echo ::set-output name=status::${{ job.status }}
+
   build-navigation:
     strategy:
       fail-fast: false
@@ -411,6 +464,7 @@ jobs:
       lint,
       build-activity,
       build-fragment,
+      build-lifecycle,
       build-navigation,
       build-paging,
       build-room,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ You can start contributing to any of the following library groups from GitHub:
   - [Activity](https://developer.android.com/guide/components/activities/intro-activities)
   - [Biometric](https://developer.android.com/training/sign-in/biometric-auth)
   - [Fragment](https://developer.android.com/guide/components/fragments)
+  - [Lifecycle](https://developer.android.com/topic/libraries/architecture/lifecycle)
   - [Navigation](https://developer.android.com/guide/navigation)
   - [Paging](https://developer.android.com/topic/libraries/architecture/paging)
   - [Room](https://developer.android.com/topic/libraries/architecture/room)
@@ -48,6 +49,7 @@ androidx
   -- activity
   -- biometric
   -- fragment
+  -- lifecycle
   -- navigation
   -- paging
   -- room

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Note: The contributions workflow via GitHub is currently experimental - only con
 * [Activity](activity)
 * [Biometric](biometric)
 * [Fragment](fragment)
+* [Lifecycle](lifecycle)
 * [Navigation](navigation)
 * [Paging](paging)
 * [Room](room)

--- a/lifecycle/.idea/codeStyles/Project.xml
+++ b/lifecycle/.idea/codeStyles/Project.xml
@@ -1,0 +1,1 @@
+../../../.idea/codeStyles/Project.xml

--- a/lifecycle/.idea/codeStyles/codeStyleConfig.xml
+++ b/lifecycle/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,1 @@
+../../../.idea/codeStyles/codeStyleConfig.xml

--- a/lifecycle/.idea/copyright/AndroidCopyright.xml
+++ b/lifecycle/.idea/copyright/AndroidCopyright.xml
@@ -1,0 +1,1 @@
+../../../.idea/copyright/AndroidCopyright.xml

--- a/lifecycle/.idea/copyright/profiles_settings.xml
+++ b/lifecycle/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,1 @@
+../../../.idea/copyright/profiles_settings.xml

--- a/lifecycle/.idea/inspectionProfiles/Project_Default.xml
+++ b/lifecycle/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,1 @@
+../../../.idea/inspectionProfiles/Project_Default.xml

--- a/lifecycle/.idea/scopes/Ignore_API_Files.xml
+++ b/lifecycle/.idea/scopes/Ignore_API_Files.xml
@@ -1,0 +1,1 @@
+../../../.idea/scopes/Ignore_API_Files.xml

--- a/lifecycle/.idea/scopes/buildSrc.xml
+++ b/lifecycle/.idea/scopes/buildSrc.xml
@@ -1,0 +1,1 @@
+../../../.idea/scopes/buildSrc.xml

--- a/lifecycle/gradle
+++ b/lifecycle/gradle
@@ -1,0 +1,1 @@
+../playground-common/gradle

--- a/lifecycle/gradle.properties
+++ b/lifecycle/gradle.properties
@@ -1,0 +1,1 @@
+../playground-common/androidx-shared.properties

--- a/lifecycle/gradlew
+++ b/lifecycle/gradlew
@@ -1,0 +1,1 @@
+../playground-common/gradlew

--- a/lifecycle/gradlew.bat
+++ b/lifecycle/gradlew.bat
@@ -1,0 +1,1 @@
+../playground-common/gradlew.bat

--- a/lifecycle/integration-tests/kotlintestapp/build.gradle
+++ b/lifecycle/integration-tests/kotlintestapp/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 dependencies {
     implementation(project(":lifecycle:lifecycle-runtime-ktx"))
-    implementation(project(":activity:activity")) {
+    implementation(projectOrArtifact(":activity:activity")) {
         exclude group: 'androidx.lifecycle'
     }
     implementation(project(":lifecycle:lifecycle-viewmodel-savedstate")) {

--- a/lifecycle/integration-tests/testapp/build.gradle
+++ b/lifecycle/integration-tests/testapp/build.gradle
@@ -24,7 +24,7 @@ plugins {
 
 dependencies {
     implementation(KOTLIN_STDLIB)
-    implementation(project(":fragment:fragment"))
+    implementation(projectOrArtifact(":fragment:fragment"))
     implementation(project(":lifecycle:lifecycle-process"))
     implementation(project(":lifecycle:lifecycle-common"))
     annotationProcessor(project(":lifecycle:lifecycle-compiler"))

--- a/lifecycle/integration-tests/testapp/build.gradle
+++ b/lifecycle/integration-tests/testapp/build.gradle
@@ -24,9 +24,12 @@ plugins {
 
 dependencies {
     implementation(KOTLIN_STDLIB)
-    implementation(projectOrArtifact(":fragment:fragment"))
+    implementation(projectOrArtifact(":fragment:fragment")) {
+        exclude group: "androidx.lifecycle", module: "lifecycle-runtime"
+    }
     implementation(project(":lifecycle:lifecycle-process"))
     implementation(project(":lifecycle:lifecycle-common"))
+    implementation(project(":lifecycle:lifecycle-runtime"))
     annotationProcessor(project(":lifecycle:lifecycle-compiler"))
 
     androidTestAnnotationProcessor(project(":lifecycle:lifecycle-compiler"))

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -38,7 +38,11 @@ dependencies {
     api(project(":lifecycle:lifecycle-livedata-core"))
     api(project(":lifecycle:lifecycle-viewmodel"))
 
+    androidTestImplementation project(":lifecycle:lifecycle-runtime")
+    androidTestImplementation project(":lifecycle:lifecycle-livedata-core")
     androidTestImplementation projectOrArtifact(":fragment:fragment"), {
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-runtime'
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-livedata-core'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-savedstate'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel'
     }

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     api(project(":lifecycle:lifecycle-livedata-core"))
     api(project(":lifecycle:lifecycle-viewmodel"))
 
-    androidTestImplementation project(":fragment:fragment"), {
+    androidTestImplementation projectOrArtifact(":fragment:fragment"), {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-savedstate'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel'
     }

--- a/lifecycle/settings.gradle
+++ b/lifecycle/settings.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// see ../playground-common/README.md for details on how this works
+rootProject.name = "navigation-playground"
+apply from: "../playground-common/playground-include-settings.gradle"
+setupPlayground(this, "..")
+selectProjectsFromAndroidX({ name ->
+    if (name.startsWith(":lifecycle")) return true
+    if (name == ":annotation:annotation") return true
+    if (name == ":internal-testutils-runtime") return true
+    if (name == ":internal-testutils-truth") return true
+    return false
+})
+


### PR DESCRIPTION
Adds a workaround to exclude androidx.lifecycle transitive dependencies from legacy-support-core-utils
resolving an error for "Could not find lifecycle-runtime.aar" when building lifecycle-services.

Test: cd lifecycle && ./gradlew bOS