### PR TITLE
Avoid exception when calling Activity.reportFullyDrawn()

### DIFF
--- a/activity/activity/src/androidTest/AndroidManifest.xml
+++ b/activity/activity/src/androidTest/AndroidManifest.xml
@@ -23,6 +23,7 @@
         <activity android:name="androidx.activity.LifecycleComponentActivity"/>
         <activity android:name="androidx.activity.EagerOverrideLifecycleComponentActivity"/>
         <activity android:name="androidx.activity.LazyOverrideLifecycleComponentActivity"/>
+        <activity android:name="androidx.activity.ReportFullyDrawnActivity"/>
         <activity android:name="androidx.activity.ViewModelActivity"/>
         <activity android:name="androidx.activity.SavedStateActivity"/>
         <activity android:name="androidx.activity.ContentViewActivity"/>

--- a/activity/activity/src/androidTest/java/androidx/activity/ComponentActivityReportFullyDrawnTest.kt
+++ b/activity/activity/src/androidTest/java/androidx/activity/ComponentActivityReportFullyDrawnTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.activity
+
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.testutils.withActivity
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class ComponentActivityReportFullyDrawnTest {
+
+    @Test
+    fun testReportFullyDrawn() {
+        with(ActivityScenario.launch(ReportFullyDrawnActivity::class.java)) {
+            withActivity {
+                // This test makes sure that this method does not throw an exception on devices
+                // running API 19 (without UPDATE_DEVICE_STATS permission) and earlier
+                // (regardless or permissions).
+                reportFullyDrawn()
+            }
+        }
+    }
+}
+
+class ReportFullyDrawnActivity : ComponentActivity()

--- a/activity/activity/src/main/java/androidx/activity/ComponentActivity.java
+++ b/activity/activity/src/main/java/androidx/activity/ComponentActivity.java
@@ -29,6 +29,7 @@ import static androidx.activity.result.contract.ActivityResultContracts.StartInt
 import static androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.EXTRA_INTENT_SENDER_REQUEST;
 import static androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult.EXTRA_SEND_INTENT_EXCEPTION;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
@@ -62,6 +63,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.ActivityOptionsCompat;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.HasDefaultViewModelProviderFactory;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleEventObserver;
@@ -684,5 +686,20 @@ public class ComponentActivity extends androidx.core.app.ComponentActivity imple
     @Override
     public final ActivityResultRegistry getActivityResultRegistry() {
         return mActivityResultRegistry;
+    }
+
+    @Override
+    public void reportFullyDrawn() {
+        if (Build.VERSION.SDK_INT > 19) {
+            super.reportFullyDrawn();
+        } else if (Build.VERSION.SDK_INT == 19 && ContextCompat.checkSelfPermission(this,
+                Manifest.permission.UPDATE_DEVICE_STATS) == PackageManager.PERMISSION_GRANTED) {
+            // On API 19, the Activity.reportFullyDrawn() method requires the UPDATE_DEVICE_STATS
+            // permission, otherwise it throws an exception. Instead of throwing, we fall back to
+            // a no-op call.
+            super.reportFullyDrawn();
+        }
+        // The Activity.reportFullyDrawn() got added in API 19, fall back to a no-op call if this
+        // method gets called on devices with an earlier version.
     }
 }

--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java
@@ -19,15 +19,12 @@ package androidx.fragment.app;
 import static androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult;
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -55,7 +52,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.SharedElementCallback;
-import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
@@ -647,19 +643,6 @@ public class FragmentActivity extends ComponentActivity implements
         // If for some reason this method is being called directly with a requestCode that is not
         // -1, redirect it to the fragment.startActivityForResult method
         fragment.startActivityForResult(intent, requestCode, options);
-    }
-
-    @Override
-    public void reportFullyDrawn() {
-        // On KitKat (API 19) the Activity.reportFullyDrawn() method requires the
-        // UPDATE_DEVICE_STATS permission, otherwise it throws an exception. Instead of throwing,
-        // we fall back to a no-op call here.
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT && ContextCompat
-                .checkSelfPermission(this, Manifest.permission.UPDATE_DEVICE_STATS)
-                != PackageManager.PERMISSION_GRANTED) {
-            return;
-        }
-        super.reportFullyDrawn();
     }
 
     /**

--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentActivity.java
@@ -19,12 +19,15 @@ package androidx.fragment.app;
 import static androidx.activity.result.contract.ActivityResultContracts.StartIntentSenderForResult;
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -52,6 +55,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.SharedElementCallback;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LifecycleRegistry;
@@ -643,6 +647,19 @@ public class FragmentActivity extends ComponentActivity implements
         // If for some reason this method is being called directly with a requestCode that is not
         // -1, redirect it to the fragment.startActivityForResult method
         fragment.startActivityForResult(intent, requestCode, options);
+    }
+
+    @Override
+    public void reportFullyDrawn() {
+        // On KitKat (API 19) the Activity.reportFullyDrawn() method requires the
+        // UPDATE_DEVICE_STATS permission, otherwise it throws an exception. Instead of throwing,
+        // we fall back to a no-op call here.
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT && ContextCompat
+                .checkSelfPermission(this, Manifest.permission.UPDATE_DEVICE_STATS)
+                != PackageManager.PERMISSION_GRANTED) {
+            return;
+        }
+        super.reportFullyDrawn();
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

  - Avoid a bug on API 19 when calling `Activity.reportFullyDrawn()`

I'm not quite sure if this class is the right place for this workaround, the code could also live in other places, e.g.:
- `androidx.core.app.ComponentActivity`
- `androidx.activity.ComponentActivity`
- `androidx.appcompat.app.AppCompatActivity`

## Testing

Test: Manually tested. If your test harness is also executed on devices with API 19, I could write an automated test for this change if you want.

## Issues Fixed

Fixes: 163239764
