### PR TITLE
Call AbstractProgressFragment's onViewCreated

### DIFF
--- a/navigation/navigation-dynamic-features-fragment/src/main/java/androidx/navigation/dynamicfeatures/fragment/ui/DefaultProgressFragment.kt
+++ b/navigation/navigation-dynamic-features-fragment/src/main/java/androidx/navigation/dynamicfeatures/fragment/ui/DefaultProgressFragment.kt
@@ -51,6 +51,7 @@ public class DefaultProgressFragment :
     private var action: Button? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         with(view) {
             title = findViewById(R.id.progress_title)
             progressBar = findViewById(R.id.installation_progress)


### PR DESCRIPTION
Install observation has been moved to `onViewCreated` since 29c5aee2bf2685e3bc2a0e38ca0290408aa65b11.

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
