### PR TITLE
attr/listChoiceBackgroundIndicator misleading documentation

### DIFF
--- a/appcompat/appcompat/src/main/res/values/attrs.xml
+++ b/appcompat/appcompat/src/main/res/values/attrs.xml
@@ -309,7 +309,7 @@
         <attr name="panelMenuListWidth" format="dimension" />
         <!-- Default Panel Menu style. -->
         <attr name="panelMenuListTheme" format="reference" />
-        <!-- Drawable used as a background for selected list items. -->
+        <!-- Drawable used as a background for activated list items. -->
         <attr name="listChoiceBackgroundIndicator" format="reference" />
 
         <!-- ============= -->


### PR DESCRIPTION
It is a drawable used as a background for activated list items, not selected ones. There is a difference between a selected and an activated state as stated in Android's documentation. A choice in a list represents a non-transient active state, as opposed to, for example, a transient selection of files in a file manager's list (the one which triggers an ActionMode). This mistake stems from the AOSP itself.

## Testing

Test: Isn't required