### PR TITLE
Update PageFetcherSnapshotTest asserts with containsExactly

### DIFF
--- a/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -467,7 +467,11 @@ class PageFetcherSnapshotTest {
 
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+                LoadStateUpdate<PageEvent<Int>>(
+                    loadType = REFRESH,
+                    fromMediator = false,
+                    loadState = Loading
+                ),
                 createRefresh(range = 50..54)
             )
 
@@ -483,7 +487,11 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+                LoadStateUpdate<PageEvent<Int>>(
+                    loadType = PREPEND,
+                    fromMediator = false,
+                    loadState = Loading
+                ),
                 createPrepend(
                     pageOffset = -1,
                     range = 49..49,
@@ -606,7 +614,7 @@ class PageFetcherSnapshotTest {
             LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
             createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
             createPrepend(pageOffset = -2, range = 48..48)
-    )
+        )
 
         fetcherState.job.cancel()
     }
@@ -625,7 +633,11 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = false,
+                loadState = Loading
+            ),
             createRefresh(range = 50..52)
         )
 
@@ -642,10 +654,14 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = PREPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
             createPrepend(pageOffset = -2, range = 48..48)
-    )
+        )
 
         // APPEND a few pages causing PREPEND pages to drop
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -660,7 +676,11 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = APPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             Drop<PageEvent<Int>>(
                 loadType = PREPEND,
                 minPageOffset = -2,
@@ -690,7 +710,11 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = PREPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             Drop<PageEvent<Int>>(
                 loadType = APPEND,
                 minPageOffset = 2,
@@ -698,7 +722,7 @@ class PageFetcherSnapshotTest {
                 placeholdersRemaining = 46
             ),
             createPrepend(pageOffset = -1, range = 49..49)
-    )
+        )
 
         fetcherState.job.cancel()
     }
@@ -855,7 +879,7 @@ class PageFetcherSnapshotTest {
             assertThat(fetcherState.newEvents()).containsExactly(
                 LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
                 createRefresh(range = 50..54)
-        )
+            )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
                 ViewportHint.Access(
@@ -975,7 +999,11 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = false,
+                loadState = Loading
+            ),
             createRefresh(range = 50..52)
         )
 
@@ -992,7 +1020,11 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = APPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             createAppend(pageOffset = 1, range = 53..53, endState = Loading),
             createAppend(pageOffset = 2, range = 54..54)
         )
@@ -1010,7 +1042,11 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = PREPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             Drop<PageEvent<Int>>(
                 loadType = APPEND,
                 minPageOffset = 2,
@@ -1040,7 +1076,11 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = APPEND,
+                fromMediator = false,
+                loadState = Loading
+            ),
             Drop<PageEvent<Int>>(
                 loadType = PREPEND,
                 minPageOffset = -2,
@@ -1167,27 +1207,27 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Error(LOAD_ERROR)
-                        )
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Error(LOAD_ERROR)
+                    )
                 )
 
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createAppend(pageOffset = 1, range = 52..52)
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createAppend(pageOffset = 1, range = 52..52)
                 )
             }
         }
@@ -1223,12 +1263,12 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createAppend(pageOffset = 1, range = 52..52)
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createAppend(pageOffset = 1, range = 52..52)
                 )
                 retryBus.send(Unit)
                 advanceUntilIdle()
@@ -1376,23 +1416,23 @@ class PageFetcherSnapshotTest {
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = PREPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate<PageEvent<Int>>(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createPrepend(
-                            pageOffset = -1,
-                            range = 49..49,
-                            startState = NotLoading.Incomplete,
-                            endState = Loading
-                        ),
-                        createAppend(pageOffset = 1, range = 52..52)
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = PREPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createPrepend(
+                        pageOffset = -1,
+                        range = 49..49,
+                        startState = NotLoading.Incomplete,
+                        endState = Loading
+                    ),
+                    createAppend(pageOffset = 1, range = 52..52)
                 )
             }
         }
@@ -1444,8 +1484,8 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                        LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                        LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
                 )
 
                 // Retry failed APPEND
@@ -1711,8 +1751,7 @@ class PageFetcherSnapshotTest {
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
             LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
-
-            )
+        )
 
         fetcherState.job.cancel()
     }
@@ -2141,7 +2180,11 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(state.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = true, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = true,
+                loadState = Loading
+            ),
             LoadStateUpdate<PageEvent<Int>>(
                 loadType = REFRESH,
                 fromMediator = false,
@@ -3070,15 +3113,27 @@ class PageFetcherSnapshotTest {
         collectSnapshotData(pageFetcherSnapshot) { state, _ ->
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+                LoadStateUpdate<PageEvent<Int>>(
+                    loadType = REFRESH,
+                    fromMediator = false,
+                    loadState = Loading
+                ),
                 createRefresh(range = 50..51),
-        )
+            )
 
             pageFetcherSnapshot.accessHint(ViewportHint.Initial(0, 0, 0, 0))
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+                LoadStateUpdate<PageEvent<Int>>(
+                    loadType = PREPEND,
+                    fromMediator = false,
+                    loadState = Loading
+                ),
+                LoadStateUpdate<PageEvent<Int>>(
+                    loadType = APPEND,
+                    fromMediator = false,
+                    loadState = Loading
+                ),
                 createPrepend(pageOffset = -1, range = 49..49, endState = Loading),
                 createAppend(pageOffset = 1, range = 52..52),
             )

--- a/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -281,8 +281,8 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
 
-        val expected: List<PageEvent<Int>> = listOf(
-            LoadStateUpdate(REFRESH, false, Loading),
+        assertThat(fetcherState.pageEventLists[0]).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(
                 range = 0..1,
                 startState = NotLoading.Complete,
@@ -290,7 +290,6 @@ class PageFetcherSnapshotTest {
             )
         )
 
-        assertEvents(expected, fetcherState.pageEventLists[0])
         fetcherState.job.cancel()
     }
 
@@ -301,8 +300,8 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
 
-        val expected: List<PageEvent<Int>> = listOf(
-            LoadStateUpdate(REFRESH, false, Loading),
+        assertThat(fetcherState.pageEventLists[0]).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(
                 range = 98..99,
                 startState = NotLoading.Incomplete,
@@ -310,7 +309,6 @@ class PageFetcherSnapshotTest {
             )
         )
 
-        assertEvents(expected, fetcherState.pageEventLists[0])
         fetcherState.job.cancel()
     }
 
@@ -321,12 +319,11 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
 
-        val expected: List<PageEvent<Int>> = listOf(
-            LoadStateUpdate(REFRESH, false, Loading),
+        assertThat(fetcherState.pageEventLists[0]).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(range = 50..51)
         )
 
-        assertEvents(expected, fetcherState.pageEventLists[0])
         fetcherState.job.cancel()
     }
 
@@ -347,14 +344,13 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
 
-        val expected: List<PageEvent<Int>> = listOf(
-            LoadStateUpdate(REFRESH, false, Loading),
+        assertThat(fetcherState.pageEventLists[0]).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(range = 50..51),
-            LoadStateUpdate(PREPEND, false, Loading),
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
             createPrepend(pageOffset = -1, range = 49..49)
         )
 
-        assertEvents(expected, fetcherState.pageEventLists[0])
         fetcherState.job.cancel()
     }
 
@@ -900,11 +896,9 @@ class PageFetcherSnapshotTest {
             val fetcherState = collectFetcherState(pageFetcher)
 
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    createRefresh(range = 50..51)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                createRefresh(range = 50..51)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -918,11 +912,9 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(APPEND, false, Loading),
-                    createAppend(pageOffset = 1, range = 52..53)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                createAppend(pageOffset = 1, range = 52..53)
             )
 
             // Start hint processing until load starts, but hasn't finished.
@@ -948,22 +940,20 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(APPEND, false, Loading),
-                    LoadStateUpdate(PREPEND, false, Loading),
-                    Drop(
-                        loadType = PREPEND,
-                        minPageOffset = 0,
-                        maxPageOffset = 0,
-                        placeholdersRemaining = 52
-                    ),
-                    createAppend(
-                        pageOffset = 2,
-                        range = 54..55,
-                        startState = NotLoading.Incomplete,
-                        endState = NotLoading.Incomplete
-                    )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                Drop<PageEvent<Int>>(
+                    loadType = PREPEND,
+                    minPageOffset = 0,
+                    maxPageOffset = 0,
+                    placeholdersRemaining = 52
+                ),
+                createAppend(
+                    pageOffset = 2,
+                    range = 54..55,
+                    startState = NotLoading.Incomplete,
+                    endState = NotLoading.Incomplete
                 )
             )
 
@@ -984,11 +974,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = REFRESH, fromMediator = false, loadState = Loading),
-                createRefresh(range = 50..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+            createRefresh(range = 50..52)
         )
 
         // APPEND a few pages.
@@ -1003,12 +991,10 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = APPEND, fromMediator = false, loadState = Loading),
-                createAppend(pageOffset = 1, range = 53..53, endState = Loading),
-                createAppend(pageOffset = 2, range = 54..54)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            createAppend(pageOffset = 1, range = 53..53, endState = Loading),
+            createAppend(pageOffset = 2, range = 54..54)
         )
 
         // PREPEND a few pages causing APPEND pages to drop
@@ -1023,24 +1009,22 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                Drop(
-                    loadType = APPEND,
-                    minPageOffset = 2,
-                    maxPageOffset = 2,
-                    placeholdersRemaining = 46
-                ),
-                createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
-                Drop(
-                    loadType = APPEND,
-                    minPageOffset = 1,
-                    maxPageOffset = 1,
-                    placeholdersRemaining = 47
-                ),
-                createPrepend(pageOffset = -2, range = 48..48)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = APPEND,
+                minPageOffset = 2,
+                maxPageOffset = 2,
+                placeholdersRemaining = 46
+            ),
+            createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = APPEND,
+                minPageOffset = 1,
+                maxPageOffset = 1,
+                placeholdersRemaining = 47
+            ),
+            createPrepend(pageOffset = -2, range = 48..48)
         )
 
         // APPEND a page, this hint would normally be ignored, but has a newer generationId.
@@ -1055,17 +1039,15 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = APPEND, fromMediator = false, loadState = Loading),
-                Drop(
-                    loadType = PREPEND,
-                    minPageOffset = -2,
-                    maxPageOffset = -2,
-                    placeholdersRemaining = 49
-                ),
-                createAppend(pageOffset = 1, range = 53..53)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = PREPEND,
+                minPageOffset = -2,
+                maxPageOffset = -2,
+                placeholdersRemaining = 49
+            ),
+            createAppend(pageOffset = 1, range = 53..53)
         )
 
         fetcherState.job.cancel()
@@ -1077,20 +1059,16 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..51)
         )
 
         pageFetcher.refresh()
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..51)
         )
 
         fetcherState.job.cancel()
@@ -1102,11 +1080,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..51)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -1121,21 +1097,17 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
 
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(1, 52..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(1, 52..52)
         )
 
         pageFetcher.refresh()
         advanceUntilIdle()
 
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(51..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(51..52)
         )
 
         fetcherState.job.cancel()
@@ -1173,15 +1145,13 @@ class PageFetcherSnapshotTest {
 
             collectSnapshotData(pager) { state, _ ->
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createRefresh(range = 50..51)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createRefresh(range = 50..51)
                 )
 
                 pageSource.errorNextLoad = true
@@ -1196,32 +1166,28 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
+                assertThat(state.newEvents()).containsExactly(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = APPEND,
                             fromMediator = false,
                             loadState = Loading
                         ),
-                        LoadStateUpdate(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = APPEND,
                             fromMediator = false,
                             loadState = Error(LOAD_ERROR)
                         )
-                    )
                 )
 
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
+                assertThat(state.newEvents()).containsExactly(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = APPEND,
                             fromMediator = false,
                             loadState = Loading
                         ),
                         createAppend(pageOffset = 1, range = 52..52)
-                    )
                 )
             }
         }
@@ -1236,15 +1202,13 @@ class PageFetcherSnapshotTest {
             collectSnapshotData(pager) { state, _ ->
 
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createRefresh(range = 50..51)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createRefresh(range = 50..51)
                 )
 
                 pager.accessHint(
@@ -1258,15 +1222,13 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
+                assertThat(state.newEvents()).containsExactly(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = APPEND,
                             fromMediator = false,
                             loadState = Loading
                         ),
                         createAppend(pageOffset = 1, range = 52..52)
-                    )
                 )
                 retryBus.send(Unit)
                 advanceUntilIdle()
@@ -1284,15 +1246,13 @@ class PageFetcherSnapshotTest {
             collectSnapshotData(pager) { state, _ ->
 
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createRefresh(range = 50..51)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createRefresh(range = 50..51)
                 )
                 pageSource.errorNextLoad = true
                 pager.accessHint(
@@ -1306,31 +1266,27 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Error(LOAD_ERROR)
-                        )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Error(LOAD_ERROR)
                     )
                 )
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createAppend(pageOffset = 1, range = 52..52)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createAppend(pageOffset = 1, range = 52..52)
                 )
                 retryBus.send(Unit)
                 advanceUntilIdle()
@@ -1355,15 +1311,13 @@ class PageFetcherSnapshotTest {
             collectSnapshotData(pager) { state, _ ->
                 // Initial REFRESH
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createRefresh(range = 50..51)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createRefresh(range = 50..51)
                 )
 
                 // Failed APPEND
@@ -1379,18 +1333,16 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate(
-                            loadType = APPEND,
-                            fromMediator = false,
-                            loadState = Error(LOAD_ERROR)
-                        )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = APPEND,
+                        fromMediator = false,
+                        loadState = Error(LOAD_ERROR)
                     )
                 )
 
@@ -1407,32 +1359,29 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = PREPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate(
-                            loadType = PREPEND,
-                            fromMediator = false,
-                            loadState = Error(LOAD_ERROR)
-                        )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = PREPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = PREPEND,
+                        fromMediator = false,
+                        loadState = Error(LOAD_ERROR)
                     )
                 )
 
                 // Retry should trigger in both directions.
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
+                assertThat(state.newEvents()).containsExactly(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = PREPEND,
                             fromMediator = false,
                             loadState = Loading
                         ),
-                        LoadStateUpdate(
+                        LoadStateUpdate<PageEvent<Int>>(
                             loadType = APPEND,
                             fromMediator = false,
                             loadState = Loading
@@ -1444,7 +1393,6 @@ class PageFetcherSnapshotTest {
                             endState = Loading
                         ),
                         createAppend(pageOffset = 1, range = 52..52)
-                    )
                 )
             }
         }
@@ -1473,15 +1421,13 @@ class PageFetcherSnapshotTest {
                     itemsAfter = 48
                 )
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(REFRESH, false, Loading),
-                        Refresh(
-                            pages = listOf(TransformablePage(listOf(0, 1))),
-                            placeholdersBefore = 50,
-                            placeholdersAfter = 48,
-                            combinedLoadStates = CombinedLoadStates.IDLE_SOURCE
-                        )
+                assertThat(pageEvents.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                    Refresh(
+                        pages = listOf(TransformablePage(listOf(0, 1))),
+                        placeholdersBefore = 50,
+                        placeholdersAfter = 48,
+                        combinedLoadStates = CombinedLoadStates.IDLE_SOURCE
                     )
                 )
 
@@ -1497,21 +1443,18 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(APPEND, false, Loading),
-                        LoadStateUpdate(APPEND, false, Error(LOAD_ERROR))
-                    )
+                assertThat(pageEvents.newEvents()).containsExactly(
+                        LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                        LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
                 )
 
                 // Retry failed APPEND
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(APPEND, false, Loading),
-                        LoadStateUpdate(APPEND, false, Error(LOAD_ERROR))
-                    )
+                assertThat(pageEvents.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
+
                 )
 
                 // This hint should be ignored even though in the non-error state it would
@@ -1527,7 +1470,7 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(listOf<PageEvent<Int>>())
+                assertThat(pageEvents.newEvents()).isEmpty()
 
                 // Hint to trigger PREPEND
                 pager.accessHint(
@@ -1541,23 +1484,19 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(PREPEND, false, Loading),
-                        LoadStateUpdate(PREPEND, false, Error(LOAD_ERROR))
-                    )
+                assertThat(pageEvents.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Error(LOAD_ERROR))
                 )
 
                 // Retry failed hints, both PREPEND and APPEND should trigger.
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(PREPEND, false, Loading),
-                        LoadStateUpdate(APPEND, false, Loading),
-                        LoadStateUpdate(PREPEND, false, Error(LOAD_ERROR)),
-                        LoadStateUpdate(APPEND, false, Error(LOAD_ERROR))
-                    )
+                assertThat(pageEvents.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Error(LOAD_ERROR)),
+                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
                 )
 
                 // This hint should be ignored even though in the non-error state it would
@@ -1573,7 +1512,7 @@ class PageFetcherSnapshotTest {
                     )
                 )
                 advanceUntilIdle()
-                assertThat(pageEvents.newEvents()).isEqualTo(listOf<PageEvent<Int>>())
+                assertThat(pageEvents.newEvents()).isEmpty()
             }
         }
     }
@@ -1588,20 +1527,16 @@ class PageFetcherSnapshotTest {
 
                 pageSource.errorNextLoad = true
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(REFRESH, false, Loading),
-                        LoadStateUpdate(REFRESH, false, Error(LOAD_ERROR))
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
                 )
 
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(REFRESH, false, Loading),
-                        createRefresh(50..51)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                    createRefresh(50..51)
                 )
             }
         }
@@ -1615,18 +1550,16 @@ class PageFetcherSnapshotTest {
             collectSnapshotData(pager) { state, _ ->
                 pageSource.errorNextLoad = true
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Error(LOAD_ERROR)
-                        )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Error(LOAD_ERROR)
                     )
                 )
                 pager.accessHint(
@@ -1644,21 +1577,19 @@ class PageFetcherSnapshotTest {
 
                 retryBus.send(Unit)
                 advanceUntilIdle()
-                assertThat(state.newEvents()).isEqualTo(
-                    listOf<PageEvent<Int>>(
-                        LoadStateUpdate(
-                            loadType = REFRESH,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createRefresh(range = 50..51),
-                        LoadStateUpdate(
-                            loadType = PREPEND,
-                            fromMediator = false,
-                            loadState = Loading
-                        ),
-                        createPrepend(pageOffset = -1, range = 49..49)
-                    )
+                assertThat(state.newEvents()).containsExactly(
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = REFRESH,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createRefresh(range = 50..51),
+                    LoadStateUpdate<PageEvent<Int>>(
+                        loadType = PREPEND,
+                        fromMediator = false,
+                        loadState = Loading
+                    ),
+                    createPrepend(pageOffset = -1, range = 49..49)
                 )
             }
         }
@@ -1777,12 +1708,12 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
 
-        val expected: List<PageEvent<Int>> = listOf(
-            LoadStateUpdate(REFRESH, false, Loading),
+        assertThat(fetcherState.pageEventLists[0]).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
             createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
-        )
 
-        assertEvents(expected, fetcherState.pageEventLists[0])
+            )
+
         fetcherState.job.cancel()
     }
 
@@ -1799,11 +1730,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
         )
         fetcherState.pagingDataList[0].receiver.accessHint(
             ViewportHint.Access(
@@ -1816,11 +1745,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                createPrepend(-1, 49..49).let { Prepend(it.pages, 0, it.combinedLoadStates) }
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            createPrepend(-1, 49..49).let { Prepend(it.pages, 0, it.combinedLoadStates) }
         )
 
         fetcherState.job.cancel()
@@ -1839,11 +1766,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -1857,11 +1782,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(1, 52..52).let { Append(it.pages, 0, it.combinedLoadStates) }
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(1, 52..52).let { Append(it.pages, 0, it.combinedLoadStates) }
         )
 
         fetcherState.job.cancel()
@@ -1880,11 +1803,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 50..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 50..52)
         )
         fetcherState.pagingDataList[0].receiver.accessHint(
             ViewportHint.Access(
@@ -1897,11 +1818,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(pageOffset = 1, range = 53..53)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(pageOffset = 1, range = 53..53)
         )
 
         fetcherState.job.cancel()
@@ -2065,11 +1984,9 @@ class PageFetcherSnapshotTest {
         collectSnapshotData(pager) { state, _ ->
             pagingSource.errorNextLoad = true
             advanceUntilIdle()
-            assertThat(state.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    LoadStateUpdate(REFRESH, false, Error(LOAD_ERROR))
-                )
+            assertThat(state.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
             )
 
             pagingSource.errorNextLoad = true
@@ -2077,11 +1994,9 @@ class PageFetcherSnapshotTest {
             // Should be ignored by pager as it's still processing previous retry.
             retryBus.send(Unit)
             advanceUntilIdle()
-            assertThat(state.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    LoadStateUpdate(REFRESH, false, Error(LOAD_ERROR))
-                )
+            assertThat(state.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
             )
         }
     }
@@ -2224,47 +2139,50 @@ class PageFetcherSnapshotTest {
         val state = collectFetcherState(pager)
 
         advanceUntilIdle()
-        assertThat(state.newEvents()).isEqualTo(
-            listOf(
-                LoadStateUpdate(loadType = REFRESH, fromMediator = true, loadState = Loading),
-                LoadStateUpdate(loadType = REFRESH, fromMediator = false, loadState = Loading),
-                LoadStateUpdate(
-                    loadType = REFRESH,
-                    fromMediator = true,
-                    loadState = NotLoading(endOfPaginationReached = true)
-                ),
-                LoadStateUpdate(
-                    loadType = PREPEND,
-                    fromMediator = true,
-                    loadState = NotLoading(endOfPaginationReached = true)
-                ),
-                LoadStateUpdate(
-                    loadType = APPEND,
-                    fromMediator = true,
-                    loadState = NotLoading(endOfPaginationReached = true)
-                ),
-                Refresh(
-                    pages = listOf(
-                        TransformablePage(
-                            originalPageOffsets = intArrayOf(0),
-                            data = listOf(0),
-                            hintOriginalPageOffset = 0,
-                            hintOriginalIndices = null
-                        )
-                    ),
-                    placeholdersBefore = 0,
-                    placeholdersAfter = 0,
-                    combinedLoadStates = remoteLoadStatesOf(
-                        refresh = NotLoading(endOfPaginationReached = true),
-                        prepend = NotLoading(endOfPaginationReached = true),
-                        append = NotLoading(endOfPaginationReached = true),
-                        refreshLocal = NotLoading(endOfPaginationReached = false),
-                        prependLocal = NotLoading(endOfPaginationReached = true),
-                        appendLocal = NotLoading(endOfPaginationReached = true),
-                        refreshRemote = NotLoading(endOfPaginationReached = true),
-                        prependRemote = NotLoading(endOfPaginationReached = true),
-                        appendRemote = NotLoading(endOfPaginationReached = true),
+
+        assertThat(state.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = true, loadState = Loading),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = false,
+                loadState = Loading
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = true,
+                loadState = NotLoading(endOfPaginationReached = true)
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = PREPEND,
+                fromMediator = true,
+                loadState = NotLoading(endOfPaginationReached = true)
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = APPEND,
+                fromMediator = true,
+                loadState = NotLoading(endOfPaginationReached = true)
+            ),
+            Refresh(
+                pages = listOf(
+                    TransformablePage(
+                        originalPageOffsets = intArrayOf(0),
+                        data = listOf(0),
+                        hintOriginalPageOffset = 0,
+                        hintOriginalIndices = null
                     )
+                ),
+                placeholdersBefore = 0,
+                placeholdersAfter = 0,
+                combinedLoadStates = remoteLoadStatesOf(
+                    refresh = NotLoading(endOfPaginationReached = true),
+                    prepend = NotLoading(endOfPaginationReached = true),
+                    append = NotLoading(endOfPaginationReached = true),
+                    refreshLocal = NotLoading(endOfPaginationReached = false),
+                    prependLocal = NotLoading(endOfPaginationReached = true),
+                    appendLocal = NotLoading(endOfPaginationReached = true),
+                    refreshRemote = NotLoading(endOfPaginationReached = true),
+                    prependRemote = NotLoading(endOfPaginationReached = true),
+                    appendRemote = NotLoading(endOfPaginationReached = true),
                 )
             )
         )
@@ -2854,57 +2772,53 @@ class PageFetcherSnapshotTest {
 
         advanceTimeBy(1000)
 
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf(
-                LoadStateUpdate(
-                    loadType = REFRESH,
-                    fromMediator = true,
-                    loadState = Loading,
-                ),
-                LoadStateUpdate(
-                    loadType = REFRESH,
-                    fromMediator = false,
-                    loadState = Loading,
-                ),
-                Refresh(
-                    pages = listOf(
-                        TransformablePage(
-                            originalPageOffset = 0,
-                            data = listOf(50)
-                        )
-                    ),
-                    placeholdersBefore = 50,
-                    placeholdersAfter = 49,
-                    combinedLoadStates = remoteLoadStatesOf(
-                        refresh = Loading,
-                        prependLocal = NotLoading.Complete,
-                        appendLocal = NotLoading.Complete,
-                        refreshRemote = Loading,
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = true,
+                loadState = Loading,
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = false,
+                loadState = Loading,
+            ),
+            Refresh(
+                pages = listOf(
+                    TransformablePage(
+                        originalPageOffset = 0,
+                        data = listOf(50)
                     )
                 ),
+                placeholdersBefore = 50,
+                placeholdersAfter = 49,
+                combinedLoadStates = remoteLoadStatesOf(
+                    refresh = Loading,
+                    prependLocal = NotLoading.Complete,
+                    appendLocal = NotLoading.Complete,
+                    refreshRemote = Loading,
+                )
             ),
         )
 
         advanceUntilIdle()
 
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(
-                    loadType = REFRESH,
-                    fromMediator = true,
-                    loadState = NotLoading.Complete,
-                ),
-                LoadStateUpdate(
-                    loadType = PREPEND,
-                    fromMediator = true,
-                    loadState = NotLoading.Complete
-                ),
-                LoadStateUpdate(
-                    loadType = APPEND,
-                    fromMediator = true,
-                    loadState = NotLoading.Complete
-                ),
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = REFRESH,
+                fromMediator = true,
+                loadState = NotLoading.Complete,
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = PREPEND,
+                fromMediator = true,
+                loadState = NotLoading.Complete
+            ),
+            LoadStateUpdate<PageEvent<Int>>(
+                loadType = APPEND,
+                fromMediator = true,
+                loadState = NotLoading.Complete
+            ),
         )
 
         fetcherState.job.cancel()
@@ -3155,22 +3069,18 @@ class PageFetcherSnapshotTest {
         )
         collectSnapshotData(pageFetcherSnapshot) { state, _ ->
             advanceUntilIdle()
-            assertThat(state.newEvents()).isEqualTo(
-                listOf(
-                    LoadStateUpdate(loadType = REFRESH, fromMediator = false, loadState = Loading),
-                    createRefresh(range = 50..51),
-                )
-            )
+            assertThat(state.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+                createRefresh(range = 50..51),
+        )
 
             pageFetcherSnapshot.accessHint(ViewportHint.Initial(0, 0, 0, 0))
             advanceUntilIdle()
-            assertThat(state.newEvents()).isEqualTo(
-                listOf(
-                    LoadStateUpdate(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                    LoadStateUpdate(loadType = APPEND, fromMediator = false, loadState = Loading),
-                    createPrepend(pageOffset = -1, range = 49..49, endState = Loading),
-                    createAppend(pageOffset = 1, range = 52..52),
-                )
+            assertThat(state.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+                LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+                createPrepend(pageOffset = -1, range = 49..49, endState = Loading),
+                createAppend(pageOffset = 1, range = 52..52),
             )
         }
     }

--- a/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -92,11 +92,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(1..2)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(1..2)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -110,14 +108,12 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                createPrepend(
-                    pageOffset = -1,
-                    range = 0..0,
-                    startState = NotLoading.Complete
-                )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            createPrepend(
+                pageOffset = -1,
+                range = 0..0,
+                startState = NotLoading.Complete
             )
         )
 
@@ -130,11 +126,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(1..2)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(1..2)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -148,14 +142,12 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                createPrepend(
-                    pageOffset = -1,
-                    range = 0..0,
-                    startState = NotLoading.Complete
-                )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            createPrepend(
+                pageOffset = -1,
+                range = 0..0,
+                startState = NotLoading.Complete
             )
         )
 
@@ -170,21 +162,19 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                Drop(
-                    loadType = PREPEND,
-                    minPageOffset = -1,
-                    maxPageOffset = -1,
-                    placeholdersRemaining = 1
-                ),
-                createAppend(
-                    pageOffset = 1,
-                    range = 3..3,
-                    startState = NotLoading.Incomplete,
-                    endState = NotLoading.Incomplete
-                )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            Drop<PageEvent<Int>>(
+                loadType = PREPEND,
+                minPageOffset = -1,
+                maxPageOffset = -1,
+                placeholdersRemaining = 1
+            ),
+            createAppend(
+                pageOffset = 1,
+                range = 3..3,
+                startState = NotLoading.Incomplete,
+                endState = NotLoading.Incomplete
             )
         )
 
@@ -197,11 +187,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 97..98)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 97..98)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -215,11 +203,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(pageOffset = 1, range = 99..99, endState = NotLoading.Complete)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(pageOffset = 1, range = 99..99, endState = NotLoading.Complete)
         )
 
         fetcherState.job.cancel()
@@ -231,11 +217,10 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 97..98)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 97..98)
+
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -249,15 +234,13 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(
-                    pageOffset = 1,
-                    range = 99..99,
-                    startState = NotLoading.Incomplete,
-                    endState = NotLoading.Complete
-                )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(
+                pageOffset = 1,
+                range = 99..99,
+                startState = NotLoading.Incomplete,
+                endState = NotLoading.Complete
             )
         )
 
@@ -272,21 +255,19 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                Drop(
-                    loadType = APPEND,
-                    minPageOffset = 1,
-                    maxPageOffset = 1,
-                    placeholdersRemaining = 1
-                ),
-                createPrepend(
-                    pageOffset = -1,
-                    range = 96..96,
-                    startState = NotLoading.Incomplete,
-                    endState = NotLoading.Incomplete
-                )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            Drop<PageEvent<Int>>(
+                loadType = APPEND,
+                minPageOffset = 1,
+                maxPageOffset = 1,
+                placeholdersRemaining = 1
+            ),
+            createPrepend(
+                pageOffset = -1,
+                range = 96..96,
+                startState = NotLoading.Incomplete,
+                endState = NotLoading.Incomplete
             )
         )
 
@@ -383,11 +364,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 50..51)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -401,11 +380,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                createPrepend(pageOffset = -1, range = 49..49)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            createPrepend(pageOffset = -1, range = 49..49)
         )
 
         fetcherState.job.cancel()
@@ -427,11 +404,9 @@ class PageFetcherSnapshotTest {
             advanceUntilIdle()
             // Make sure the job didn't complete exceptionally
             assertFalse { fetcherState.job.isCancelled }
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    createRefresh(range = 50..51)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                createRefresh(range = 50..51)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -446,11 +421,9 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertFalse { fetcherState.job.isCancelled }
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(PREPEND, false, Loading),
-                    createPrepend(pageOffset = -1, range = 48..49)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                createPrepend(pageOffset = -1, range = 48..49)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -465,17 +438,15 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertFalse { fetcherState.job.isCancelled }
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(PREPEND, false, Loading),
-                    Drop(
-                        loadType = APPEND,
-                        minPageOffset = 0,
-                        maxPageOffset = 0,
-                        placeholdersRemaining = 50
-                    ),
-                    createPrepend(pageOffset = -2, range = 46..47)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                Drop<PageEvent<Int>>(
+                    loadType = APPEND,
+                    minPageOffset = 0,
+                    maxPageOffset = 0,
+                    placeholdersRemaining = 50
+                ),
+                createPrepend(pageOffset = -2, range = 46..47)
             )
 
             fetcherState.job.cancel()
@@ -499,11 +470,9 @@ class PageFetcherSnapshotTest {
             val fetcherState = collectFetcherState(pageFetcher)
 
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(loadType = REFRESH, fromMediator = false, loadState = Loading),
-                    createRefresh(range = 50..54)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+                createRefresh(range = 50..54)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -517,16 +486,14 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                    createPrepend(
-                        pageOffset = -1,
-                        range = 49..49,
-                        startState = Loading
-                    ),
-                    createPrepend(pageOffset = -2, range = 48..48)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+                createPrepend(
+                    pageOffset = -1,
+                    range = 49..49,
+                    startState = Loading
+                ),
+                createPrepend(pageOffset = -2, range = 48..48)
             )
 
             // Make sure the job didn't complete exceptionally
@@ -550,11 +517,9 @@ class PageFetcherSnapshotTest {
             val fetcherState = collectFetcherState(pageFetcher)
 
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    createRefresh(range = 50..51)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                createRefresh(range = 50..51)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -568,11 +533,9 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(PREPEND, false, Loading),
-                    createPrepend(pageOffset = -1, range = 48..49)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                createPrepend(pageOffset = -1, range = 48..49)
             )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
@@ -598,18 +561,16 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(PREPEND, false, Loading),
-                    LoadStateUpdate(APPEND, false, Loading),
-                    Drop(
-                        loadType = APPEND,
-                        minPageOffset = 0,
-                        maxPageOffset = 0,
-                        placeholdersRemaining = 50
-                    ),
-                    createPrepend(pageOffset = -2, range = 46..47)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                Drop<PageEvent<Int>>(
+                    loadType = APPEND,
+                    minPageOffset = 0,
+                    maxPageOffset = 0,
+                    placeholdersRemaining = 50
+                ),
+                createPrepend(pageOffset = -2, range = 46..47)
             )
 
             fetcherState.job.cancel()
@@ -629,11 +590,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..52)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -647,13 +606,11 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(PREPEND, false, Loading),
-                createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
-                createPrepend(pageOffset = -2, range = 48..48)
-            )
-        )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
+            createPrepend(pageOffset = -2, range = 48..48)
+    )
 
         fetcherState.job.cancel()
     }
@@ -671,11 +628,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = REFRESH, fromMediator = false, loadState = Loading),
-                createRefresh(range = 50..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = REFRESH, fromMediator = false, loadState = Loading),
+            createRefresh(range = 50..52)
         )
 
         // PREPEND a few pages.
@@ -690,13 +645,11 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
-                createPrepend(pageOffset = -2, range = 48..48)
-            )
-        )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
+            createPrepend(pageOffset = -2, range = 48..48)
+    )
 
         // APPEND a few pages causing PREPEND pages to drop
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -710,24 +663,22 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = APPEND, fromMediator = false, loadState = Loading),
-                Drop(
-                    loadType = PREPEND,
-                    minPageOffset = -2,
-                    maxPageOffset = -2,
-                    placeholdersRemaining = 49
-                ),
-                createAppend(pageOffset = 1, range = 53..53, endState = Loading),
-                Drop(
-                    loadType = PREPEND,
-                    minPageOffset = -1,
-                    maxPageOffset = -1,
-                    placeholdersRemaining = 50
-                ),
-                createAppend(pageOffset = 2, range = 54..54)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = APPEND, fromMediator = false, loadState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = PREPEND,
+                minPageOffset = -2,
+                maxPageOffset = -2,
+                placeholdersRemaining = 49
+            ),
+            createAppend(pageOffset = 1, range = 53..53, endState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = PREPEND,
+                minPageOffset = -1,
+                maxPageOffset = -1,
+                placeholdersRemaining = 50
+            ),
+            createAppend(pageOffset = 2, range = 54..54)
         )
 
         // PREPEND a page, this hint would normally be ignored, but has a newer generationId.
@@ -742,18 +693,16 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(loadType = PREPEND, fromMediator = false, loadState = Loading),
-                Drop(
-                    loadType = APPEND,
-                    minPageOffset = 2,
-                    maxPageOffset = 2,
-                    placeholdersRemaining = 46
-                ),
-                createPrepend(pageOffset = -1, range = 49..49)
-            )
-        )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(loadType = PREPEND, fromMediator = false, loadState = Loading),
+            Drop<PageEvent<Int>>(
+                loadType = APPEND,
+                minPageOffset = 2,
+                maxPageOffset = 2,
+                placeholdersRemaining = 46
+            ),
+            createPrepend(pageOffset = -1, range = 49..49)
+    )
 
         fetcherState.job.cancel()
     }
@@ -764,11 +713,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..51)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -782,11 +729,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(1, 52..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(1, 52..52)
         )
 
         fetcherState.job.cancel()
@@ -805,11 +750,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(50..52)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(50..52)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -823,17 +766,15 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(
-                    pageOffset = 1,
-                    range = 53..53,
-                    startState = NotLoading.Incomplete,
-                    endState = Loading
-                ),
-                createAppend(2, 54..54)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(
+                pageOffset = 1,
+                range = 53..53,
+                startState = NotLoading.Incomplete,
+                endState = Loading
+            ),
+            createAppend(2, 54..54)
         )
 
         fetcherState.job.cancel()
@@ -852,11 +793,9 @@ class PageFetcherSnapshotTest {
         val fetcherState = collectFetcherState(pageFetcher)
 
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(REFRESH, false, Loading),
-                createRefresh(range = 50..51)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            createRefresh(range = 50..51)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -870,11 +809,9 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                createAppend(pageOffset = 1, range = 52..53)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            createAppend(pageOffset = 1, range = 52..53)
         )
 
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -888,17 +825,15 @@ class PageFetcherSnapshotTest {
             )
         )
         advanceUntilIdle()
-        assertThat(fetcherState.newEvents()).isEqualTo(
-            listOf<PageEvent<Int>>(
-                LoadStateUpdate(APPEND, false, Loading),
-                Drop(
-                    loadType = PREPEND,
-                    minPageOffset = 0,
-                    maxPageOffset = 0,
-                    placeholdersRemaining = 52
-                ),
-                createAppend(pageOffset = 2, range = 54..55)
-            )
+        assertThat(fetcherState.newEvents()).containsExactly(
+            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            Drop<PageEvent<Int>>(
+                loadType = PREPEND,
+                minPageOffset = 0,
+                maxPageOffset = 0,
+                placeholdersRemaining = 52
+            ),
+            createAppend(pageOffset = 2, range = 54..55)
         )
 
         fetcherState.job.cancel()
@@ -921,12 +856,10 @@ class PageFetcherSnapshotTest {
             val fetcherState = collectFetcherState(pageFetcher)
 
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(REFRESH, false, Loading),
-                    createRefresh(range = 50..54)
-                )
-            )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                createRefresh(range = 50..54)
+        )
 
             fetcherState.pagingDataList[0].receiver.accessHint(
                 ViewportHint.Access(
@@ -939,16 +872,14 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceUntilIdle()
-            assertThat(fetcherState.newEvents()).isEqualTo(
-                listOf<PageEvent<Int>>(
-                    LoadStateUpdate(APPEND, false, Loading),
-                    createAppend(
-                        pageOffset = 1,
-                        range = 55..55,
-                        endState = Loading
-                    ),
-                    createAppend(pageOffset = 2, range = 56..56)
-                )
+            assertThat(fetcherState.newEvents()).containsExactly(
+                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                createAppend(
+                    pageOffset = 1,
+                    range = 55..55,
+                    endState = Loading
+                ),
+                createAppend(pageOffset = 2, range = 56..56)
             )
 
             fetcherState.job.cancel()

--- a/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -93,7 +93,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(1..2)
         )
 
@@ -109,7 +109,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(
                 pageOffset = -1,
                 range = 0..0,
@@ -127,7 +127,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(1..2)
         )
 
@@ -143,7 +143,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(
                 pageOffset = -1,
                 range = 0..0,
@@ -163,8 +163,8 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-            Drop<PageEvent<Int>>(
+            LoadStateUpdate<Int>(APPEND, false, Loading),
+            Drop<Int>(
                 loadType = PREPEND,
                 minPageOffset = -1,
                 maxPageOffset = -1,
@@ -188,7 +188,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 97..98)
         )
 
@@ -204,7 +204,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(pageOffset = 1, range = 99..99, endState = NotLoading.Complete)
         )
 
@@ -218,7 +218,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 97..98)
 
         )
@@ -235,7 +235,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(
                 pageOffset = 1,
                 range = 99..99,
@@ -256,8 +256,8 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-            Drop<PageEvent<Int>>(
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
+            Drop<Int>(
                 loadType = APPEND,
                 minPageOffset = 1,
                 maxPageOffset = 1,
@@ -282,7 +282,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(
                 range = 0..1,
                 startState = NotLoading.Complete,
@@ -301,7 +301,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(
                 range = 98..99,
                 startState = NotLoading.Incomplete,
@@ -320,7 +320,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51)
         )
 
@@ -345,9 +345,9 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51),
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(pageOffset = -1, range = 49..49)
         )
 
@@ -361,7 +361,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51)
         )
 
@@ -377,7 +377,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(pageOffset = -1, range = 49..49)
         )
 
@@ -401,7 +401,7 @@ class PageFetcherSnapshotTest {
             // Make sure the job didn't complete exceptionally
             assertFalse { fetcherState.job.isCancelled }
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
                 createRefresh(range = 50..51)
             )
 
@@ -418,7 +418,7 @@ class PageFetcherSnapshotTest {
             advanceUntilIdle()
             assertFalse { fetcherState.job.isCancelled }
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                LoadStateUpdate<Int>(PREPEND, false, Loading),
                 createPrepend(pageOffset = -1, range = 48..49)
             )
 
@@ -435,8 +435,8 @@ class PageFetcherSnapshotTest {
             advanceUntilIdle()
             assertFalse { fetcherState.job.isCancelled }
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-                Drop<PageEvent<Int>>(
+                LoadStateUpdate<Int>(PREPEND, false, Loading),
+                Drop<Int>(
                     loadType = APPEND,
                     minPageOffset = 0,
                     maxPageOffset = 0,
@@ -467,7 +467,7 @@ class PageFetcherSnapshotTest {
 
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(
+                LoadStateUpdate<Int>(
                     loadType = REFRESH,
                     fromMediator = false,
                     loadState = Loading
@@ -487,7 +487,7 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(
+                LoadStateUpdate<Int>(
                     loadType = PREPEND,
                     fromMediator = false,
                     loadState = Loading
@@ -522,7 +522,7 @@ class PageFetcherSnapshotTest {
 
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
                 createRefresh(range = 50..51)
             )
 
@@ -538,7 +538,7 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+                LoadStateUpdate<Int>(PREPEND, false, Loading),
                 createPrepend(pageOffset = -1, range = 48..49)
             )
 
@@ -566,9 +566,9 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                Drop<PageEvent<Int>>(
+                LoadStateUpdate<Int>(PREPEND, false, Loading),
+                LoadStateUpdate<Int>(APPEND, false, Loading),
+                Drop<Int>(
                     loadType = APPEND,
                     minPageOffset = 0,
                     maxPageOffset = 0,
@@ -595,7 +595,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..52)
         )
 
@@ -611,7 +611,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
             createPrepend(pageOffset = -2, range = 48..48)
         )
@@ -633,7 +633,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = false,
                 loadState = Loading
@@ -654,7 +654,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = PREPEND,
                 fromMediator = false,
                 loadState = Loading
@@ -676,19 +676,19 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = APPEND,
                 fromMediator = false,
                 loadState = Loading
             ),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = PREPEND,
                 minPageOffset = -2,
                 maxPageOffset = -2,
                 placeholdersRemaining = 49
             ),
             createAppend(pageOffset = 1, range = 53..53, endState = Loading),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = PREPEND,
                 minPageOffset = -1,
                 maxPageOffset = -1,
@@ -710,12 +710,12 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = PREPEND,
                 fromMediator = false,
                 loadState = Loading
             ),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = APPEND,
                 minPageOffset = 2,
                 maxPageOffset = 2,
@@ -734,7 +734,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..51)
         )
 
@@ -750,7 +750,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(1, 52..52)
         )
 
@@ -771,7 +771,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..52)
         )
 
@@ -787,7 +787,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(
                 pageOffset = 1,
                 range = 53..53,
@@ -814,7 +814,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51)
         )
 
@@ -830,7 +830,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(pageOffset = 1, range = 52..53)
         )
 
@@ -846,8 +846,8 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-            Drop<PageEvent<Int>>(
+            LoadStateUpdate<Int>(APPEND, false, Loading),
+            Drop<Int>(
                 loadType = PREPEND,
                 minPageOffset = 0,
                 maxPageOffset = 0,
@@ -877,7 +877,7 @@ class PageFetcherSnapshotTest {
 
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
                 createRefresh(range = 50..54)
             )
 
@@ -893,7 +893,7 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                LoadStateUpdate<Int>(APPEND, false, Loading),
                 createAppend(
                     pageOffset = 1,
                     range = 55..55,
@@ -921,7 +921,7 @@ class PageFetcherSnapshotTest {
 
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
                 createRefresh(range = 50..51)
             )
 
@@ -937,7 +937,7 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+                LoadStateUpdate<Int>(APPEND, false, Loading),
                 createAppend(pageOffset = 1, range = 52..53)
             )
 
@@ -965,9 +965,9 @@ class PageFetcherSnapshotTest {
             )
             advanceUntilIdle()
             assertThat(fetcherState.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-                Drop<PageEvent<Int>>(
+                LoadStateUpdate<Int>(APPEND, false, Loading),
+                LoadStateUpdate<Int>(PREPEND, false, Loading),
+                Drop<Int>(
                     loadType = PREPEND,
                     minPageOffset = 0,
                     maxPageOffset = 0,
@@ -999,7 +999,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = false,
                 loadState = Loading
@@ -1020,7 +1020,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = APPEND,
                 fromMediator = false,
                 loadState = Loading
@@ -1042,19 +1042,19 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = PREPEND,
                 fromMediator = false,
                 loadState = Loading
             ),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = APPEND,
                 minPageOffset = 2,
                 maxPageOffset = 2,
                 placeholdersRemaining = 46
             ),
             createPrepend(pageOffset = -1, range = 49..49, startState = Loading),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = APPEND,
                 minPageOffset = 1,
                 maxPageOffset = 1,
@@ -1076,12 +1076,12 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = APPEND,
                 fromMediator = false,
                 loadState = Loading
             ),
-            Drop<PageEvent<Int>>(
+            Drop<Int>(
                 loadType = PREPEND,
                 minPageOffset = -2,
                 maxPageOffset = -2,
@@ -1100,14 +1100,14 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..51)
         )
 
         pageFetcher.refresh()
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..51)
         )
 
@@ -1121,7 +1121,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(50..51)
         )
 
@@ -1138,7 +1138,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(1, 52..52)
         )
 
@@ -1146,7 +1146,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(51..52)
         )
 
@@ -1186,7 +1186,7 @@ class PageFetcherSnapshotTest {
             collectSnapshotData(pager) { state, _ ->
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
@@ -1207,12 +1207,12 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Error(LOAD_ERROR)
@@ -1222,7 +1222,7 @@ class PageFetcherSnapshotTest {
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
@@ -1243,7 +1243,7 @@ class PageFetcherSnapshotTest {
 
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
@@ -1263,7 +1263,7 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
@@ -1287,7 +1287,7 @@ class PageFetcherSnapshotTest {
 
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
@@ -1307,12 +1307,12 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Error(LOAD_ERROR)
@@ -1321,7 +1321,7 @@ class PageFetcherSnapshotTest {
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
@@ -1352,7 +1352,7 @@ class PageFetcherSnapshotTest {
                 // Initial REFRESH
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
@@ -1374,12 +1374,12 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Error(LOAD_ERROR)
@@ -1400,12 +1400,12 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = PREPEND,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = PREPEND,
                         fromMediator = false,
                         loadState = Error(LOAD_ERROR)
@@ -1416,12 +1416,12 @@ class PageFetcherSnapshotTest {
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = PREPEND,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = APPEND,
                         fromMediator = false,
                         loadState = Loading
@@ -1462,7 +1462,7 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                    LoadStateUpdate<Int>(REFRESH, false, Loading),
                     Refresh(
                         pages = listOf(TransformablePage(listOf(0, 1))),
                         placeholdersBefore = 50,
@@ -1484,16 +1484,16 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<Int>(APPEND, false, Loading),
+                    LoadStateUpdate<Int>(APPEND, false, Error(LOAD_ERROR))
                 )
 
                 // Retry failed APPEND
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<Int>(APPEND, false, Loading),
+                    LoadStateUpdate<Int>(APPEND, false, Error(LOAD_ERROR))
 
                 )
 
@@ -1525,18 +1525,18 @@ class PageFetcherSnapshotTest {
                 )
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<Int>(PREPEND, false, Loading),
+                    LoadStateUpdate<Int>(PREPEND, false, Error(LOAD_ERROR))
                 )
 
                 // Retry failed hints, both PREPEND and APPEND should trigger.
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(pageEvents.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Error(LOAD_ERROR)),
-                    LoadStateUpdate<PageEvent<Int>>(APPEND, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<Int>(PREPEND, false, Loading),
+                    LoadStateUpdate<Int>(APPEND, false, Loading),
+                    LoadStateUpdate<Int>(PREPEND, false, Error(LOAD_ERROR)),
+                    LoadStateUpdate<Int>(APPEND, false, Error(LOAD_ERROR))
                 )
 
                 // This hint should be ignored even though in the non-error state it would
@@ -1568,14 +1568,14 @@ class PageFetcherSnapshotTest {
                 pageSource.errorNextLoad = true
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
-                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
+                    LoadStateUpdate<Int>(REFRESH, false, Loading),
+                    LoadStateUpdate<Int>(REFRESH, false, Error(LOAD_ERROR))
                 )
 
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+                    LoadStateUpdate<Int>(REFRESH, false, Loading),
                     createRefresh(50..51)
                 )
             }
@@ -1591,12 +1591,12 @@ class PageFetcherSnapshotTest {
                 pageSource.errorNextLoad = true
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
                     ),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Error(LOAD_ERROR)
@@ -1618,13 +1618,13 @@ class PageFetcherSnapshotTest {
                 retryBus.send(Unit)
                 advanceUntilIdle()
                 assertThat(state.newEvents()).containsExactly(
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = REFRESH,
                         fromMediator = false,
                         loadState = Loading
                     ),
                     createRefresh(range = 50..51),
-                    LoadStateUpdate<PageEvent<Int>>(
+                    LoadStateUpdate<Int>(
                         loadType = PREPEND,
                         fromMediator = false,
                         loadState = Loading
@@ -1749,7 +1749,7 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.pageEventLists[0]).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
         )
 
@@ -1770,7 +1770,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
         )
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -1785,7 +1785,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(PREPEND, false, Loading),
+            LoadStateUpdate<Int>(PREPEND, false, Loading),
             createPrepend(-1, 49..49).let { Prepend(it.pages, 0, it.combinedLoadStates) }
         )
 
@@ -1806,7 +1806,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..51).let { Refresh(it.pages, 0, 0, it.combinedLoadStates) }
         )
 
@@ -1822,7 +1822,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(1, 52..52).let { Append(it.pages, 0, it.combinedLoadStates) }
         )
 
@@ -1843,7 +1843,7 @@ class PageFetcherSnapshotTest {
 
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
+            LoadStateUpdate<Int>(REFRESH, false, Loading),
             createRefresh(range = 50..52)
         )
         fetcherState.pagingDataList[0].receiver.accessHint(
@@ -1858,7 +1858,7 @@ class PageFetcherSnapshotTest {
         )
         advanceUntilIdle()
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(APPEND, false, Loading),
+            LoadStateUpdate<Int>(APPEND, false, Loading),
             createAppend(pageOffset = 1, range = 53..53)
         )
 
@@ -2024,8 +2024,8 @@ class PageFetcherSnapshotTest {
             pagingSource.errorNextLoad = true
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Error(LOAD_ERROR))
             )
 
             pagingSource.errorNextLoad = true
@@ -2034,8 +2034,8 @@ class PageFetcherSnapshotTest {
             retryBus.send(Unit)
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Loading),
-                LoadStateUpdate<PageEvent<Int>>(REFRESH, false, Error(LOAD_ERROR))
+                LoadStateUpdate<Int>(REFRESH, false, Loading),
+                LoadStateUpdate<Int>(REFRESH, false, Error(LOAD_ERROR))
             )
         }
     }
@@ -2180,12 +2180,12 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(state.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = true,
                 loadState = Loading
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = false,
                 loadState = Loading
@@ -2195,12 +2195,12 @@ class PageFetcherSnapshotTest {
                 fromMediator = true,
                 loadState = NotLoading(endOfPaginationReached = true)
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = PREPEND,
                 fromMediator = true,
                 loadState = NotLoading(endOfPaginationReached = true)
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = APPEND,
                 fromMediator = true,
                 loadState = NotLoading(endOfPaginationReached = true)
@@ -2816,12 +2816,12 @@ class PageFetcherSnapshotTest {
         advanceTimeBy(1000)
 
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = true,
                 loadState = Loading,
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = false,
                 loadState = Loading,
@@ -2847,17 +2847,17 @@ class PageFetcherSnapshotTest {
         advanceUntilIdle()
 
         assertThat(fetcherState.newEvents()).containsExactly(
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = REFRESH,
                 fromMediator = true,
                 loadState = NotLoading.Complete,
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = PREPEND,
                 fromMediator = true,
                 loadState = NotLoading.Complete
             ),
-            LoadStateUpdate<PageEvent<Int>>(
+            LoadStateUpdate<Int>(
                 loadType = APPEND,
                 fromMediator = true,
                 loadState = NotLoading.Complete
@@ -3113,7 +3113,7 @@ class PageFetcherSnapshotTest {
         collectSnapshotData(pageFetcherSnapshot) { state, _ ->
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(
+                LoadStateUpdate<Int>(
                     loadType = REFRESH,
                     fromMediator = false,
                     loadState = Loading
@@ -3124,12 +3124,12 @@ class PageFetcherSnapshotTest {
             pageFetcherSnapshot.accessHint(ViewportHint.Initial(0, 0, 0, 0))
             advanceUntilIdle()
             assertThat(state.newEvents()).containsExactly(
-                LoadStateUpdate<PageEvent<Int>>(
+                LoadStateUpdate<Int>(
                     loadType = PREPEND,
                     fromMediator = false,
                     loadState = Loading
                 ),
-                LoadStateUpdate<PageEvent<Int>>(
+                LoadStateUpdate<Int>(
                     loadType = APPEND,
                     fromMediator = false,
                     loadState = Loading


### PR DESCRIPTION
## Proposed Changes

Update assertThat tests from using isEqualTo to containsExactly.

## Testing

Test: ./gradlew paging:paging-common:test

