### PR TITLE
fix bug in navigation: allow integer default types with argType float.

### DIFF
--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavInflaterTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavInflaterTest.kt
@@ -168,6 +168,14 @@ class NavInflaterTest {
     }
 
     @Test
+    fun testDefaultIntArgumentsFloat() {
+        val defaultArguments = inflateDefaultArgumentsFromGraph()
+
+        assertThat(defaultArguments["test_int_as_float"]?.run { type to defaultValue })
+            .isEqualTo(NavType.FloatType to 3f)
+    }
+
+    @Test
     fun testDefaultArgumentsBoolean() {
         val defaultArguments = inflateDefaultArgumentsFromGraph()
 

--- a/navigation/navigation-runtime/src/androidTest/res/navigation/nav_default_arguments.xml
+++ b/navigation/navigation-runtime/src/androidTest/res/navigation/nav_default_arguments.xml
@@ -28,6 +28,11 @@
             android:defaultValue="3.14" />
 
         <argument
+            android:name="test_int_as_float"
+            app:argType="float"
+            android:defaultValue="3" />
+
+        <argument
             android:name="test_reference"
             android:defaultValue="@style/AppTheme" />
         <argument

--- a/navigation/navigation-runtime/src/main/java/androidx/navigation/NavInflater.java
+++ b/navigation/navigation-runtime/src/main/java/androidx/navigation/NavInflater.java
@@ -244,9 +244,15 @@ public final class NavInflater {
                     default:
                         if (value.type >= TypedValue.TYPE_FIRST_INT
                                 && value.type <= TypedValue.TYPE_LAST_INT) {
-                            navType = checkNavType(value, navType, NavType.IntType,
-                                    argType, "integer");
-                            defaultValue = value.data;
+                            if (navType == NavType.FloatType) {
+                                navType = checkNavType(value, navType, NavType.FloatType,
+                                        argType, "float");
+                                defaultValue = (float) value.data;
+                            } else {
+                                navType = checkNavType(value, navType, NavType.IntType,
+                                        argType, "integer");
+                                defaultValue = value.data;
+                            }
                         } else {
                             throw new XmlPullParserException(
                                     "unsupported argument type " + value.type);


### PR DESCRIPTION
## Proposed Changes
changes the `NavInflater` to allow integer default types with argType="float". 
From now on this will work: 
```xml
<argument
         android:name="ratio"
         android:defaultValue="0" <-- notice the value, 0 instead of 0.0
         app:argType="float" />
```
before there was an error: `org.xmlpull.v1.XmlPullParserException: Type is float but found integer: 0`
## Testing

Test: ./gradlew navigation:navigation-runtime:connectedCheck

## Issues Fixed

Fixes: The bug on [https://issuetracker.google.com/issues/173766247](https://issuetracker.google.com/issues/173766247) being fixed
