### PR TITLE
Add initial infrastructure for FragmentStrictMode

### DIFF
--- a/fragment/fragment/api/public_plus_experimental_current.txt
+++ b/fragment/fragment/api/public_plus_experimental_current.txt
@@ -477,7 +477,7 @@ package androidx.fragment.app.strictmode {
     method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyLog();
   }
 
-  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.Throwable {
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.RuntimeException {
     ctor public Violation();
   }
 

--- a/fragment/fragment/api/public_plus_experimental_current.txt
+++ b/fragment/fragment/api/public_plus_experimental_current.txt
@@ -287,6 +287,7 @@ package androidx.fragment.app {
     method public androidx.fragment.app.FragmentFactory getFragmentFactory();
     method public java.util.List<androidx.fragment.app.Fragment!> getFragments();
     method public androidx.fragment.app.Fragment? getPrimaryNavigationFragment();
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public androidx.fragment.app.strictmode.FragmentStrictMode.Policy? getStrictModePolicy();
     method public boolean isDestroyed();
     method public boolean isStateSaved();
     method public void popBackStack();
@@ -303,6 +304,7 @@ package androidx.fragment.app {
     method public void setFragmentFactory(androidx.fragment.app.FragmentFactory);
     method public final void setFragmentResult(String, android.os.Bundle);
     method public final void setFragmentResultListener(String, androidx.lifecycle.LifecycleOwner, androidx.fragment.app.FragmentResultListener);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public void setStrictModePolicy(androidx.fragment.app.strictmode.FragmentStrictMode.Policy?);
     method public void unregisterFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks);
     field public static final int POP_BACK_STACK_INCLUSIVE = 1; // 0x1
   }
@@ -448,6 +450,35 @@ package androidx.fragment.app {
     method public void setListShown(boolean);
     method public void setListShownNoAnimation(boolean);
     method public void setSelection(int);
+  }
+
+}
+
+package androidx.fragment.app.strictmode {
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public final class FragmentStrictMode {
+    method public static androidx.fragment.app.strictmode.FragmentStrictMode.Policy getDefaultPolicy();
+    method public static void setDefaultPolicy(androidx.fragment.app.strictmode.FragmentStrictMode.Policy);
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static interface FragmentStrictMode.OnViolationListener {
+    method public void onViolation(androidx.fragment.app.strictmode.Violation);
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static final class FragmentStrictMode.Policy {
+    field public static final androidx.fragment.app.strictmode.FragmentStrictMode.Policy LAX;
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static final class FragmentStrictMode.Policy.Builder {
+    ctor public FragmentStrictMode.Policy.Builder();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy build();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyDeath();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyListener(androidx.fragment.app.strictmode.FragmentStrictMode.OnViolationListener);
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyLog();
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.Throwable {
+    ctor public Violation();
   }
 
 }

--- a/fragment/fragment/api/restricted_current.txt
+++ b/fragment/fragment/api/restricted_current.txt
@@ -291,6 +291,7 @@ package androidx.fragment.app {
     method public androidx.fragment.app.FragmentFactory getFragmentFactory();
     method public java.util.List<androidx.fragment.app.Fragment!> getFragments();
     method public androidx.fragment.app.Fragment? getPrimaryNavigationFragment();
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public androidx.fragment.app.strictmode.FragmentStrictMode.Policy? getStrictModePolicy();
     method public boolean isDestroyed();
     method public boolean isStateSaved();
     method @Deprecated @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public androidx.fragment.app.FragmentTransaction openTransaction();
@@ -308,6 +309,7 @@ package androidx.fragment.app {
     method public void setFragmentFactory(androidx.fragment.app.FragmentFactory);
     method public final void setFragmentResult(String, android.os.Bundle);
     method public final void setFragmentResultListener(String, androidx.lifecycle.LifecycleOwner, androidx.fragment.app.FragmentResultListener);
+    method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public void setStrictModePolicy(androidx.fragment.app.strictmode.FragmentStrictMode.Policy?);
     method public void unregisterFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks);
     field public static final int POP_BACK_STACK_INCLUSIVE = 1; // 0x1
   }
@@ -474,6 +476,35 @@ package androidx.fragment.app {
     method public void setListShown(boolean);
     method public void setListShownNoAnimation(boolean);
     method public void setSelection(int);
+  }
+
+}
+
+package androidx.fragment.app.strictmode {
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public final class FragmentStrictMode {
+    method public static androidx.fragment.app.strictmode.FragmentStrictMode.Policy getDefaultPolicy();
+    method public static void setDefaultPolicy(androidx.fragment.app.strictmode.FragmentStrictMode.Policy);
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static interface FragmentStrictMode.OnViolationListener {
+    method public void onViolation(androidx.fragment.app.strictmode.Violation);
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static final class FragmentStrictMode.Policy {
+    field public static final androidx.fragment.app.strictmode.FragmentStrictMode.Policy LAX;
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public static final class FragmentStrictMode.Policy.Builder {
+    ctor public FragmentStrictMode.Policy.Builder();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy build();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyDeath();
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyListener(androidx.fragment.app.strictmode.FragmentStrictMode.OnViolationListener);
+    method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyLog();
+  }
+
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.Throwable {
+    ctor public Violation();
   }
 
 }

--- a/fragment/fragment/api/restricted_current.txt
+++ b/fragment/fragment/api/restricted_current.txt
@@ -503,7 +503,7 @@ package androidx.fragment.app.strictmode {
     method public androidx.fragment.app.strictmode.FragmentStrictMode.Policy.Builder penaltyLog();
   }
 
-  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.Throwable {
+  @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY) public abstract class Violation extends java.lang.RuntimeException {
     ctor public Violation();
   }
 

--- a/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
+++ b/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.fragment.app.strictmode
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.executePendingTransactions
+import androidx.fragment.app.test.FragmentTestActivity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import androidx.testutils.withActivity
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+public class FragmentStrictModeTest {
+    private lateinit var originalPolicy: FragmentStrictMode.Policy
+
+    @Before
+    public fun setup() {
+        originalPolicy = FragmentStrictMode.getDefaultPolicy()
+    }
+
+    @After
+    public fun teardown() {
+        FragmentStrictMode.setDefaultPolicy(originalPolicy)
+    }
+
+    @Test
+    public fun policyHierarchy() {
+        var lastTriggeredPolicy = ""
+        val violation = object : Violation() {}
+
+        fun policy(name: String) = FragmentStrictMode.Policy.Builder()
+            .penaltyListener { lastTriggeredPolicy = name }
+            .build()
+
+        with(ActivityScenario.launch(FragmentTestActivity::class.java)) {
+            val fragmentManager = withActivity { supportFragmentManager }
+
+            val parentFragment = Fragment()
+            fragmentManager.beginTransaction()
+                .add(parentFragment, "parentFragment")
+                .commit()
+            executePendingTransactions()
+
+            val childFragment = Fragment()
+            parentFragment.childFragmentManager.beginTransaction()
+                .add(childFragment, "childFragment")
+                .commit()
+            executePendingTransactions()
+
+            FragmentStrictMode.setDefaultPolicy(policy("Default policy"))
+            FragmentStrictMode.onPolicyViolation(childFragment, violation)
+            assertThat(lastTriggeredPolicy).isEqualTo("Default policy")
+
+            fragmentManager.strictModePolicy = policy("Parent policy")
+            FragmentStrictMode.onPolicyViolation(childFragment, violation)
+            assertThat(lastTriggeredPolicy).isEqualTo("Parent policy")
+
+            parentFragment.childFragmentManager.strictModePolicy = policy("Child policy")
+            FragmentStrictMode.onPolicyViolation(childFragment, violation)
+            assertThat(lastTriggeredPolicy).isEqualTo("Child policy")
+        }
+    }
+}

--- a/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
+++ b/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
@@ -47,9 +47,10 @@ public class FragmentStrictModeTest {
 
     @Test
     public fun penaltyDeath() {
-        FragmentStrictMode.setDefaultPolicy(FragmentStrictMode.Policy.Builder()
+        val policy = FragmentStrictMode.Policy.Builder()
             .penaltyDeath()
-            .build())
+            .build()
+        FragmentStrictMode.setDefaultPolicy(policy)
 
         var violation: Violation? = null
         try {

--- a/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
+++ b/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.fragment.app.strictmode
 
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.StrictFragment
 import androidx.fragment.app.executePendingTransactions
 import androidx.fragment.app.test.FragmentTestActivity
@@ -73,13 +72,13 @@ public class FragmentStrictModeTest {
         with(ActivityScenario.launch(FragmentTestActivity::class.java)) {
             val fragmentManager = withActivity { supportFragmentManager }
 
-            val parentFragment = Fragment()
+            val parentFragment = StrictFragment()
             fragmentManager.beginTransaction()
                 .add(parentFragment, "parentFragment")
                 .commit()
             executePendingTransactions()
 
-            val childFragment = Fragment()
+            val childFragment = StrictFragment()
             parentFragment.childFragmentManager.beginTransaction()
                 .add(childFragment, "childFragment")
                 .commit()

--- a/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
+++ b/fragment/fragment/src/androidTest/java/androidx/fragment/app/strictmode/FragmentStrictModeTest.kt
@@ -17,6 +17,7 @@
 package androidx.fragment.app.strictmode
 
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.StrictFragment
 import androidx.fragment.app.executePendingTransactions
 import androidx.fragment.app.test.FragmentTestActivity
 import androidx.test.core.app.ActivityScenario
@@ -24,6 +25,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import androidx.testutils.withActivity
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -42,6 +44,21 @@ public class FragmentStrictModeTest {
     @After
     public fun teardown() {
         FragmentStrictMode.setDefaultPolicy(originalPolicy)
+    }
+
+    @Test
+    public fun penaltyDeath() {
+        FragmentStrictMode.setDefaultPolicy(FragmentStrictMode.Policy.Builder()
+            .penaltyDeath()
+            .build())
+
+        var violation: Violation? = null
+        try {
+            FragmentStrictMode.onPolicyViolation(StrictFragment(), object : Violation() {})
+        } catch (thrown: Violation) {
+            violation = thrown
+        }
+        assertWithMessage("No exception thrown on policy violation").that(violation).isNotNull()
     }
 
     @Test

--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
@@ -3470,6 +3470,7 @@ public abstract class FragmentManager implements FragmentResultOwner {
 
     /** Returns the current policy for this FragmentManager. If no policy is set, returns null. */
     @Nullable
+    @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
     public FragmentStrictMode.Policy getStrictModePolicy() {
         return mStrictModePolicy;
     }
@@ -3481,6 +3482,7 @@ public abstract class FragmentManager implements FragmentResultOwner {
      *
      * @param policy the policy to put into place
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
     public void setStrictModePolicy(@Nullable FragmentStrictMode.Policy policy) {
         mStrictModePolicy = policy;
     }

--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
@@ -3477,8 +3477,9 @@ public abstract class FragmentManager implements FragmentResultOwner {
 
     /**
      * Sets the policy for what actions should be detected, as well as the penalty if such actions
-     * occur. This policy is specific to this FragmentManager and all children of it. Pass null to
-     * clear the policy for this FragmentManager.
+     * occur. The {@link Fragment#getChildFragmentManager() child FragmentManager} of all Fragments
+     * in this FragmentManager will also use this policy if one is not explicitly set. Pass null to
+     * clear the policy.
      *
      * @param policy the policy to put into place
      */

--- a/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java
@@ -63,6 +63,7 @@ import androidx.annotation.StringRes;
 import androidx.collection.ArraySet;
 import androidx.core.os.CancellationSignal;
 import androidx.fragment.R;
+import androidx.fragment.app.strictmode.FragmentStrictMode;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.LifecycleOwner;
@@ -517,6 +518,8 @@ public abstract class FragmentManager implements FragmentResultOwner {
     private ArrayList<StartEnterTransitionListener> mPostponedTransactions;
 
     private FragmentManagerViewModel mNonConfig;
+
+    private FragmentStrictMode.Policy mStrictModePolicy;
 
     private Runnable mExecCommit = new Runnable() {
         @Override
@@ -3463,6 +3466,23 @@ public abstract class FragmentManager implements FragmentResultOwner {
     @NonNull
     LayoutInflater.Factory2 getLayoutInflaterFactory() {
         return mLayoutInflaterFactory;
+    }
+
+    /** Returns the current policy for this FragmentManager. If no policy is set, returns null. */
+    @Nullable
+    public FragmentStrictMode.Policy getStrictModePolicy() {
+        return mStrictModePolicy;
+    }
+
+    /**
+     * Sets the policy for what actions should be detected, as well as the penalty if such actions
+     * occur. This policy is specific to this FragmentManager and all children of it. Pass null to
+     * clear the policy for this FragmentManager.
+     *
+     * @param policy the policy to put into place
+     */
+    public void setStrictModePolicy(@Nullable FragmentStrictMode.Policy policy) {
+        mStrictModePolicy = policy;
     }
 
     /**

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -65,7 +65,7 @@ public final class FragmentStrictMode {
     }
 
     /**
-     * {@link FragmentStrictMode} policy applied to a certain thread.
+     * {@link FragmentStrictMode} policy applied to a certain {@link FragmentManager} (or globally).
      *
      * <p>This policy can either be enabled globally using {@link #setDefaultPolicy} or for a
      * specific {@link FragmentManager} using {@link FragmentManager#setStrictModePolicy(Policy)}.

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -180,14 +180,13 @@ public final class FragmentStrictMode {
         return defaultPolicy;
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    @VisibleForTesting
     static void onPolicyViolation(@NonNull Fragment fragment, @NonNull Violation violation) {
-        onPolicyViolation(getNearestPolicy(fragment), violation);
-    }
+        Policy policy = getNearestPolicy(fragment);
+        String fragmentName = fragment.getClass().getName();
 
-    private static void onPolicyViolation(@NonNull Policy policy, @NonNull Violation violation) {
         if (policy.flags.contains(Flag.PENALTY_LOG)) {
-            Log.d(TAG, "FragmentStrictMode policy violation: ", violation);
+            Log.d(TAG, "Policy violation in " + fragmentName, violation);
         }
 
         if (policy.listener != null) {
@@ -195,7 +194,7 @@ public final class FragmentStrictMode {
         }
 
         if (policy.flags.contains(Flag.PENALTY_DEATH)) {
-            Log.e(TAG, "FragmentStrictMode policy violation with PENALTY_DEATH - shutting down.");
+            Log.e(TAG, "Policy violation with PENALTY_DEATH in " + fragmentName, violation);
             throw violation;
         }
     }

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -17,7 +17,6 @@
 package androidx.fragment.app.strictmode;
 
 import android.annotation.SuppressLint;
-import android.os.Process;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -117,9 +116,9 @@ public final class FragmentStrictMode {
             }
 
             /**
-             * Crash the whole process on violation. This penalty runs at the end of all enabled
-             * penalties so you'll still get to see logging or other violations before the process
-             * dies.
+             * Throws an exception on violation. This penalty runs at the end of all enabled
+             * penalties so you'll still get to see logging or other violations before the exception
+             * is thrown.
              */
             @NonNull
             @SuppressLint("BuilderSetStyle")
@@ -197,8 +196,7 @@ public final class FragmentStrictMode {
 
         if (policy.flags.contains(Flag.PENALTY_DEATH)) {
             Log.e(TAG, "FragmentStrictMode policy violation with PENALTY_DEATH - shutting down.");
-            Process.killProcess(Process.myPid());
-            System.exit(10);
+            throw violation;
         }
     }
 }

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -127,7 +127,10 @@ public final class FragmentStrictMode {
                 return this;
             }
 
-            /** Call #{@link OnViolationListener#onViolation} for every violation. */
+            /**
+             * Call #{@link OnViolationListener#onViolation} for every violation. The listener will
+             * be called on the thread which caused the violation.
+             */
             @NonNull
             @SuppressLint("BuilderSetStyle")
             public Builder penaltyListener(@NonNull OnViolationListener listener) {

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.fragment.app.strictmode;
+
+import android.annotation.SuppressLint;
+import android.os.Process;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * FragmentStrictMode is a tool which detects things you might be doing by accident and brings
+ * them to your attention so you can fix them. Basically, it's a version of
+ * {@link android.os.StrictMode} specifically for fragment-related issues.
+ *
+ * <p>You can decide what should happen when a violation is detected. For example, using {@link
+ * Policy.Builder#penaltyLog} you can watch the output of <code>adb logcat</code> while you
+ * use your application to see the violations as they happen.
+ */
+@SuppressLint("SyntheticAccessor")
+@RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
+public final class FragmentStrictMode {
+    private static final String TAG = "FragmentStrictMode";
+    private static Policy defaultPolicy = Policy.LAX;
+
+    private enum Flag {
+        PENALTY_LOG,
+        PENALTY_DEATH
+    }
+
+    private FragmentStrictMode() {}
+
+    /**
+     * When #{@link Policy.Builder#penaltyListener} is enabled, the listener is called when a
+     * violation occurs.
+     */
+    public interface OnViolationListener {
+
+        /** Called on a VM policy violation. */
+        void onViolation(@NonNull Violation violation);
+    }
+
+    /**
+     * {@link FragmentStrictMode} policy applied to a certain thread.
+     *
+     * <p>This policy can either be enabled globally using {@link #setDefaultPolicy} or for a
+     * specific {@link FragmentManager} using {@link FragmentManager#setStrictModePolicy(Policy)}.
+     * The current policy can be retrieved using {@link #getDefaultPolicy} and
+     * {@link FragmentManager#getStrictModePolicy} respectively.
+     *
+     * <p>Note that multiple penalties may be provided and they're run in order from least to most
+     * severe (logging before process death, for example). There's currently no mechanism to choose
+     * different penalties for different detected actions.
+     */
+    public static final class Policy {
+        private final Set<Flag> flags;
+        private final OnViolationListener listener;
+
+        /** The default, lax policy which doesn't catch anything. */
+        public static final Policy LAX = new Policy(new HashSet<Flag>(), null);
+
+        private Policy(@NonNull Set<Flag> flags, @Nullable OnViolationListener listener) {
+            this.flags = Collections.unmodifiableSet(flags);
+            this.listener = listener;
+        }
+
+        /**
+         * Creates {@link Policy} instances. Methods whose names start with {@code detect} specify
+         * what problems we should look for. Methods whose names start with {@code penalty} specify
+         * what we should do when we detect a problem.
+         *
+         * <p>You can call as many {@code detect} and {@code penalty} methods as you like. Currently
+         * order is insignificant: all penalties apply to all detected problems.
+         */
+        public static final class Builder {
+            private final Set<Flag> flags;
+            private OnViolationListener listener;
+
+            /** Create a Builder that detects nothing and has no violations. */
+            public Builder() {
+                flags = new HashSet<>();
+            }
+
+            /** Log detected violations to the system log. */
+            @NonNull
+            public Builder penaltyLog() {
+                flags.add(Flag.PENALTY_LOG);
+                return this;
+            }
+
+            /**
+             * Crash the whole process on violation. This penalty runs at the end of all enabled
+             * penalties so you'll still get to see logging or other violations before the process
+             * dies.
+             */
+            @NonNull
+            public Builder penaltyDeath() {
+                flags.add(Flag.PENALTY_DEATH);
+                return this;
+            }
+
+            /** Call #{@link OnViolationListener#onViolation} for every violation. */
+            @NonNull
+            public Builder penaltyListener(@NonNull OnViolationListener listener) {
+                this.listener = listener;
+                return this;
+            }
+
+            /**
+             * Construct the Policy instance.
+             *
+             * <p>Note: if no penalties are enabled before calling <code>build</code>, {@link
+             * #penaltyLog} is implicitly set.
+             */
+            @NonNull
+            public Policy build() {
+                if (listener == null && !flags.contains(Flag.PENALTY_DEATH)) {
+                    penaltyLog();
+                }
+                return new Policy(flags, listener);
+            }
+        }
+    }
+
+    /** Returns the current default policy. */
+     @NonNull
+    public static Policy getDefaultPolicy() {
+        return defaultPolicy;
+    }
+
+    /**
+     * Sets the policy for what actions should be detected, as well as the penalty if such actions
+     * occur.
+     *
+     * @param policy the policy to put into place
+     */
+    public static void setDefaultPolicy(@NonNull Policy policy) {
+        defaultPolicy = policy;
+    }
+
+    private static Policy getNearestPolicy(@Nullable Fragment fragment) {
+        while (fragment != null) {
+            if (fragment.isAdded()) {
+                FragmentManager fragmentManager = fragment.getParentFragmentManager();
+                if (fragmentManager.getStrictModePolicy() != null) {
+                    return fragmentManager.getStrictModePolicy();
+                }
+            }
+            fragment = fragment.getParentFragment();
+        }
+        return defaultPolicy;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    static void onPolicyViolation(@NonNull Fragment fragment, @NonNull Violation violation) {
+        onPolicyViolation(getNearestPolicy(fragment), violation);
+    }
+
+    private static void onPolicyViolation(@NonNull Policy policy, @NonNull Violation violation) {
+        if (policy.flags.contains(Flag.PENALTY_LOG)) {
+            Log.d(TAG, "FragmentStrictMode policy violation: ", violation);
+        }
+
+        if (policy.listener != null) {
+            policy.listener.onViolation(violation);
+        }
+
+        if (policy.flags.contains(Flag.PENALTY_DEATH)) {
+            Log.e(TAG, "FragmentStrictMode policy violation with PENALTY_DEATH - shutting down.");
+            Process.killProcess(Process.myPid());
+            System.exit(10);
+        }
+    }
+}

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/FragmentStrictMode.java
@@ -57,6 +57,7 @@ public final class FragmentStrictMode {
      * When #{@link Policy.Builder#penaltyListener} is enabled, the listener is called when a
      * violation occurs.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
     public interface OnViolationListener {
 
         /** Called on a VM policy violation. */
@@ -75,11 +76,13 @@ public final class FragmentStrictMode {
      * severe (logging before process death, for example). There's currently no mechanism to choose
      * different penalties for different detected actions.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
     public static final class Policy {
         private final Set<Flag> flags;
         private final OnViolationListener listener;
 
         /** The default, lax policy which doesn't catch anything. */
+        @NonNull
         public static final Policy LAX = new Policy(new HashSet<Flag>(), null);
 
         private Policy(@NonNull Set<Flag> flags, @Nullable OnViolationListener listener) {
@@ -95,6 +98,7 @@ public final class FragmentStrictMode {
          * <p>You can call as many {@code detect} and {@code penalty} methods as you like. Currently
          * order is insignificant: all penalties apply to all detected problems.
          */
+        @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
         public static final class Builder {
             private final Set<Flag> flags;
             private OnViolationListener listener;
@@ -106,6 +110,7 @@ public final class FragmentStrictMode {
 
             /** Log detected violations to the system log. */
             @NonNull
+            @SuppressLint("BuilderSetStyle")
             public Builder penaltyLog() {
                 flags.add(Flag.PENALTY_LOG);
                 return this;
@@ -117,6 +122,7 @@ public final class FragmentStrictMode {
              * dies.
              */
             @NonNull
+            @SuppressLint("BuilderSetStyle")
             public Builder penaltyDeath() {
                 flags.add(Flag.PENALTY_DEATH);
                 return this;
@@ -124,6 +130,7 @@ public final class FragmentStrictMode {
 
             /** Call #{@link OnViolationListener#onViolation} for every violation. */
             @NonNull
+            @SuppressLint("BuilderSetStyle")
             public Builder penaltyListener(@NonNull OnViolationListener listener) {
                 this.listener = listener;
                 return this;

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
@@ -20,5 +20,5 @@ import androidx.annotation.RestrictTo;
 
 /** Root class for all FragmentStrictMode violations. */
 @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
-public abstract class Violation extends Throwable {
+public abstract class Violation extends RuntimeException {
 }

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.fragment.app.strictmode;
+
+import androidx.annotation.RestrictTo;
+
+/** Root class for all FragmentStrictMode violations. */
+@RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
+public abstract class Violation extends Throwable {
+}

--- a/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/strictmode/Violation.java
@@ -19,6 +19,7 @@ package androidx.fragment.app.strictmode;
 import androidx.annotation.RestrictTo;
 
 /** Root class for all FragmentStrictMode violations. */
+@SuppressWarnings("ExceptionName")
 @RestrictTo(RestrictTo.Scope.LIBRARY) // TODO: Make API public as soon as we have a few checks
 public abstract class Violation extends RuntimeException {
 }


### PR DESCRIPTION
## Proposed Changes

  - Add initial infrastructure for `FragmentStrictMode`
  
Found this in the issue tracker and think it's a great idea. I tried to keep the first version as lean and as closely aligned to `StrictMode` as possible. I also plan on creating some follow-up PRs to add a few checks (see issue tracker), as soon as the infrastructure is discussed and somewhat agreed upon. For now the classes are restricted to the library, until we have the first few checks.

## Testing

Test: See `FragmentStrictModeTest`

## Issues Fixed

Fixes: 153737341
