### PR TITLE
Playground build fixes

### DIFF
--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
@@ -75,8 +75,8 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
         project.extra.set(AndroidXRootPlugin.PROJECT_OR_ARTIFACT_EXT_NAME, projectOrArtifactClosure)
         project.configurations.all { configuration ->
             configuration.resolutionStrategy.dependencySubstitution.all { substitution ->
-                substitution.replaceIfSnapshot()
                 substitution.allowAndroidxSnapshotReplacement()
+                substitution.replaceIfSnapshot()
             }
         }
     }
@@ -121,7 +121,7 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
     private fun DependencySubstitution.allowAndroidxSnapshotReplacement() {
         val requested = this.requested
         if (requested is ModuleComponentSelector && requested.group.startsWith("androidx") &&
-                requested.version.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
+            requested.version.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
         ) {
             useTarget("${requested.group}:${requested.module}:${requested.version}+")
         }

--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
@@ -76,6 +76,7 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
         project.configurations.all { configuration ->
             configuration.resolutionStrategy.dependencySubstitution.all { substitution ->
                 substitution.replaceIfSnapshot()
+                substitution.allowAndroidxSnapshotReplacement()
             }
         }
     }
@@ -114,6 +115,15 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
             }
 
             throw GradleException("projectOrArtifact cannot find/replace project $path")
+        }
+    }
+
+    private fun DependencySubstitution.allowAndroidxSnapshotReplacement() {
+        val requested = this.requested
+        if (requested is ModuleComponentSelector && requested.group.startsWith("androidx") &&
+                requested.version.matches(Regex("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
+        ) {
+            useTarget("${requested.group}:${requested.module}:${requested.version}+")
         }
     }
 

--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXPlugin.kt
@@ -411,7 +411,12 @@ class AndroidXPlugin : Plugin<Project> {
                     val target = dep.target
                     val version = target.version
                     // Enforce the ban on declaring dependencies with version ranges.
-                    if (version != null && Version.isDependencyRange(version)) {
+                    // Note: In playground, this ban is exempted to allow unresolvable prebuilts
+                    // to automatically get bumped to snapshot versions via version range
+                    // substituion.
+                    if (version != null && Version.isDependencyRange(version) &&
+                        project.rootProject.rootDir == project.getSupportRootFolder()
+                    ) {
                         throw IllegalArgumentException(
                             "Dependency ${dep.target} declares its version as " +
                                 "version range ${dep.target.version} however the use of " +

--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXPlugin.kt
@@ -413,7 +413,7 @@ class AndroidXPlugin : Plugin<Project> {
                     // Enforce the ban on declaring dependencies with version ranges.
                     // Note: In playground, this ban is exempted to allow unresolvable prebuilts
                     // to automatically get bumped to snapshot versions via version range
-                    // substituion.
+                    // substitution.
                     if (version != null && Version.isDependencyRange(version) &&
                         project.rootProject.rootDir == project.getSupportRootFolder()
                     ) {

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -47,6 +47,8 @@ dependencies {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel'
     }
     androidTestImplementation project(":internal-testutils-runtime"), {
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-runtime'
+        exclude group: 'androidx.lifecycle', module: 'lifecycle-livedata-core'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-savedstate'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel'
     }

--- a/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
+++ b/lifecycle/lifecycle-viewmodel-savedstate/build.gradle
@@ -35,11 +35,11 @@ android {
 dependencies {
     api("androidx.annotation:annotation:1.0.0")
     api("androidx.savedstate:savedstate:1.0.0")
-    api(project(":lifecycle:lifecycle-livedata-core"))
-    api(project(":lifecycle:lifecycle-viewmodel"))
+    api(projectOrArtifact(":lifecycle:lifecycle-livedata-core"))
+    api(projectOrArtifact(":lifecycle:lifecycle-viewmodel"))
 
-    androidTestImplementation project(":lifecycle:lifecycle-runtime")
-    androidTestImplementation project(":lifecycle:lifecycle-livedata-core")
+    androidTestImplementation projectOrArtifact(":lifecycle:lifecycle-runtime")
+    androidTestImplementation projectOrArtifact(":lifecycle:lifecycle-livedata-core")
     androidTestImplementation projectOrArtifact(":fragment:fragment"), {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-runtime'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-livedata-core'

--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -23,6 +23,7 @@ selectProjectsFromAndroidX({ name ->
     if (name.startsWith(":navigation")) return true
     if (name == ":annotation:annotation-sampled") return true
     if (name == ":compose:integration-tests:demos:common") return true
+    if (name == ":lifecycle:lifecycle-viewmodel-savedstate") return true
     if (name.startsWith(":internal-testutils-navigation")) return true
     if (name.startsWith(":internal-testutils-runtime")) return true
     if (name.startsWith(":internal-testutils-truth")) return true

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -28,7 +28,7 @@ kotlin.code.style=official
 androidx.enableDocumentation=false
 # Disable coverage
 androidx.coverageEnabled=false
-androidx.playground.snapshotBuildId=7095513
-androidx.playground.metalavaBuildId=7093240
+androidx.playground.snapshotBuildId=7109468
+androidx.playground.metalavaBuildId=7109364
 androidx.playground.dokkaBuildId=7019924
 androidx.studio.type=playground


### PR DESCRIPTION
Fixing project resolution in navigation playground.

Added a way to substitute unresolvable prebuilts with snapshots via version ranges

Test: GH Workflows