### PR TITLE
Fix compose layout document

### DIFF
--- a/compose/integration-tests/docs-snippets/src/main/java/androidx/compose/integration/docs/layout/Layout.kt
+++ b/compose/integration-tests/docs-snippets/src/main/java/androidx/compose/integration/docs/layout/Layout.kt
@@ -321,7 +321,7 @@ private object LayoutSnippet14 {
     ) {
         Layout(
             modifier = modifier,
-            children = content
+            content = content
         ) { measurables, constraints ->
             // measure and position children given constraints logic here
         }


### PR DESCRIPTION
## Proposed Changes

  - Layout component doesn't have `children` argument. But it has `content` argument.

```kt
@Composable
fun MyOwnColumn(
    modifier: Modifier = Modifier,
    content: @Composable() () -> Unit
) {
    Layout(
        modifier = modifier,
        children = content                              /* Here is wrong */
    ) { measurables, constraints ->
        // measure and position children given constraints logic here
    }
}
```

```kt
@Suppress("ComposableLambdaParameterPosition")
@Composable
/*inline*/ fun Layout(
    /*crossinline*/
    content: @Composable () -> Unit, //  HERE
    modifier: Modifier = Modifier,
    /*noinline*/
    measureBlock: MeasureBlock
) {
    val measureBlocks = remember(measureBlock) { MeasuringIntrinsicsMeasureBlocks(measureBlock) }
    Layout(content, measureBlocks, modifier)
}
```

## Testing

Test: Only fix document, no test.
