### PR TITLE
Remove compose dependency from playground common

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -22,6 +22,7 @@ selectProjectsFromAndroidX({ name ->
     if (name.startsWith(":activity")) return true
     if (name == ":annotation:annotation-sampled") return true
     if (name.startsWith(":internal-testutils-runtime")) return true
+    if (name == ":compose:internal-lint-checks") return true
     return false
 })
 

--- a/compose/compiler/settings.gradle
+++ b/compose/compiler/settings.gradle
@@ -21,6 +21,7 @@ setupPlayground(this, "../..")
 selectProjectsFromAndroidX({ name ->
     if (name.startsWith(":compose:compiler")) return true
     if (name == ":compose:androidview:androidview") return true
+    if (name == ":compose:internal-lint-checks") return true
     return false
 })
 

--- a/lifecycle/settings.gradle
+++ b/lifecycle/settings.gradle
@@ -24,6 +24,7 @@ selectProjectsFromAndroidX({ name ->
     if (name == ":annotation:annotation") return true
     if (name == ":internal-testutils-runtime") return true
     if (name == ":internal-testutils-truth") return true
+    if (name == ":compose:internal-lint-checks") return true
     return false
 })
 

--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -28,6 +28,7 @@ selectProjectsFromAndroidX({ name ->
     if (name.startsWith(":internal-testutils-navigation")) return true
     if (name.startsWith(":internal-testutils-runtime")) return true
     if (name.startsWith(":internal-testutils-truth")) return true
+    if (name == ":compose:internal-lint-checks") return true
     return false
 })
 

--- a/paging/settings.gradle
+++ b/paging/settings.gradle
@@ -24,6 +24,7 @@ selectProjectsFromAndroidX({ name ->
     if (name == ":annotation:annotation-sampled") return true
     if (name == ":internal-testutils-ktx") return true
     if (name == ":internal-testutils-paging") return true
+    if (name == ":compose:internal-lint-checks") return true
     return false
 })
 

--- a/playground-common/playground-include-settings.gradle
+++ b/playground-common/playground-include-settings.gradle
@@ -70,10 +70,6 @@ def setupPlayground(settings, String relativePathToRoot) {
             new File(supportRoot, "testutils/testutils-common"))
     settings.includeProject(":internal-testutils-gradle-plugin",
             new File(supportRoot, "testutils/testutils-gradle-plugin"))
-
-    // AndroidXUiPlugin dependencies
-    settings.includeProject(":compose:internal-lint-checks",
-            new File(supportRoot, "compose/internal-lint-checks"))
 }
 
 /**


### PR DESCRIPTION
This PR removes compose dependency from playgorund-common and moves it
to projects which need compose testing.

Bug: n/a
Test: ./gradlew tasks in all playground projects