### PR TITLE
Use stable version of android.inspection in workmanager-inspection

### DIFF
--- a/work/workmanager-inspection/build.gradle
+++ b/work/workmanager-inspection/build.gradle
@@ -30,7 +30,7 @@ plugins {
 dependencies {
     api("androidx.annotation:annotation:1.1.0")
     api(KOTLIN_STDLIB)
-    compileOnly(projectOrArtifact(":inspection:inspection"))
+    compileOnly("androidx.inspection:inspection:1.0.0")
     compileOnly("androidx.lifecycle:lifecycle-runtime:2.2.0")
     compileOnly(project(":work:work-runtime"))
     compileOnly("androidx.room:room-runtime:2.2.5")


### PR DESCRIPTION
Use stable version of android.inspection in workmanager-inspection

Test: NA