### PR TITLE
Adds KotlinPoet integration to Room Processing

### DIFF
--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/CompilationResultSubject.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/CompilationResultSubject.kt
@@ -427,7 +427,10 @@ internal class KotlinCompileTestingCompilationResult(
                         Source.loadJavaSource(sourceFile, qName)
                     }
                     sourceFile.name.endsWith(".kt") -> {
-                        Source.loadKotlinSource(sourceFile)
+                        val relativePath = sourceFile.absolutePath.substringAfter(
+                            srcRoot.absolutePath
+                        ).dropWhile { it == '/' }
+                        Source.loadKotlinSource(sourceFile, relativePath)
                     }
                     else -> null
                 }

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/Source.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/Source.kt
@@ -126,10 +126,11 @@ sealed class Source {
         }
 
         fun loadKotlinSource(
-            file: File
+            file: File,
+            relativePath: String
         ): Source {
             check(file.exists() && file.name.endsWith(".kt"))
-            return kotlin(file.absolutePath, file.readText())
+            return kotlin(relativePath, file.readText())
         }
 
         fun loadJavaSource(
@@ -142,13 +143,14 @@ sealed class Source {
 
         fun load(
             file: File,
-            qName: String
+            qName: String,
+            relativePath: String
         ): Source {
             check(file.exists()) {
                 "file does not exist: ${file.absolutePath}"
             }
             return when {
-                file.name.endsWith(".kt") -> loadKotlinSource(file)
+                file.name.endsWith(".kt") -> loadKotlinSource(file, relativePath)
                 file.name.endsWith(".java") -> loadJavaSource(file, qName)
                 else -> error("invalid file extension ${file.name}")
             }

--- a/room/compiler-processing/build.gradle
+++ b/room/compiler-processing/build.gradle
@@ -28,6 +28,7 @@ plugins {
 dependencies {
     api(KOTLIN_STDLIB)
     api(JAVAPOET)
+    api(KOTLINPOET)
     implementation("androidx.annotation:annotation:1.1.0")
     implementation(GUAVA)
     implementation(AUTO_COMMON)

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
@@ -17,12 +17,17 @@
 package androidx.room.compiler.processing
 
 import com.squareup.javapoet.JavaFile
+import com.squareup.kotlinpoet.FileSpec
 
 /**
  * Code generation interface for XProcessing.
  */
 interface XFiler {
     fun write(javaFile: JavaFile)
+
+    fun write(fileSpec: FileSpec)
 }
 
 fun JavaFile.writeTo(generator: XFiler) = generator.write(this)
+
+fun FileSpec.writeTo(generator: XFiler) = generator.write(this)

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
@@ -20,13 +20,19 @@ import androidx.room.compiler.processing.XFiler
 import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import javax.annotation.processing.Filer
+import javax.annotation.processing.ProcessingEnvironment
 
-internal class JavacFiler(val filer: Filer) : XFiler {
+internal class JavacFiler(val processingEnv: ProcessingEnvironment) : XFiler {
     override fun write(javaFile: JavaFile) {
-        javaFile.writeTo(filer)
+        javaFile.writeTo(processingEnv.filer)
     }
 
     override fun write(fileSpec: FileSpec) {
-        fileSpec.writeTo(filer)
+        require(processingEnv.options.containsKey("kapt.kotlin.generated")) {
+            val filePath = fileSpec.packageName.replace('.', '/')
+            "Could not generate kotlin file $filePath/${fileSpec.name}.kt. The " +
+                "annotation processing environment is not set to generate Kotlin files."
+        }
+        fileSpec.writeTo(processingEnv.filer)
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
@@ -19,7 +19,6 @@ package androidx.room.compiler.processing.javac
 import androidx.room.compiler.processing.XFiler
 import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
-import javax.annotation.processing.Filer
 import javax.annotation.processing.ProcessingEnvironment
 
 internal class JavacFiler(val processingEnv: ProcessingEnvironment) : XFiler {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
@@ -18,10 +18,15 @@ package androidx.room.compiler.processing.javac
 
 import androidx.room.compiler.processing.XFiler
 import com.squareup.javapoet.JavaFile
+import com.squareup.kotlinpoet.FileSpec
 import javax.annotation.processing.Filer
 
 internal class JavacFiler(val filer: Filer) : XFiler {
     override fun write(javaFile: JavaFile) {
         javaFile.writeTo(filer)
+    }
+
+    override fun write(fileSpec: FileSpec) {
+        fileSpec.writeTo(filer)
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -58,7 +58,7 @@ internal class JavacProcessingEnv(
         JavacProcessingEnvMessager(delegate)
     }
 
-    override val filer = JavacFiler(delegate.filer)
+    override val filer = JavacFiler(delegate)
 
     override val options: Map<String, String>
         get() = delegate.options

--- a/room/compiler/src/test/kotlin/androidx/room/testing/test_util.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/testing/test_util.kt
@@ -259,7 +259,7 @@ fun loadJavaCode(fileName: String, qName: String): JavaFileObject {
 
 fun loadTestSource(fileName: String, qName: String): Source {
     val contents = File("src/test/data/$fileName")
-    return Source.load(contents, qName)
+    return Source.load(contents, qName, fileName)
 }
 
 fun createVerifierFromEntitiesAndViews(invocation: TestInvocation): DatabaseVerifier {


### PR DESCRIPTION
## Proposed Changes

Adds `write()` method that accepts KotlinPoet's an instance of
`FileSpec`. Also adds KotlinPoet as an API dependency and an extension
function similar to that of JavaPoet.

Also verifies if processing backend is set for generating kotlin code
and fails for KotlinPoet if it isn't.

## Testing

Test: ./gradlew test connectedCheck without benchmarks

## Fixes
Fixes: [b/182195680](https://issuetracker.google.com/issues/182195680)