### PR TITLE
Adds element deferring for KSP to Room Processing

### DIFF
--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
@@ -19,6 +19,7 @@ package androidx.room.compiler.processing
 import androidx.room.compiler.processing.javac.JavacElement
 import androidx.room.compiler.processing.javac.JavacProcessingEnv
 import androidx.room.compiler.processing.ksp.KspProcessingEnv
+import androidx.room.compiler.processing.ksp.KspTypeElement
 import com.google.auto.common.BasicAnnotationProcessor
 import com.google.auto.common.MoreElements
 import com.google.common.collect.SetMultimap
@@ -69,20 +70,17 @@ interface XProcessingStep {
 
     fun executeInKsp(env: XProcessingEnv): List<KSAnnotated> {
         check(env is KspProcessingEnv)
-        val elementMap = mutableMapOf<XTypeElement, KSAnnotated>()
         val args = annotations().associateWith { annotation ->
             val elements = env.resolver.getSymbolsWithAnnotation(
                 annotation.java.canonicalName
             ).filterIsInstance<KSClassDeclaration>()
                 .map {
-                    val element = env.requireTypeElement(it.qualifiedName!!.asString())
-                    elementMap[element] = it
-                    element
+                    env.requireTypeElement(it.qualifiedName!!.asString())
                 }
             elements
         }
         return process(env, args)
-            .mapNotNull { elementMap[it] }
+            .map { (it as KspTypeElement).declaration }
     }
 }
 

--- a/room/compiler/src/main/kotlin/androidx/room/RoomKspProcessor.kt
+++ b/room/compiler/src/main/kotlin/androidx/room/RoomKspProcessor.kt
@@ -53,9 +53,8 @@ class RoomKspProcessor : SymbolProcessor {
             logger
         )
 
-        DatabaseProcessingStep().executeInKsp(
+        return DatabaseProcessingStep().executeInKsp(
             processingEnv
         )
-        return emptyList()
     }
 }


### PR DESCRIPTION
## Proposed Changes

Creates a map of `XTypeElement` to their originating `KSAnnotated` that can
be used to return elements deferred on `XProcessingStep` back to the KSP
`SymbolProcessor`.

## Testing

```
Test: ./gradlew \
    test connectedCheck \
    -x :room:room-benchmark:cC \
    -x :room:integration-tests:room-incremental-annotation-processing:test
```

## Issues Fixed

Fixes: [b/182822821](https://issuetracker.google.com/182822821)
