### PR TITLE
[Navigation] Fix deeplink domain parsing being case sensitive

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1076,7 +1076,7 @@ class NavDeepLinkTest {
             .that(matchArgs?.containsKey("path"))
             .isFalse()
     }
-    
+
     @Test
     fun deepLinkCaseSensitiveParams() {
         val deepLinkString = "$DEEP_LINK_EXACT_HTTP/?myParam={param}"

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1057,7 +1057,7 @@ class NavDeepLinkTest {
 
         val id = 2
         val matchArgs = deepLink.getMatchingArguments(
-            Uri.parse("${DEEP_LINK_EXACT_HTTPS.toUpperCase()}/users/${id}/posts"),
+            Uri.parse("${DEEP_LINK_EXACT_HTTPS.toUpperCase()}/users/$id/posts"),
             mapOf("id" to intArgument())
         )
         assertWithMessage("Args should not be null")
@@ -1075,9 +1075,10 @@ class NavDeepLinkTest {
 
         val id = 2
         val matchArgs = deepLink.getMatchingArguments(
-            Uri.parse(deepLinkArgument
-                .replace("{id}", id.toString())
-                .replace("users", "Users")
+            Uri.parse(
+                deepLinkArgument
+                    .replace("{id}", id.toString())
+                    .replace("users", "Users")
             ),
             mapOf("id" to intArgument())
         )
@@ -1098,8 +1099,10 @@ class NavDeepLinkTest {
         val deepLinkUpper = deepLinkString
             .replace("myParam", "MYPARAM")
             .replace("{param}", param.toString())
-        val matchArgs = deepLink.getMatchingArguments(Uri.parse(deepLinkUpper),
-            mapOf("param" to intArgument()))
+        val matchArgs = deepLink.getMatchingArguments(
+            Uri.parse(deepLinkUpper),
+            mapOf("param" to intArgument())
+        )
 
         assertWithMessage("Args should be not be null")
             .that(matchArgs)

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1049,4 +1049,51 @@ class NavDeepLinkTest {
             .that(matchArgs?.getInt("id"))
             .isEqualTo(id)
     }
+
+    @Test
+    fun deepLinkCaseInsensitiveDomain() {
+        val deepLinkString = DEEP_LINK_EXACT_HTTP
+        val deepLink = NavDeepLink(deepLinkString)
+
+        val deepLinkUpper = deepLinkString.toUpperCase()
+        assertThat(deepLink.matches(Uri.parse(deepLinkUpper)))
+    }
+
+    @Test
+    fun deepLinkCaseInsensitiveDomainRegexMatching() {
+        val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users?path=go/to/{path}"
+        val deepLink = NavDeepLink(deepLinkArgument)
+
+        val path = "directions"
+        val matchArgs = deepLink.getMatchingArguments(
+            Uri.parse("${DEEP_LINK_EXACT_HTTPS.toUpperCase()}/users?path=go/to/"),
+            mapOf("path" to stringArgument(path))
+        )
+        assertWithMessage("Args should not be null")
+            .that(matchArgs)
+            .isNotNull()
+        assertWithMessage("Args should not contain the path")
+            .that(matchArgs?.containsKey("path"))
+            .isFalse()
+    }
+    
+    @Test
+    fun deepLinkCaseSensitiveParams() {
+        val deepLinkString = "$DEEP_LINK_EXACT_HTTP/?myParam={param}"
+        val deepLink = NavDeepLink(deepLinkString)
+
+        val param = 2
+        val deepLinkUpper = deepLinkString
+            .replace("myParam", "MyParam")
+            .replace("{param}", param.toString())
+        val matchArgs = deepLink.getMatchingArguments(Uri.parse(deepLinkUpper),
+            mapOf("param" to intArgument()))
+
+        assertWithMessage("Args should be not be null")
+            .that(matchArgs)
+            .isNotNull()
+        assertWithMessage("Args bundle should be empty")
+            .that(matchArgs!!.isEmpty)
+            .isTrue()
+    }
 }

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1061,20 +1061,41 @@ class NavDeepLinkTest {
 
     @Test
     fun deepLinkCaseInsensitiveDomainRegexMatching() {
-        val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users?path=go/to/{path}"
+        val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users/{id}/posts"
         val deepLink = NavDeepLink(deepLinkArgument)
 
-        val path = "directions"
+        val id = 2
         val matchArgs = deepLink.getMatchingArguments(
-            Uri.parse("${DEEP_LINK_EXACT_HTTPS.toUpperCase()}/users?path=go/to/"),
-            mapOf("path" to stringArgument(path))
+            Uri.parse("${DEEP_LINK_EXACT_HTTPS.toUpperCase()}/users/${id}/posts"),
+            mapOf("id" to intArgument())
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
             .isNotNull()
-        assertWithMessage("Args should not contain the path")
-            .that(matchArgs?.containsKey("path"))
-            .isFalse()
+        assertWithMessage("Args should contain the id")
+            .that(matchArgs?.getInt("id"))
+            .isEqualTo(id)
+    }
+
+    @Test
+    fun deepLinkCaseInsensitiveArguments() {
+        val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users/{id}/posts"
+        val deepLink = NavDeepLink(deepLinkArgument)
+
+        val id = 2
+        val matchArgs = deepLink.getMatchingArguments(
+            Uri.parse(deepLinkArgument
+                .replace("{id}", id.toString())
+                .replace("users", "Users")
+            ),
+            mapOf("id" to intArgument())
+        )
+        assertWithMessage("Args should not be null")
+            .that(matchArgs)
+            .isNotNull()
+        assertWithMessage("Args should contain the id")
+            .that(matchArgs?.getInt("id"))
+            .isEqualTo(id)
     }
 
     @Test

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1051,16 +1051,7 @@ class NavDeepLinkTest {
     }
 
     @Test
-    fun deepLinkCaseInsensitiveDomain() {
-        val deepLinkString = DEEP_LINK_EXACT_HTTP
-        val deepLink = NavDeepLink(deepLinkString)
-
-        val deepLinkUpper = deepLinkString.toUpperCase()
-        assertThat(deepLink.matches(Uri.parse(deepLinkUpper)))
-    }
-
-    @Test
-    fun deepLinkCaseInsensitiveDomainRegexMatching() {
+    fun deepLinkCaseInsensitiveDomainWithPath() {
         val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users/{id}/posts"
         val deepLink = NavDeepLink(deepLinkArgument)
 
@@ -1078,7 +1069,7 @@ class NavDeepLinkTest {
     }
 
     @Test
-    fun deepLinkCaseInsensitiveArguments() {
+    fun deepLinkCaseInsensitivePath() {
         val deepLinkArgument = "$DEEP_LINK_EXACT_HTTPS/users/{id}/posts"
         val deepLink = NavDeepLink(deepLinkArgument)
 
@@ -1099,13 +1090,13 @@ class NavDeepLinkTest {
     }
 
     @Test
-    fun deepLinkCaseSensitiveParams() {
+    fun deepLinkCaseSensitiveQueryParams() {
         val deepLinkString = "$DEEP_LINK_EXACT_HTTP/?myParam={param}"
         val deepLink = NavDeepLink(deepLinkString)
 
         val param = 2
         val deepLinkUpper = deepLinkString
-            .replace("myParam", "MyParam")
+            .replace("myParam", "MYPARAM")
             .replace("{param}", param.toString())
         val matchArgs = deepLink.getMatchingArguments(Uri.parse(deepLinkUpper),
             mapOf("param" to intArgument()))
@@ -1114,7 +1105,7 @@ class NavDeepLinkTest {
             .that(matchArgs)
             .isNotNull()
         assertWithMessage("Args bundle should be empty")
-            .that(matchArgs!!.isEmpty)
+            .that(matchArgs?.isEmpty)
             .isTrue()
     }
 }

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -422,7 +422,7 @@ public class NavDeepLink internal constructor(
             // specifically escape any .* instances to ensure
             // they are still treated as wildcards in our final regex
             val finalRegex = uriRegex.toString().replace(".*", "\\E.*\\Q")
-            pattern = Pattern.compile(finalRegex)
+            pattern = Pattern.compile(finalRegex, Pattern.CASE_INSENSITIVE)
         }
         if (mimeType != null) {
             val mimeTypePattern = Pattern.compile("^[\\s\\S]+/[\\s\\S]+$")


### PR DESCRIPTION
## Proposed Changes

The current regex pattern matcher was doing a case sensitive check of the domain and arguments. Simply changing it to case insensitive seems to be all that's required to fix this bug. It is important that parameters are still case sensitive but this is still the case as parameter matching is done by the `Uri` code not the `NavDeepLink` code. I have written tests to cover these cases.

If it is deemed too risky to just run the pattern matcher with `CASE_INSENSITIVE` I believe the regex will have to be redesigned not to use `\Q\E`.

## Testing

- Tested using the sample project and deep linking via `adb shell am start -a android.intent.action.VIEW -d https://www.Iana.org/domains/second`
- Added new unit tests to the project for the different case insensitive and sensitive sections

Test: /gradlew test connectedCheck

## Issues Fixed
https://issuetracker.google.com/issues/153829033
Fixes: b/153829033