### PR TITLE
Replace jitterbit/get-changed-files with androidx/changed-files-action

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -41,11 +41,28 @@ jobs:
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
+      - name: "Compute actions/checkout arguments"
+        id: checkout-args
+        run: |
+          set -x
+
+          REF=${{ github.event.pull_request.head.ref }}
+          if [ -z "$REF" ]; then
+            REF=${{ github.event.ref }}
+          fi
+          echo "::set-output name=ref::$REF"
+
+          REPOSITORY=${{ github.event.pull_request.head.repo.full_name }}
+          if [ -z "$REPOSITORY" ]; then
+            REPOSITORY=${{ github.repository }}
+          fi
+          echo "::set-output name=repository::$REPOSITORY"
+
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ steps.checkout-args.outputs.ref }}
+          repository: ${{ steps.checkout-args.outputs.repository }}
           fetch-depth: 0 # Need full depth for changed-files-action
 
       - name: "Get changed files in push or pull_request"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -86,7 +86,7 @@ jobs:
         id: ktlint-file-args
         run: |
           set -x
-          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=${{ github.workspace }}/&|g'`
+          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=${{ github.workspace }}/&|g' | grep -v "*.txt"`
           echo "::set-output name=ktlint-file-args::$KTLINT_FILES"
 
       - name: "ktlint"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -69,7 +69,7 @@ jobs:
         id: changed-files
         # Temporary workaround for failing on force-push
         continue-on-error: true
-        uses: dlam/changed-files-action@main
+        uses: androidx/changed-files-action@main
 
       - name: Check invalid suppressions
         run: |

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -44,29 +44,32 @@ jobs:
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0 # Need full depth for changed-files-action
 
       - name: "Get changed files in push or pull_request"
         id: changed-files
         # Temporary workaround for failing on force-push
         continue-on-error: true
-        uses: jitterbit/get-changed-files@v1
+        uses: dlam/changed-files-action@main
 
       - name: Check invalid suppressions
         run: |
           set -x
-          ./development/checkInvalidSuppress.py -f ${{ steps.changed-files.outputs.added_modified }}
+          echo ${{ steps.changed-files.outputs.files }}
+          ./development/checkInvalidSuppress.py -f ${{ steps.changed-files.outputs.files }}
 
       - name: "Warn on missing updateApi"
         run: |
           set -x
-          ./development/apilint.py -f ${{ steps.changed-files.outputs.added_modified }}
+          ./development/apilint.py -f ${{ steps.changed-files.outputs.files }}
 
       - name: "Parse changed-files as ktlint args"
         id: ktlint-file-args
         run: |
           set -x
-          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.added_modified }}" | sed 's|[^ ]* *|--file=${{ github.workspace }}/&|g'`
+          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=${{ github.workspace }}/&|g'`
           echo "::set-output name=ktlint-file-args::$KTLINT_FILES"
 
       - name: "ktlint"


### PR DESCRIPTION
New action supports `pull_request_target` and `force pushes`.

Also fixed a bug with ktlint failing on .txt files by filtering them out.

Test: GH Actions on fork
