### PR TITLE
[Lifecycle] [Lint] fixes b/183696616: KtCallExpression is not always the first in the list

### DIFF
--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
@@ -33,7 +33,6 @@ import com.intellij.psi.PsiVariable
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
-import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.uast.UAnnotated
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UClass
@@ -101,7 +100,7 @@ class NonNullableMutableLiveDataDetector : Detector(), UastScanner {
                 // argument: `Boolean`
                 val expression = element.sourcePsi
                     ?.children
-                    ?.firstIsInstanceOrNull<KtCallExpression>()
+                    ?.firstOrNull { it is KtCallExpression } as? KtCallExpression
                 val argument = expression?.typeArguments?.singleOrNull()
                 return argument?.typeReference
             }

--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
@@ -33,6 +33,7 @@ import com.intellij.psi.PsiVariable
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 import org.jetbrains.uast.UAnnotated
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UClass
@@ -98,7 +99,9 @@ class NonNullableMutableLiveDataDetector : Detector(), UastScanner {
                 // Given the field `val liveDataField = MutableLiveData<Boolean>()`
                 // expression: `MutableLiveData<Boolean>()`
                 // argument: `Boolean`
-                val expression = element.sourcePsi?.children?.get(0) as? KtCallExpression
+                val expression = element.sourcePsi
+                    ?.children
+                    ?.firstIsInstanceOrNull<KtCallExpression>()
                 val argument = expression?.typeArguments?.singleOrNull()
                 return argument?.typeReference
             }

--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
@@ -582,6 +582,167 @@ Fix for src/com/example/MyClass1.kt line 16: Change `LiveData` type to nullable:
     }
 
     @Test
+    fun modifiersFieldTest() {
+        check(
+            kotlin(
+                """
+                package com.example
+
+                import androidx.lifecycle.LiveData
+                import androidx.lifecycle.MutableLiveData
+
+                class MyClass1 {
+                    internal val firstLiveDataField = MutableLiveData<Boolean>()
+                    protected val secondLiveDataField = MutableLiveData<Boolean?>()
+
+                    fun foo() {
+                        firstLiveDataField.value = false
+                        firstLiveDataField.value = null
+                        secondLiveDataField.value = null
+                        secondLiveDataField.value = false
+                    }
+                }
+            """
+            ).indented()
+        ).expect(
+            """
+src/com/example/MyClass1.kt:12: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+        firstLiveDataField.value = null
+                                   ~~~~
+1 errors, 0 warnings
+        """
+        ).expectFixDiffs(
+            """
+Fix for src/com/example/MyClass1.kt line 12: Change `LiveData` type to nullable:
+@@ -7 +7
+-     internal val firstLiveDataField = MutableLiveData<Boolean>()
++     internal val firstLiveDataField = MutableLiveData<Boolean?>()
+        """
+        )
+    }
+
+    @Test
+    fun implementationClassTest() {
+        check(
+            kotlin(
+                """
+                package com.example
+
+                import androidx.lifecycle.LiveData
+                import androidx.lifecycle.MutableLiveData
+
+                interface MyClass2 {
+                    val firstLiveDataField : LiveData<Boolean>
+                    val secondLiveDataField : LiveData<Boolean?>
+                    val thirdLiveDataField : LiveData<Boolean?>
+                    val fourLiveDataField : LiveData<List<Boolean>?>
+                    val fiveLiveDataField : LiveData<List<Boolean>?>
+                }
+
+                class MyClass1 : MyClass2 {
+                    override val firstLiveDataField = MutableLiveData<Boolean>()
+                    override val secondLiveDataField = MutableLiveData<Boolean?>()
+                    override val thirdLiveDataField = MutableLiveData<Boolean?>(null)
+                    override val fourLiveDataField = MutableLiveData<List<Boolean>?>(null)
+                    override val fiveLiveDataField : MutableLiveData<List<Boolean>?> = MutableLiveData(null)
+
+                    fun foo() {
+                        firstLiveDataField.value = false
+                        firstLiveDataField.value = null
+                        secondLiveDataField.value = null
+                        secondLiveDataField.value = false
+                        thirdLiveDataField.value = null
+                        thirdLiveDataField.value = false
+                        fourLiveDataField.value = null
+                        fourLiveDataField.value = emptyList()
+                        fiveLiveDataField.value = null
+                        fiveLiveDataField.value = emptyList()
+                    }
+                }
+            """
+            ).indented()
+        ).expect(
+            """
+src/com/example/MyClass2.kt:23: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+        firstLiveDataField.value = null
+                                   ~~~~
+1 errors, 0 warnings
+        """
+        ).expectFixDiffs(
+            """
+Fix for src/com/example/MyClass2.kt line 23: Change `LiveData` type to nullable:
+@@ -15 +15
+-     override val firstLiveDataField = MutableLiveData<Boolean>()
++     override val firstLiveDataField = MutableLiveData<Boolean?>()
+        """
+        )
+    }
+
+    @Test
+    fun extendClassTest() {
+        check(
+            kotlin(
+                """
+                package com.example
+
+                import androidx.lifecycle.LiveData
+                import androidx.lifecycle.MutableLiveData
+
+                abstract class MyClass2 {
+                    val firstLiveDataField : LiveData<Boolean>
+                    val secondLiveDataField : LiveData<Boolean?>
+                    val thirdLiveDataField : LiveData<Boolean?>
+                    val fourLiveDataField : LiveData<List<Boolean>?>
+                    val fiveLiveDataField : LiveData<List<Boolean>>
+                }
+
+                class MyClass1 : MyClass2() {
+                    override val firstLiveDataField = MutableLiveData<Boolean>()
+                    override val secondLiveDataField = MutableLiveData<Boolean?>()
+                    override val thirdLiveDataField = MutableLiveData<Boolean?>(null)
+                    override val fourLiveDataField = MutableLiveData<List<Boolean>?>(null)
+                    override val fiveLiveDataField = MutableLiveData<List<Boolean>>()
+
+                    fun foo() {
+                        firstLiveDataField.value = false
+                        firstLiveDataField.value = null
+                        secondLiveDataField.value = null
+                        secondLiveDataField.value = false
+                        thirdLiveDataField.value = null
+                        thirdLiveDataField.value = false
+                        fourLiveDataField.value = null
+                        fourLiveDataField.value = emptyList()
+                        fiveLiveDataField.value = null
+                        fiveLiveDataField.value = emptyList()
+                    }
+                }
+            """
+            ).indented()
+        ).expect(
+            """
+src/com/example/MyClass2.kt:23: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+        firstLiveDataField.value = null
+                                   ~~~~
+src/com/example/MyClass2.kt:30: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+        fiveLiveDataField.value = null
+                                  ~~~~
+2 errors, 0 warnings
+        """
+        ).expectFixDiffs(
+            """
+Fix for src/com/example/MyClass2.kt line 23: Change `LiveData` type to nullable:
+@@ -15 +15
+-     override val firstLiveDataField = MutableLiveData<Boolean>()
++     override val firstLiveDataField = MutableLiveData<Boolean?>()
+Fix for src/com/example/MyClass2.kt line 30: Change `LiveData` type to nullable:
+@@ -19 +19
+-     override val fiveLiveDataField = MutableLiveData<List<Boolean>>()
++     override val fiveLiveDataField = MutableLiveData<List<Boolean>?>()
+        """
+        )
+    }
+
+    @Test
     fun objectLiveData() {
         check(
             kotlin(


### PR DESCRIPTION
## Proposed Changes
KtCallExpression is not always the first in the list. In this case, it is KtModifierList.

## Testing

Test: ./gradlew test lint buildOnServer

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/183696616