### PR TITLE
[Navigation] Allow case-insensitive matches of Enum args in deep links

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavTypeTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavTypeTest.kt
@@ -48,6 +48,8 @@ class NavTypeTest {
         private val parcelable = ActivityInfo()
         private val parcelables = arrayOf(parcelable)
         private val en = Bitmap.Config.ALPHA_8
+        private val enString = "ALPHA_8"
+        private val enStringCasing = "alpha_8"
         private val serializable = Person()
         private val serializables = arrayOf(Bitmap.Config.ALPHA_8)
         private val parcelableNavType = NavType.ParcelableType(ActivityInfo::class.java)
@@ -241,5 +243,14 @@ class NavTypeTest {
 
         assertThat(NavType.ReferenceType.parseValue(referenceHex))
             .isEqualTo(reference)
+    }
+
+    @Test
+    fun parseEnumValue() {
+        assertThat(enumNavType.parseValue(enString))
+            .isEqualTo(en)
+
+        assertThat(enumNavType.parseValue(enStringCasing))
+            .isEqualTo(en)
     }
 }

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
@@ -757,7 +757,6 @@ public abstract class NavType<T> internal constructor(
                 }
                 if (enumConstant.name.equals(value, ignoreCase = true)) {
                     caseInsensitiveMatch = constant
-                    break
                 }
             }
             if (caseInsensitiveMatch != null) return caseInsensitiveMatch

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
@@ -749,18 +749,9 @@ public abstract class NavType<T> internal constructor(
          */
         @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         public override fun parseValue(value: String): D {
-            var caseInsensitiveMatch: D? = null
-            for (constant in type.enumConstants) {
-                val enumConstant = (constant as Enum<*>)
-                if (enumConstant.name == value) {
-                    return constant
-                }
-                if (enumConstant.name.equals(value, ignoreCase = true)) {
-                    caseInsensitiveMatch = constant
-                }
-            }
-            if (caseInsensitiveMatch != null) return caseInsensitiveMatch
-            throw IllegalArgumentException(
+            return type.enumConstants.firstOrNull { constant ->
+                constant.name.equals(value, ignoreCase = true)
+            } ?: throw IllegalArgumentException(
                 "Enum value $value not found for type ${type.name}."
             )
         }

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavType.kt
@@ -749,11 +749,18 @@ public abstract class NavType<T> internal constructor(
          */
         @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
         public override fun parseValue(value: String): D {
+            var caseInsensitiveMatch: D? = null
             for (constant in type.enumConstants) {
-                if ((constant as Enum<*>).name == value) {
+                val enumConstant = (constant as Enum<*>)
+                if (enumConstant.name == value) {
                     return constant
                 }
+                if (enumConstant.name.equals(value, ignoreCase = true)) {
+                    caseInsensitiveMatch = constant
+                    break
+                }
             }
+            if (caseInsensitiveMatch != null) return caseInsensitiveMatch
             throw IllegalArgumentException(
                 "Enum value $value not found for type ${type.name}."
             )


### PR DESCRIPTION
## Proposed Changes
 Deep Link arguments that are Enum types would only match and get parsed if the casing of the argument value was an exact match to the casing of the Enum value. Since enum values are typically all upper case, this required deep links to contain upper case values as well, meaning if you have an enum with a value of say `Bitmap.Config.ALPHA_8`, a deep link that has an argument of type `Bitmap.Config` will only match if the URL contains `/ALPHA_8` and will not match a url with `/alpha_8`. 

This PR updates the EnumType value parsing to include case-insensitive matching. It will first try to parse an enum value using a case-sensitive match, and if no match is found, it will then try to parse the enum value using a case-insensitive match. 

Given the following enum:
```
 enum class Colors {
   RED,
   BLUE,
   GREEN
}
```

And a destination with an Enum argument and deep link:
```
<argument
        android:name="destColor"
        app:argType="com.my.app.Colors"
        android:defaultValue="RED" />
  
<deepLink
        app:uri="https://myapp.com/{destColor}" />
```

This PR updates the EnumType parsing so that a url like `https://myapp.com/green` will be matched and the `destColor` will be set to `Colors.GREEN`

## Testing
- There were no existing tests for the EnumType.parseValue() method. 
-  I added a test in `NavTypeTest` to test `EnumType.parseValue()` asserting that both case-sensitive and case-insensitive values are matched.

Test: /gradlew test connnectedCheck

## Issues Fixed

https://issuetracker.google.com/issues/135857840
Fixes: b/135857840