### PR TITLE
[Navigation] Make deep link path arguments to not include slash

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
@@ -112,6 +112,26 @@ class NavDestinationAndroidTest {
     }
 
     @Test
+    fun matchDeepLinkBestMatchPathTail() {
+        val destination = NoOpNavigator().createDestination()
+
+        destination.addArgument("id", stringArgument())
+        destination.addDeepLink("www.example.com/users/{id}")
+        destination.addDeepLink("www.example.com/users/{id}/posts")
+
+        val match = destination.matchDeepLink(
+            Uri.parse("https://www.example.com/users/u43/posts")
+        )
+
+        assertWithMessage("Deep link should match")
+            .that(match)
+            .isNotNull()
+        assertWithMessage("Deep link should extract id argument correctly")
+            .that(match?.matchingArgs?.getString("id"))
+            .isEqualTo("u43")
+    }
+
+    @Test
     fun matchDeepLinkBestMimeType() {
         val destination = NoOpNavigator().createDestination()
 
@@ -173,6 +193,18 @@ class NavDestinationAndroidTest {
         val destination = NoOpNavigator().createDestination()
 
         val deepLink = Uri.parse("android-app://androidx.navigation.test/invalid")
+
+        assertWithMessage("Deep link should not match")
+            .that(destination.hasDeepLink(deepLink)).isFalse()
+    }
+
+    @Test
+    fun testIsValidDeepLinkInvalidLinkPathTail() {
+        val destination = NoOpNavigator().createDestination()
+        destination.addArgument("testString", stringArgument())
+        destination.addDeepLink("android-app://androidx.navigation.test/{testString}")
+
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/extra")
 
         assertWithMessage("Deep link should not match")
             .that(destination.hasDeepLink(deepLink)).isFalse()

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -79,7 +79,7 @@ public class NavDeepLink internal constructor(
             arguments.add(argName)
             // Use Pattern.quote() to treat the input string as a literal
             uriRegex.append(Pattern.quote(uri.substring(appendPos, matcher.start())))
-            uriRegex.append("(.+?)")
+            uriRegex.append("([^/]+?)")
             appendPos = matcher.end()
             exactDeepLink = false
         }


### PR DESCRIPTION
## Proposed Changes

Slash is used for URI path splitting. Arguments should not include more than one path section.
I purpose to replace `(.+?)` with `([^/]+?)` in resulting regexp.

## Testing

Added corresponing tests to `NavDestinationAndroidTest`

Test: ./gradlew test connectedCheck

## Issues Fixed

Fixes: [b/184072811](https://issuetracker.google.com/issues/184072811)