### PR TITLE
[Room][Compiler Processing] Support getting non type elements

### DIFF
--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
@@ -18,6 +18,7 @@ package androidx.room.compiler.processing.util
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
 import androidx.room.compiler.processing.XProcessingStep
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.runner.CompilationTestRunner
 import androidx.room.compiler.processing.util.runner.JavacCompilationTestRunner
 import androidx.room.compiler.processing.util.runner.KaptCompilationTestRunner
@@ -138,9 +139,13 @@ fun runProcessorTest(
         classpath = classpath
     ) { invocation ->
         val step = createProcessingStep()
-        val elements = step.annotations().associate {
-            it to invocation.roundEnv.getTypeElementsAnnotatedWith(it).toList()
-        }
+        val elements =
+            step.annotations()
+                .associateWith { annotation ->
+                    invocation.roundEnv.getElementsAnnotatedWith(annotation)
+                        .filterIsInstance<XTypeElement>()
+                        .toSet()
+                }
         step.process(
             env = invocation.processingEnv,
             elementsByAnnotation = elements

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
@@ -88,7 +88,7 @@ internal class JavacProcessingStepDelegate(
         val xEnv = JavacProcessingEnv(env)
         annotations().forEach { annotation ->
             val elements = elementsByAnnotation[annotation].mapNotNull { element ->
-                xEnv.wrapElement(element, annotationName = { annotation })
+                xEnv.wrapAnnotatedElement(element, annotation)
             }.toSet()
             converted[annotation] = elements
         }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XRoundEnv.kt
@@ -16,7 +16,6 @@
 
 package androidx.room.compiler.processing
 
-import androidx.annotation.VisibleForTesting
 import androidx.room.compiler.processing.javac.JavacProcessingEnv
 import androidx.room.compiler.processing.javac.JavacRoundEnv
 import androidx.room.compiler.processing.ksp.KspProcessingEnv
@@ -29,23 +28,11 @@ import kotlin.reflect.KClass
  *
  * @see javax.annotation.processing.RoundEnvironment
  */
-@VisibleForTesting
 interface XRoundEnv {
     /**
      * The root elements in the round.
      */
     val rootElements: Set<XElement>
-
-    /**
-     * Returns the set of [XTypeElement]s that are annotated with the given [annotationQualifiedName].
-     *
-     * Note, Elements that are not Type elements (such as functions) are ignored by this.
-     *
-     * @see getElementsAnnotatedWith
-     */
-    fun getTypeElementsAnnotatedWith(annotationQualifiedName: String): Set<XTypeElement>
-
-    fun getTypeElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XTypeElement>
 
     /**
      * Returns the set of [XElement]s that are annotated with the given annotation [klass].

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XRoundEnv.kt
@@ -22,6 +22,7 @@ import androidx.room.compiler.processing.javac.JavacRoundEnv
 import androidx.room.compiler.processing.ksp.KspProcessingEnv
 import androidx.room.compiler.processing.ksp.KspRoundEnv
 import javax.annotation.processing.RoundEnvironment
+import kotlin.reflect.KClass
 
 /**
  * Representation of an annotation processing round.
@@ -36,9 +37,22 @@ interface XRoundEnv {
     val rootElements: Set<XElement>
 
     /**
-     * Returns the set of [XElement]s that are annotated with the given [annotationQualifiedName].
+     * Returns the set of [XTypeElement]s that are annotated with the given [annotationQualifiedName].
+     *
+     * Note, Elements that are not Type elements (such as functions) are ignored by this.
+     *
+     * @see getElementsAnnotatedWith
      */
     fun getTypeElementsAnnotatedWith(annotationQualifiedName: String): Set<XTypeElement>
+
+    fun getTypeElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XTypeElement>
+
+    /**
+     * Returns the set of [XElement]s that are annotated with the given annotation [klass].
+     */
+    fun getElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XElement>
+
+    fun getElementsAnnotatedWith(annotationQualifiedName: String): Set<XElement>
 
     companion object {
         /**

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -16,6 +16,7 @@
 
 package androidx.room.compiler.processing.javac
 
+import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XMessager
 import androidx.room.compiler.processing.XNullability
 import androidx.room.compiler.processing.XProcessingEnv
@@ -26,8 +27,10 @@ import com.google.auto.common.GeneratedAnnotations
 import com.google.auto.common.MoreTypes
 import java.util.Locale
 import javax.annotation.processing.ProcessingEnvironment
+import javax.lang.model.element.Element
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.PackageElement
 import javax.lang.model.element.TypeElement
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeKind
@@ -183,6 +186,31 @@ internal class JavacProcessingEnv(
                     )
                 }
         } as T
+    }
+
+    internal inline fun wrapElement(
+        element: Element,
+        annotationName: () -> String
+    ): XElement {
+
+        return when (element) {
+            is VariableElement -> {
+                wrapVariableElement(element)
+            }
+            is TypeElement -> {
+                wrapTypeElement(element)
+            }
+            is ExecutableElement -> {
+                wrapExecutableElement(element)
+            }
+            is PackageElement -> {
+                error(
+                    "Cannot get elements with annotation ${annotationName()}. Package " +
+                        "elements are not supported by KSP."
+                )
+            }
+            else -> error("Unsupported element $element with annotation ${annotationName()}")
+        }
     }
 
     // TODO: Add a cache layer

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -188,11 +188,10 @@ internal class JavacProcessingEnv(
         } as T
     }
 
-    internal inline fun wrapElement(
+    internal fun wrapAnnotatedElement(
         element: Element,
-        annotationName: () -> String
+        annotationName: String
     ): XElement {
-
         return when (element) {
             is VariableElement -> {
                 wrapVariableElement(element)
@@ -205,11 +204,11 @@ internal class JavacProcessingEnv(
             }
             is PackageElement -> {
                 error(
-                    "Cannot get elements with annotation ${annotationName()}. Package " +
+                    "Cannot get elements with annotation ${annotationName}. Package " +
                         "elements are not supported by XProcessing."
                 )
             }
-            else -> error("Unsupported element $element with annotation ${annotationName()}")
+            else -> error("Unsupported element $element with annotation $annotationName")
         }
     }
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -206,7 +206,7 @@ internal class JavacProcessingEnv(
             is PackageElement -> {
                 error(
                     "Cannot get elements with annotation ${annotationName()}. Package " +
-                        "elements are not supported by KSP."
+                        "elements are not supported by XProcessing."
                 )
             }
             else -> error("Unsupported element $element with annotation ${annotationName()}")
@@ -241,7 +241,7 @@ internal class JavacProcessingEnv(
                 val executableElement = wrapExecutableElement(enclosingElement)
 
                 executableElement.parameters.find { param ->
-                    param.element == element
+                    param.element === element
                 } ?: error("Unable to create variable element for $element")
             }
             is TypeElement -> {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -204,7 +204,7 @@ internal class JavacProcessingEnv(
             }
             is PackageElement -> {
                 error(
-                    "Cannot get elements with annotation ${annotationName}. Package " +
+                    "Cannot get elements with annotation $annotationName. Package " +
                         "elements are not supported by XProcessing."
                 )
             }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -213,7 +213,6 @@ internal class JavacProcessingEnv(
         }
     }
 
-    // TODO: Add a cache layer
     fun wrapExecutableElement(element: ExecutableElement): JavacExecutableElement {
         val enclosingType = element.requireEnclosingType(this)
 
@@ -236,7 +235,6 @@ internal class JavacProcessingEnv(
         }
     }
 
-    // TODO: Add a cache layer
     fun wrapVariableElement(element: VariableElement): JavacVariableElement {
         return when (val enclosingElement = element.enclosingElement) {
             is ExecutableElement -> {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacRoundEnv.kt
@@ -37,7 +37,7 @@ internal class JavacRoundEnv(
 
     override fun getElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XElement> {
         val elements = delegate.getElementsAnnotatedWith(klass.java)
-        return wrapElements(elements, annotationName = { klass.java.name })
+        return wrapElements(elements, annotationName = { klass.java.canonicalName })
     }
 
     override fun getElementsAnnotatedWith(annotationQualifiedName: String): Set<XElement> {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacRoundEnv.kt
@@ -37,7 +37,7 @@ internal class JavacRoundEnv(
 
     override fun getElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XElement> {
         val elements = delegate.getElementsAnnotatedWith(klass.java)
-        return wrapElements(elements, annotationName = { klass.java.canonicalName })
+        return wrapAnnotatedElements(elements, klass.java.canonicalName)
     }
 
     override fun getElementsAnnotatedWith(annotationQualifiedName: String): Set<XElement> {
@@ -46,13 +46,13 @@ internal class JavacRoundEnv(
 
         val elements = delegate.getElementsAnnotatedWith(element)
 
-        return wrapElements(elements, annotationName = { annotationQualifiedName })
+        return wrapAnnotatedElements(elements, annotationQualifiedName)
     }
 
-    private inline fun wrapElements(
+    private fun wrapAnnotatedElements(
         elements: Set<Element>,
-        annotationName: () -> String
+        annotationName: String
     ): Set<XElement> {
-        return elements.map { env.wrapElement(it, annotationName) }.toSet()
+        return elements.map { env.wrapAnnotatedElement(it, annotationName) }.toSet()
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspExecutableElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspExecutableElement.kt
@@ -22,6 +22,7 @@ import androidx.room.compiler.processing.XExecutableParameterElement
 import androidx.room.compiler.processing.XHasModifiers
 import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.ksp.KspAnnotated.UseSiteFilter.Companion.NO_USE_SITE
+import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 
@@ -66,5 +67,29 @@ internal abstract class KspExecutableElement(
             declaration.parameters.any {
                 it.isVararg
             }
+    }
+
+    companion object {
+        fun create(
+            env: KspProcessingEnv,
+            declaration: KSFunctionDeclaration
+        ): KspExecutableElement {
+            return when {
+                declaration.isConstructor() -> {
+                    KspConstructorElement(
+                        env = env,
+                        containing = declaration.requireEnclosingTypeElement(env),
+                        declaration = declaration
+                    )
+                }
+                else -> {
+                    KspMethodElement.create(
+                        env = env,
+                        containing = declaration.requireEnclosingTypeElement(env),
+                        declaration = declaration
+                    )
+                }
+            }
+        }
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspExecutableElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspExecutableElement.kt
@@ -74,18 +74,25 @@ internal abstract class KspExecutableElement(
             env: KspProcessingEnv,
             declaration: KSFunctionDeclaration
         ): KspExecutableElement {
+            val enclosingType = declaration.findEnclosingTypeElement(env)
+
+            checkNotNull(enclosingType) {
+                "XProcessing does not currently support annotations on top level " +
+                    "functions with KSP. Cannot process $declaration."
+            }
+
             return when {
                 declaration.isConstructor() -> {
                     KspConstructorElement(
                         env = env,
-                        containing = declaration.requireEnclosingTypeElement(env),
+                        containing = enclosingType,
                         declaration = declaration
                     )
                 }
                 else -> {
                     KspMethodElement.create(
                         env = env,
-                        containing = declaration.requireEnclosingTypeElement(env),
+                        containing = enclosingType,
                         declaration = declaration
                     )
                 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFieldElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFieldElement.kt
@@ -69,4 +69,17 @@ internal class KspFieldElement(
         declaration = declaration,
         containing = newContaining
     )
+
+    companion object {
+        fun create(
+            env: KspProcessingEnv,
+            declaration: KSPropertyDeclaration
+        ): KspFieldElement {
+            return KspFieldElement(
+                env = env,
+                declaration = declaration,
+                containing = declaration.requireEnclosingTypeElement(env)
+            )
+        }
+    }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRoundEnv.kt
@@ -16,10 +16,8 @@
 
 package androidx.room.compiler.processing.ksp
 
-import androidx.annotation.VisibleForTesting
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XRoundEnv
-import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
@@ -27,27 +25,11 @@ import com.google.devtools.ksp.symbol.KSPropertyAccessor
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import kotlin.reflect.KClass
 
-@VisibleForTesting
 internal class KspRoundEnv(
     private val env: KspProcessingEnv
 ) : XRoundEnv {
     override val rootElements: Set<XElement>
         get() = TODO("not supported")
-
-    override fun getTypeElementsAnnotatedWith(annotationQualifiedName: String): Set<XTypeElement> {
-        return env.resolver.getSymbolsWithAnnotation(
-            annotationQualifiedName
-        ).filterIsInstance<KSClassDeclaration>()
-            .map {
-                env.wrapClassDeclaration(it)
-            }.toSet()
-    }
-
-    override fun getTypeElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XTypeElement> {
-        return getTypeElementsAnnotatedWith(
-            annotationQualifiedName = klass.qualifiedName ?: error("No qualified name for $klass")
-        )
-    }
 
     override fun getElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XElement> {
         return getElementsAnnotatedWith(

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRoundEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspRoundEnv.kt
@@ -20,7 +20,12 @@ import androidx.annotation.VisibleForTesting
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XRoundEnv
 import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyAccessor
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import kotlin.reflect.KClass
 
 @VisibleForTesting
 internal class KspRoundEnv(
@@ -35,6 +40,39 @@ internal class KspRoundEnv(
         ).filterIsInstance<KSClassDeclaration>()
             .map {
                 env.wrapClassDeclaration(it)
+            }.toSet()
+    }
+
+    override fun getTypeElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XTypeElement> {
+        return getTypeElementsAnnotatedWith(
+            annotationQualifiedName = klass.qualifiedName ?: error("No qualified name for $klass")
+        )
+    }
+
+    override fun getElementsAnnotatedWith(klass: KClass<out Annotation>): Set<XElement> {
+        return getElementsAnnotatedWith(
+            annotationQualifiedName = klass.qualifiedName ?: error("No qualified name for $klass")
+        )
+    }
+
+    override fun getElementsAnnotatedWith(annotationQualifiedName: String): Set<XElement> {
+        return env.resolver.getSymbolsWithAnnotation(annotationQualifiedName)
+            .map { symbol ->
+                when (symbol) {
+                    is KSPropertyDeclaration -> {
+                        KspFieldElement.create(env, symbol)
+                    }
+                    is KSClassDeclaration -> {
+                        KspTypeElement.create(env, symbol)
+                    }
+                    is KSFunctionDeclaration -> {
+                        KspExecutableElement.create(env, symbol)
+                    }
+                    is KSPropertyAccessor -> {
+                        KspSyntheticPropertyMethodElement.create(env, symbol)
+                    }
+                    else -> error("Unsupported $symbol with annotation $annotationQualifiedName")
+                }
             }.toSet()
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/synthetic/KspSyntheticPropertyMethodElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/synthetic/KspSyntheticPropertyMethodElement.kt
@@ -32,8 +32,8 @@ import androidx.room.compiler.processing.ksp.KspFieldElement
 import androidx.room.compiler.processing.ksp.KspHasModifiers
 import androidx.room.compiler.processing.ksp.KspProcessingEnv
 import androidx.room.compiler.processing.ksp.KspTypeElement
+import androidx.room.compiler.processing.ksp.findEnclosingTypeElement
 import androidx.room.compiler.processing.ksp.overrides
-import androidx.room.compiler.processing.ksp.requireEnclosingTypeElement
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.symbol.KSPropertyAccessor
 import com.google.devtools.ksp.symbol.KSPropertyGetter
@@ -248,10 +248,17 @@ internal sealed class KspSyntheticPropertyMethodElement(
             env: KspProcessingEnv,
             propertyAccessor: KSPropertyAccessor
         ): KspSyntheticPropertyMethodElement {
+            val enclosingType = propertyAccessor.receiver.findEnclosingTypeElement(env)
+
+            checkNotNull(enclosingType) {
+                "XProcessing does not currently support annotations on top level " +
+                    "properties with KSP. Cannot process $propertyAccessor."
+            }
+
             val field = KspFieldElement(
                 env,
                 propertyAccessor.receiver,
-                propertyAccessor.receiver.requireEnclosingTypeElement(env)
+                enclosingType
             )
 
             return when (propertyAccessor) {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/synthetic/KspSyntheticPropertyMethodElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/synthetic/KspSyntheticPropertyMethodElement.kt
@@ -33,8 +33,11 @@ import androidx.room.compiler.processing.ksp.KspHasModifiers
 import androidx.room.compiler.processing.ksp.KspProcessingEnv
 import androidx.room.compiler.processing.ksp.KspTypeElement
 import androidx.room.compiler.processing.ksp.overrides
+import androidx.room.compiler.processing.ksp.requireEnclosingTypeElement
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.symbol.KSPropertyAccessor
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSPropertySetter
 import java.util.Locale
 
 /**
@@ -235,6 +238,30 @@ internal sealed class KspSyntheticPropertyMethodElement(
                 } else {
                     "set${propName.capitalize(Locale.US)}"
                 }
+            }
+        }
+    }
+
+    companion object {
+
+        fun create(
+            env: KspProcessingEnv,
+            propertyAccessor: KSPropertyAccessor
+        ): KspSyntheticPropertyMethodElement {
+            val field = KspFieldElement(
+                env,
+                propertyAccessor.receiver,
+                propertyAccessor.receiver.requireEnclosingTypeElement(env)
+            )
+
+            return when (propertyAccessor) {
+                is KSPropertyGetter -> {
+                    Getter(env, field)
+                }
+                is KSPropertySetter -> {
+                    Setter(env, field)
+                }
+                else -> error("Unsupported property accessor $propertyAccessor")
             }
         }
     }

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/JavacTestProcessorTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/JavacTestProcessorTest.kt
@@ -38,10 +38,8 @@ class JavacTestProcessorTest {
             import androidx.room.compiler.processing.testcode.OtherAnnotation;
             @OtherAnnotation(value="xx")
             class Baz {
-            
               @OtherAnnotation(value="xx")
               int myField = 0;
-              
               @OtherAnnotation(value="xx")
               void myFunction() { }
             }

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/JavacTestProcessorTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/JavacTestProcessorTest.kt
@@ -28,38 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.reflect.KClass
 
 class JavacTestProcessorTest {
-    @Test
-    fun testGetTypeAnnotation() {
-        val source = Source.java(
-            "foo.bar.Baz",
-            """
-            package foo.bar;
-            import androidx.room.compiler.processing.testcode.OtherAnnotation;
-            @OtherAnnotation(value="xx")
-            class Baz {
-            }
-            """.trimIndent()
-        )
-        testProcessor(listOf(source), listOf(OtherAnnotation::class)) { roundEnv ->
-            val annotatedElements = roundEnv.getTypeElementsAnnotatedWith(
-                OtherAnnotation::class.qualifiedName!!
-            )
-            val targetElement = xProcessingEnv.requireTypeElement("foo.bar.Baz")
-            assertThat(
-                annotatedElements
-            ).apply {
-                containsExactly(targetElement)
-
-                val elementsByAnnotationClass = roundEnv.getTypeElementsAnnotatedWith(
-                    OtherAnnotation::class
-                )
-                containsExactlyElementsIn(elementsByAnnotationClass)
-            }
-        }
-    }
 
     @Test
-    fun testGetAllAnnotations() {
+    fun getElementsAnnotatedWith() {
         val source = Source.java(
             "foo.bar.Baz",
             """

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
@@ -54,14 +54,18 @@ class XProcessingStepTest {
         val processingStep = object : XProcessingStep {
             override fun process(
                 env: XProcessingEnv,
-                elementsByAnnotation: Map<String, List<XTypeElement>>
+                elementsByAnnotation: Map<String, Set<XElement>>
             ): Set<XTypeElement> {
-                elementsByAnnotation[OtherAnnotation::class.qualifiedName]?.forEach {
-                    annotatedElements[OtherAnnotation::class] = it.qualifiedName
-                }
-                elementsByAnnotation[MainAnnotation::class.qualifiedName]?.forEach {
-                    annotatedElements[MainAnnotation::class] = it.qualifiedName
-                }
+                elementsByAnnotation[OtherAnnotation::class.qualifiedName]
+                    ?.filterIsInstance<XTypeElement>()
+                    ?.forEach {
+                        annotatedElements[OtherAnnotation::class] = it.qualifiedName
+                    }
+                elementsByAnnotation[MainAnnotation::class.qualifiedName]
+                    ?.filterIsInstance<XTypeElement>()
+                    ?.forEach {
+                        annotatedElements[MainAnnotation::class] = it.qualifiedName
+                    }
                 return emptySet()
             }
 
@@ -126,11 +130,13 @@ class XProcessingStepTest {
         val processingStep = object : XProcessingStep {
             override fun process(
                 env: XProcessingEnv,
-                elementsByAnnotation: Map<String, List<XTypeElement>>
+                elementsByAnnotation: Map<String, Set<XElement>>
             ): Set<XTypeElement> {
                 // for each element annotated with Main annotation, create a class with Other
                 // annotation to trigger another round
-                elementsByAnnotation[MainAnnotation::class.qualifiedName]?.forEach {
+                elementsByAnnotation[MainAnnotation::class.qualifiedName]
+                    ?.filterIsInstance<XTypeElement>()
+                    ?.forEach {
                     val className = ClassName.get(it.packageName, "${it.name}_Impl")
                     val spec = TypeSpec.classBuilder(className)
                         .addAnnotation(
@@ -143,7 +149,9 @@ class XProcessingStepTest {
                         .build()
                         .writeTo(env.filer)
                 }
-                elementsByAnnotation[OtherAnnotation::class.qualifiedName]?.forEach {
+                elementsByAnnotation[OtherAnnotation::class.qualifiedName]
+                    ?.filterIsInstance<XTypeElement>()
+                    ?.forEach {
                     otherAnnotatedElements.add(it.type.typeName)
                 }
                 return emptySet()
@@ -204,14 +212,16 @@ class XProcessingStepTest {
             var roundCounter = 0
             override fun process(
                 env: XProcessingEnv,
-                elementsByAnnotation: Map<String, List<XTypeElement>>
+                elementsByAnnotation: Map<String, Set<XElement>>
             ): Set<XTypeElement> {
                 elementPerRound[roundCounter++] = listOf(
                     env.requireTypeElement("foo.bar.Main"),
                     env.requireTypeElement("foo.bar.Main")
                 )
                 // trigger another round
-                elementsByAnnotation[MainAnnotation::class.qualifiedName]?.forEach {
+                elementsByAnnotation[MainAnnotation::class.qualifiedName]
+                    ?.filterIsInstance<XTypeElement>()
+                    ?.forEach {
                     val className = ClassName.get(it.packageName, "${it.name}_Impl")
                     val spec = TypeSpec.classBuilder(className)
                         .addAnnotation(
@@ -287,8 +297,8 @@ class XProcessingStepTest {
         val processingStep = object : XProcessingStep {
             override fun process(
                 env: XProcessingEnv,
-                elementsByAnnotation: Map<String, List<XTypeElement>>
-            ): Set<XTypeElement> {
+                elementsByAnnotation: Map<String, Set<XElement>>
+            ): Set<XElement> {
                 return elementsByAnnotation.values
                     .flatten()
                     .toSet()

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
@@ -137,23 +137,23 @@ class XProcessingStepTest {
                 elementsByAnnotation[MainAnnotation::class.qualifiedName]
                     ?.filterIsInstance<XTypeElement>()
                     ?.forEach {
-                    val className = ClassName.get(it.packageName, "${it.name}_Impl")
-                    val spec = TypeSpec.classBuilder(className)
-                        .addAnnotation(
-                            AnnotationSpec.builder(OtherAnnotation::class.java).apply {
-                                addMember("value", "\"foo\"")
-                            }.build()
-                        )
-                        .build()
-                    JavaFile.builder(className.packageName(), spec)
-                        .build()
-                        .writeTo(env.filer)
-                }
+                        val className = ClassName.get(it.packageName, "${it.name}_Impl")
+                        val spec = TypeSpec.classBuilder(className)
+                            .addAnnotation(
+                                AnnotationSpec.builder(OtherAnnotation::class.java).apply {
+                                    addMember("value", "\"foo\"")
+                                }.build()
+                            )
+                            .build()
+                        JavaFile.builder(className.packageName(), spec)
+                            .build()
+                            .writeTo(env.filer)
+                    }
                 elementsByAnnotation[OtherAnnotation::class.qualifiedName]
                     ?.filterIsInstance<XTypeElement>()
                     ?.forEach {
-                    otherAnnotatedElements.add(it.type.typeName)
-                }
+                        otherAnnotatedElements.add(it.type.typeName)
+                    }
                 return emptySet()
             }
 
@@ -222,18 +222,18 @@ class XProcessingStepTest {
                 elementsByAnnotation[MainAnnotation::class.qualifiedName]
                     ?.filterIsInstance<XTypeElement>()
                     ?.forEach {
-                    val className = ClassName.get(it.packageName, "${it.name}_Impl")
-                    val spec = TypeSpec.classBuilder(className)
-                        .addAnnotation(
-                            AnnotationSpec.builder(OtherAnnotation::class.java).apply {
-                                addMember("value", "\"foo\"")
-                            }.build()
-                        )
-                        .build()
-                    JavaFile.builder(className.packageName(), spec)
-                        .build()
-                        .writeTo(env.filer)
-                }
+                        val className = ClassName.get(it.packageName, "${it.name}_Impl")
+                        val spec = TypeSpec.classBuilder(className)
+                            .addAnnotation(
+                                AnnotationSpec.builder(OtherAnnotation::class.java).apply {
+                                    addMember("value", "\"foo\"")
+                                }.build()
+                            )
+                            .build()
+                        JavaFile.builder(className.packageName(), spec)
+                            .build()
+                            .writeTo(env.filer)
+                    }
                 return emptySet()
             }
 

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import androidx.room.compiler.processing.testcode.OtherAnnotation
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.getDeclaredMethod
+import androidx.room.compiler.processing.util.getField
+import androidx.room.compiler.processing.util.getMethod
+import androidx.room.compiler.processing.util.runProcessorTest
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class XRoundEnvTest {
+
+    @Test
+    fun getAnnotatedElements() {
+        val source = Source.kotlin(
+            "Baz.kt",
+            """
+            import androidx.room.compiler.processing.testcode.OtherAnnotation;
+            @OtherAnnotation(value="xx")
+            class Baz {
+                @OtherAnnotation(value="xx")
+                var myProperty: Int = 0
+                
+                @OtherAnnotation(value="xx")
+                fun myFunction() { }
+            }
+            """.trimIndent()
+        )
+
+        runProcessorTest(listOf(source)) { testInvocation ->
+            val annotatedElementsByClass = testInvocation.roundEnv.getElementsAnnotatedWith(
+                OtherAnnotation::class
+            )
+
+            val annotatedElementsByName = testInvocation.roundEnv.getElementsAnnotatedWith(
+                OtherAnnotation::class.qualifiedName!!
+            )
+
+            val targetElement = testInvocation.processingEnv.requireTypeElement("Baz")
+
+            Truth.assertThat(
+                annotatedElementsByClass
+            ).apply {
+                containsExactlyElementsIn(annotatedElementsByName)
+                hasSize(3)
+                contains(targetElement)
+                contains(targetElement.getMethod("myFunction"))
+
+                if (testInvocation.isKsp) {
+                    contains(targetElement.getField("myProperty"))
+                } else {
+                    // Javac sees a property annotation on the synthetic function
+                    contains(targetElement.getDeclaredMethod("getMyProperty\$annotations"))
+                }
+            }
+        }
+    }
+
+    @Test
+    fun getAnnotatedPropertyElements() {
+        val source = Source.kotlin(
+            "Baz.kt",
+            """
+            import androidx.room.compiler.processing.testcode.OtherAnnotation;
+            class Baz {
+                @get:OtherAnnotation(value="xx")
+                var myProperty1: Int = 0
+
+                @set:OtherAnnotation(value="xx")
+                var myProperty2: Int = 0
+                
+                @field:OtherAnnotation(value="xx")
+                var myProperty3: Int = 0
+            }
+            """.trimIndent()
+        )
+
+        runProcessorTest(listOf(source)) { testInvocation ->
+            val annotatedElements = testInvocation.roundEnv.getElementsAnnotatedWith(
+                OtherAnnotation::class
+            )
+
+            val targetElement = testInvocation.processingEnv.requireTypeElement("Baz")
+
+            Truth.assertThat(
+                annotatedElements
+            ).apply {
+                hasSize(3)
+
+                contains(targetElement.getDeclaredMethod("getMyProperty1"))
+                contains(targetElement.getDeclaredMethod("setMyProperty2"))
+                contains(targetElement.getField("myProperty3"))
+            }
+        }
+    }
+}

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
@@ -23,6 +23,7 @@ import androidx.room.compiler.processing.util.getField
 import androidx.room.compiler.processing.util.getMethod
 import androidx.room.compiler.processing.util.runProcessorTest
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class XRoundEnvTest {
@@ -55,7 +56,7 @@ class XRoundEnvTest {
 
             val targetElement = testInvocation.processingEnv.requireTypeElement("Baz")
 
-            Truth.assertThat(
+            assertThat(
                 annotatedElementsByClass
             ).apply {
                 containsExactlyElementsIn(annotatedElementsByName)
@@ -99,7 +100,7 @@ class XRoundEnvTest {
 
             val targetElement = testInvocation.processingEnv.requireTypeElement("Baz")
 
-            Truth.assertThat(
+            assertThat(
                 annotatedElements
             ).apply {
                 hasSize(3)

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
@@ -37,7 +37,6 @@ class XRoundEnvTest {
             class Baz {
                 @OtherAnnotation(value="xx")
                 var myProperty: Int = 0
-                
                 @OtherAnnotation(value="xx")
                 fun myFunction() { }
             }
@@ -82,10 +81,8 @@ class XRoundEnvTest {
             class Baz {
                 @get:OtherAnnotation(value="xx")
                 var myProperty1: Int = 0
-
                 @set:OtherAnnotation(value="xx")
                 var myProperty2: Int = 0
-                
                 @field:OtherAnnotation(value="xx")
                 var myProperty3: Int = 0
             }
@@ -135,7 +132,6 @@ class XRoundEnvTest {
             "Baz.kt",
             """
             import androidx.room.compiler.processing.XRoundEnvTest.TopLevelAnnotation
-            
             @TopLevelAnnotation
             fun myFun(): Int = 0
             """.trimIndent()
@@ -184,10 +180,8 @@ class XRoundEnvTest {
             "Baz.kt",
             """
             import androidx.room.compiler.processing.XRoundEnvTest.TopLevelAnnotation
-            
             @get:TopLevelAnnotation
             var myProperty: Int = 0
-
             """.trimIndent()
         )
 

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
@@ -22,7 +22,6 @@ import androidx.room.compiler.processing.util.getDeclaredMethod
 import androidx.room.compiler.processing.util.getField
 import androidx.room.compiler.processing.util.getMethod
 import androidx.room.compiler.processing.util.runProcessorTest
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 

--- a/room/compiler/src/main/kotlin/androidx/room/DatabaseProcessingStep.kt
+++ b/room/compiler/src/main/kotlin/androidx/room/DatabaseProcessingStep.kt
@@ -16,6 +16,7 @@
 
 package androidx.room
 
+import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XTypeElement
@@ -33,11 +34,12 @@ import java.io.File
 class DatabaseProcessingStep : XProcessingStep {
     override fun process(
         env: XProcessingEnv,
-        elementsByAnnotation: Map<String, List<XTypeElement>>
+        elementsByAnnotation: Map<String, Set<XElement>>
     ): Set<XTypeElement> {
         val context = Context(env)
         val rejectedElements = mutableSetOf<XTypeElement>()
         val databases = elementsByAnnotation[Database::class.qualifiedName]
+            ?.filterIsInstance<XTypeElement>()
             ?.mapNotNull {
                 try {
                     DatabaseProcessor(

--- a/room/compiler/src/test/kotlin/androidx/room/processor/BaseEntityParserTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/BaseEntityParserTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.room.processor
 
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
 import androidx.room.compiler.processing.util.runProcessorTest
@@ -67,9 +68,10 @@ abstract class BaseEntityParserTest {
             classpath = classpathFiles
         ) { invocation ->
             val entity = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(
+                .getElementsAnnotatedWith(
                     androidx.room.Entity::class.qualifiedName!!
-                ).first {
+                ).filterIsInstance<XTypeElement>()
+                .first {
                     it.qualifiedName == "foo.bar.MyEntity"
                 }
             val parser = TableEntityProcessor(

--- a/room/compiler/src/test/kotlin/androidx/room/processor/CustomConverterProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/CustomConverterProcessorTest.kt
@@ -28,6 +28,7 @@ import androidx.room.processor.ProcessorErrors.TYPE_CONVERTER_UNBOUND_GENERIC
 import androidx.room.testing.context
 import androidx.room.vo.CustomTypeConverter
 import com.google.common.truth.Truth
+import com.google.common.truth.Truth.*
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterSpec
@@ -294,7 +295,7 @@ class CustomConverterProcessorTest {
                 invocation.context,
                 invocation.processingEnv.requireTypeElement("foo.bar.Container")
             )
-            Truth.assertThat(result.converters).isEmpty()
+            assertThat(result.converters).isEmpty()
             invocation.assertCompilationResult {
                 if (invocation.isKsp) {
                     // for KSP it always has a type element but we rather assert the other error

--- a/room/compiler/src/test/kotlin/androidx/room/processor/CustomConverterProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/CustomConverterProcessorTest.kt
@@ -27,8 +27,7 @@ import androidx.room.processor.ProcessorErrors.TYPE_CONVERTER_MUST_BE_PUBLIC
 import androidx.room.processor.ProcessorErrors.TYPE_CONVERTER_UNBOUND_GENERIC
 import androidx.room.testing.context
 import androidx.room.vo.CustomTypeConverter
-import com.google.common.truth.Truth
-import com.google.common.truth.Truth.*
+import com.google.common.truth.Truth.assertThat
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterSpec

--- a/room/compiler/src/test/kotlin/androidx/room/processor/DaoProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/DaoProcessorTest.kt
@@ -426,7 +426,7 @@ class DaoProcessorTest(private val enableVerification: Boolean) {
             classpath = classpathFiles
         ) { invocation: XTestInvocation ->
             val dao = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(
+                .getElementsAnnotatedWith(
                     androidx.room.Dao::class.qualifiedName!!
                 )
                 .first()

--- a/room/compiler/src/test/kotlin/androidx/room/processor/DatabaseProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/DatabaseProcessorTest.kt
@@ -1235,9 +1235,10 @@ class DatabaseProcessorTest {
             sources = listOf(DB3, BOOK)
         ) { invocation ->
             val database = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(
+                .getElementsAnnotatedWith(
                     androidx.room.Database::class.qualifiedName!!
                 )
+                .filterIsInstance<XTypeElement>()
                 .first()
             val processor = DatabaseProcessor(
                 invocation.context,
@@ -1303,9 +1304,10 @@ class DatabaseProcessorTest {
             classpath = classpath
         ) { invocation ->
             val entity = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(
+                .getElementsAnnotatedWith(
                     androidx.room.Database::class.qualifiedName!!
                 )
+                .filterIsInstance<XTypeElement>()
                 .first()
             val parser = DatabaseProcessor(
                 invocation.context,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/FieldProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/FieldProcessorTest.kt
@@ -18,6 +18,7 @@ package androidx.room.processor
 
 import androidx.room.Entity
 import androidx.room.compiler.processing.XFieldElement
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
 import androidx.room.compiler.processing.util.runProcessorTest
@@ -645,7 +646,8 @@ class FieldProcessorTest {
             sources = sources
         ) { invocation ->
             val (owner, fieldElement) = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(Entity::class.qualifiedName!!)
+                .getElementsAnnotatedWith(Entity::class.qualifiedName!!)
+                .filterIsInstance<XTypeElement>()
                 .map {
                     Pair(
                         it,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/InsertionMethodProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/InsertionMethodProcessorTest.kt
@@ -20,6 +20,7 @@ import COMMON
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.ext.CommonTypeNames
 import androidx.room.ext.RxJava2TypeNames
 import androidx.room.ext.RxJava3TypeNames
@@ -863,7 +864,8 @@ class InsertionMethodProcessorTest {
                     .forAnnotations(Insert::class, Dao::class)
                     .nextRunHandler { invocation ->
                         val (owner, methods) = invocation.roundEnv
-                            .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .filterIsInstance<XTypeElement>()
                             .map {
                                 Pair(
                                     it,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/ProjectionExpanderTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/ProjectionExpanderTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.room.processor
 
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.isTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
@@ -517,7 +518,8 @@ class ProjectionExpanderTest {
             sources = ENTITIES
         ) { invocation ->
             val entities = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(androidx.room.Entity::class.qualifiedName!!)
+                .getElementsAnnotatedWith(androidx.room.Entity::class.qualifiedName!!)
+                .filterIsInstance<XTypeElement>()
                 .map { element ->
                     TableEntityProcessor(
                         invocation.context,
@@ -617,7 +619,8 @@ class ProjectionExpanderTest {
             sources = all
         ) { invocation ->
             val entities = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(androidx.room.Entity::class.qualifiedName!!)
+                .getElementsAnnotatedWith(androidx.room.Entity::class.qualifiedName!!)
+                .filterIsInstance<XTypeElement>()
                 .map { element ->
                     TableEntityProcessor(
                         invocation.context,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/QueryMethodProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/QueryMethodProcessorTest.kt
@@ -20,6 +20,7 @@ import COMMON
 import androidx.room.Dao
 import androidx.room.Query
 import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.ext.CommonTypeNames
 import androidx.room.ext.KotlinTypeNames
 import androidx.room.ext.LifecyclesTypeNames
@@ -1166,7 +1167,8 @@ class QueryMethodProcessorTest(val enableVerification: Boolean) {
                     )
                     .nextRunHandler { invocation ->
                         val (owner, methods) = invocation.roundEnv
-                            .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .filterIsInstance<XTypeElement>()
                             .map {
                                 Pair(
                                     it,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/RawQueryMethodProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/RawQueryMethodProcessorTest.kt
@@ -24,6 +24,7 @@ import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.RawQuery
 import androidx.room.compiler.processing.util.runProcessorTest
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.ext.PagingTypeNames
 import androidx.room.ext.SupportDbTypeNames
 import androidx.room.processor.ProcessorErrors.RAW_QUERY_STRING_PARAMETER_REMOVED
@@ -345,7 +346,8 @@ class RawQueryMethodProcessorTest {
                     )
                     .nextRunHandler { invocation ->
                         val (owner, methods) = invocation.roundEnv
-                            .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .filterIsInstance<XTypeElement>()
                             .map {
                                 Pair(
                                     it,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/ShortcutMethodProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/ShortcutMethodProcessorTest.kt
@@ -24,6 +24,7 @@ import androidx.room.ext.RxJava2TypeNames
 import androidx.room.ext.RxJava3TypeNames
 import androidx.room.compiler.processing.XMethodElement
 import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.testing.TestInvocation
 import androidx.room.testing.TestProcessor
 import androidx.room.vo.ShortcutMethod
@@ -536,7 +537,8 @@ abstract class ShortcutMethodProcessorTest<out T : ShortcutMethod>(
                         .forAnnotations(annotation, Dao::class)
                         .nextRunHandler { invocation ->
                             val (owner, methods) = invocation.roundEnv
-                                .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                                .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                                .filterIsInstance<XTypeElement>()
                                 .map {
                                     Pair(
                                         it,

--- a/room/compiler/src/test/kotlin/androidx/room/processor/TransactionMethodProcessorTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/processor/TransactionMethodProcessorTest.kt
@@ -19,6 +19,7 @@ package androidx.room.processor
 import COMMON
 import androidx.room.Dao
 import androidx.room.Transaction
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.testing.TestInvocation
 import androidx.room.testing.TestProcessor
 import androidx.room.vo.TransactionMethod
@@ -251,7 +252,8 @@ class TransactionMethodProcessorTest {
                     .forAnnotations(Transaction::class, Dao::class)
                     .nextRunHandler { invocation ->
                         val (owner, methods) = invocation.roundEnv
-                            .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .filterIsInstance<XTypeElement>()
                             .map {
                                 Pair(
                                     it,

--- a/room/compiler/src/test/kotlin/androidx/room/solver/query/QueryWriterTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/solver/query/QueryWriterTest.kt
@@ -18,6 +18,7 @@ package androidx.room.solver.query
 
 import androidx.room.Dao
 import androidx.room.Query
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.ext.RoomTypeNames.ROOM_SQL_QUERY
 import androidx.room.ext.RoomTypeNames.STRING_UTIL
 import androidx.room.processor.QueryMethodProcessor
@@ -354,7 +355,8 @@ class QueryWriterTest {
                     .forAnnotations(Query::class, Dao::class)
                     .nextRunHandler { invocation ->
                         val (owner, methods) = invocation.roundEnv
-                            .getTypeElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .getElementsAnnotatedWith(Dao::class.qualifiedName!!)
+                            .filterIsInstance<XTypeElement>()
                             .map {
                                 Pair(
                                     it,

--- a/room/compiler/src/test/kotlin/androidx/room/testing/XProcessingStepExt.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/testing/XProcessingStepExt.kt
@@ -17,6 +17,7 @@
 package androidx.room.testing
 
 import androidx.room.compiler.processing.XProcessingStep
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.XTestInvocation
 
 /**
@@ -27,7 +28,7 @@ fun XProcessingStep.asTestInvocationHandler(
     delegate: (XTestInvocation) -> Unit
 ): (XTestInvocation) -> Unit = { invocation ->
     val elementsByAnnotation = annotations().associateWith {
-        invocation.roundEnv.getTypeElementsAnnotatedWith(it).toList()
+        invocation.roundEnv.getElementsAnnotatedWith(it).filterIsInstance<XTypeElement>().toSet()
     }
     this.process(
         env = invocation.processingEnv,

--- a/room/compiler/src/test/kotlin/androidx/room/testing/test_util.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/testing/test_util.kt
@@ -19,6 +19,7 @@ import androidx.room.Entity
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XFieldElement
 import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
 import androidx.room.compiler.processing.util.getSystemClasspathFiles
@@ -224,6 +225,7 @@ object COMMON {
         )
     }
 }
+
 fun testCodeGenScope(): CodeGenScope {
     return CodeGenScope(mock(ClassWriter::class.java))
 }
@@ -278,28 +280,36 @@ fun createVerifierFromEntitiesAndViews(invocation: XTestInvocation): DatabaseVer
 }
 
 fun XTestInvocation.getViews(): List<androidx.room.vo.DatabaseView> {
-    return roundEnv.getTypeElementsAnnotatedWith(DatabaseView::class.qualifiedName!!).map {
-        DatabaseViewProcessor(context, it).process()
-    }
+    return roundEnv.getElementsAnnotatedWith(DatabaseView::class.qualifiedName!!)
+        .filterIsInstance<XTypeElement>()
+        .map {
+            DatabaseViewProcessor(context, it).process()
+        }
 }
 
 fun XTestInvocation.getEntities(): List<androidx.room.vo.Entity> {
-    val entities = roundEnv.getTypeElementsAnnotatedWith(Entity::class.qualifiedName!!).map {
-        TableEntityProcessor(context, it).process()
-    }
+    val entities = roundEnv.getElementsAnnotatedWith(Entity::class.qualifiedName!!)
+        .filterIsInstance<XTypeElement>()
+        .map {
+            TableEntityProcessor(context, it).process()
+        }
     return entities
 }
 
 fun TestInvocation.getViews(): List<androidx.room.vo.DatabaseView> {
-    return roundEnv.getTypeElementsAnnotatedWith(DatabaseView::class.qualifiedName!!).map {
-        DatabaseViewProcessor(context, it).process()
-    }
+    return roundEnv.getElementsAnnotatedWith(DatabaseView::class.qualifiedName!!)
+        .filterIsInstance<XTypeElement>()
+        .map {
+            DatabaseViewProcessor(context, it).process()
+        }
 }
 
 fun TestInvocation.getEntities(): List<androidx.room.vo.Entity> {
-    val entities = roundEnv.getTypeElementsAnnotatedWith(Entity::class.qualifiedName!!).map {
-        TableEntityProcessor(context, it).process()
-    }
+    val entities = roundEnv.getElementsAnnotatedWith(Entity::class.qualifiedName!!)
+        .filterIsInstance<XTypeElement>()
+        .map {
+            TableEntityProcessor(context, it).process()
+        }
     return entities
 }
 

--- a/room/compiler/src/test/kotlin/androidx/room/writer/DaoWriterTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/writer/DaoWriterTest.kt
@@ -17,6 +17,7 @@
 package androidx.room.writer
 
 import COMMON
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
 import androidx.room.compiler.processing.util.runProcessorTest
@@ -139,14 +140,14 @@ class DaoWriterTest {
             sources = sources
         ) { invocation ->
             val dao = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(
+                .getElementsAnnotatedWith(
                     androidx.room.Dao::class.qualifiedName!!
-                ).firstOrNull()
+                ).filterIsInstance<XTypeElement>().firstOrNull()
             if (dao != null) {
                 val db = invocation.roundEnv
-                    .getTypeElementsAnnotatedWith(
+                    .getElementsAnnotatedWith(
                         androidx.room.Database::class.qualifiedName!!
-                    ).firstOrNull()
+                    ).filterIsInstance<XTypeElement>().firstOrNull()
                     ?: invocation.context.processingEnv
                         .requireTypeElement(RoomTypeNames.ROOM_DB)
                 val dbType = db.type

--- a/room/compiler/src/test/kotlin/androidx/room/writer/SQLiteOpenHelperWriterTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/writer/SQLiteOpenHelperWriterTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.room.writer
 
+import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
 import androidx.room.compiler.processing.util.runProcessorTest
@@ -214,7 +215,8 @@ class SQLiteOpenHelperWriterTest {
             sources = sources + databaseCode
         ) { invocation ->
             val db = invocation.roundEnv
-                .getTypeElementsAnnotatedWith(androidx.room.Database::class.qualifiedName!!)
+                .getElementsAnnotatedWith(androidx.room.Database::class.qualifiedName!!)
+                .filterIsInstance<XTypeElement>()
                 .first()
             handler(DatabaseProcessor(invocation.context, db).process(), invocation)
         }


### PR DESCRIPTION
## Proposed Changes
Currently the Room compiler processing abstraction is set up to use the pattern of processing steps, including using auto-common for javac processing. Our existing processors (and I assume many other people's) do not use this approach and I'd prefer not to have to convert to that pattern. While annotated elements can be looked up directly with XRoundEnv, that currently only works for type elements.

This PR adds to XRoundEnv a new function to look up annotated elements of all kinds, not just type elements. This allows processors more flexibility in how they use the compiler processing (and mirrors the patterns we use with javac processing in our libraries).

The implementation is fairly straightforward, I just created new functions to wrap each possible type of Element and Symbol, leveraging existing classes.

I believe this could benefit from caching, but that could be added in the future.

I also did not attempt to modify XProcessingStep to support elements of all kinds, since the pattern it enforces seems directed towards starting with just type elements.

If this direction is OK I can also update the readme to cover this use case.

## Testing
Test: XRoundEnvTest

Wrote new unit tests that check annotated functions and properties in both java and kotlin are wrapped with the appropriate `X` class.

## Issues Fixed

Bug: b/184438287
