### PR TITLE
[Room][Compiler Processing] Originating element improvements

### DIFF
--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
@@ -51,8 +51,9 @@ internal fun TypeMirror.safeTypeName(): TypeName = if (kind == TypeKind.NONE) {
  * Adds the given element as the originating element for compilation.
  * see [TypeSpec.Builder.addOriginatingElement].
  */
-fun TypeSpec.Builder.addOriginatingElement(element: XElement) {
+fun TypeSpec.Builder.addOriginatingElement(element: XElement): TypeSpec.Builder {
     element.originatingElement()?.let(this::addOriginatingElement)
+    return this
 }
 
 internal fun TypeName.rawTypeName(): TypeName {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
@@ -50,7 +50,7 @@ internal fun TypeMirror.safeTypeName(): TypeName = if (kind == TypeKind.NONE) {
  * see [TypeSpec.Builder.addOriginatingElement].
  */
 fun TypeSpec.Builder.addOriginatingElement(element: XElement): TypeSpec.Builder {
-    element.originatingElement()?.let(this::addOriginatingElement)
+    element.originatingElementForPoet()?.let(this::addOriginatingElement)
     return this
 }
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
@@ -52,11 +52,7 @@ internal fun TypeMirror.safeTypeName(): TypeName = if (kind == TypeKind.NONE) {
  * see [TypeSpec.Builder.addOriginatingElement].
  */
 fun TypeSpec.Builder.addOriginatingElement(element: XElement) {
-    if (element is JavacElement) {
-        this.addOriginatingElement(element.element)
-    } else if (element is KspElement) {
-        element.containingFileAsOriginatingElement()?.let(this::addOriginatingElement)
-    }
+    element.originatingElement()?.let(this::addOriginatingElement)
 }
 
 internal fun TypeName.rawTypeName(): TypeName {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/JavaPoetExt.kt
@@ -15,9 +15,7 @@
  */
 package androidx.room.compiler.processing
 
-import androidx.room.compiler.processing.javac.JavacElement
 import androidx.room.compiler.processing.javac.JavacExecutableElement
-import androidx.room.compiler.processing.ksp.KspElement
 import androidx.room.compiler.processing.ksp.KspMethodElement
 import androidx.room.compiler.processing.ksp.KspMethodType
 import com.squareup.javapoet.ClassName

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import com.squareup.kotlinpoet.OriginatingElementsHolder
+
+/**
+ * Adds the given element as an originating element for compilation.
+ * see [OriginatingElementsHolder.Builder.addOriginatingElement].
+ */
+fun <T : OriginatingElementsHolder.Builder<T>> OriginatingElementsHolder.Builder<T>.addOriginatingElement(
+    element: XElement
+) {
+    element.originatingElement()?.let(this::addOriginatingElement)
+}

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
@@ -25,6 +25,6 @@ import com.squareup.kotlinpoet.OriginatingElementsHolder
 fun <T : OriginatingElementsHolder.Builder<T>> T.addOriginatingElement(
     element: XElement
 ): T {
-    element.originatingElement()?.let(this::addOriginatingElement)
+    element.originatingElementForPoet()?.let(this::addOriginatingElement)
     return this
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/KotlinPoetExt.kt
@@ -22,8 +22,9 @@ import com.squareup.kotlinpoet.OriginatingElementsHolder
  * Adds the given element as an originating element for compilation.
  * see [OriginatingElementsHolder.Builder.addOriginatingElement].
  */
-fun <T : OriginatingElementsHolder.Builder<T>> OriginatingElementsHolder.Builder<T>.addOriginatingElement(
+fun <T : OriginatingElementsHolder.Builder<T>> T.addOriginatingElement(
     element: XElement
-) {
+): T {
     element.originatingElement()?.let(this::addOriginatingElement)
+    return this
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing
 
 import androidx.room.compiler.processing.javac.JavacElement
+import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
 import androidx.room.compiler.processing.ksp.KspElement
 import javax.lang.model.element.Element
 import kotlin.contracts.contract
@@ -83,13 +84,14 @@ fun XElement.isConstructor(): Boolean {
  * Attempts to get a Javac [Element] representing the originating element for attribution
  * when writing a file for incremental processing.
  *
- * Note, instead of using this directly you can instead use the [addOriginatingElement] extension
- * functions for JavaPoet and KotlinPoet Type builders.
+ * In KSP a [KSFileAsOriginatingElement] will be returned, which is a synthetic javac element
+ * that allows us to pass originating elements to JavaPoet and KotlinPoet, and later extract
+ * the KSP file when writing with [XFiler].
  */
-fun XElement.originatingElement(): Element? {
+internal fun XElement.originatingElementForPoet(): Element? {
     return when (this) {
         is JavacElement -> element
         is KspElement -> containingFileAsOriginatingElement()
-        else -> null
+        else -> error("Originating element not implemented for ${this.javaClass}")
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
@@ -92,6 +92,6 @@ internal fun XElement.originatingElementForPoet(): Element? {
     return when (this) {
         is JavacElement -> element
         is KspElement -> containingFileAsOriginatingElement()
-        else -> error("Originating element not implemented for ${this.javaClass}")
+        else -> error("Originating element is not implemented for ${this.javaClass}")
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
@@ -16,6 +16,9 @@
 
 package androidx.room.compiler.processing
 
+import androidx.room.compiler.processing.javac.JavacElement
+import androidx.room.compiler.processing.ksp.KspElement
+import javax.lang.model.element.Element
 import kotlin.contracts.contract
 
 /**
@@ -74,4 +77,19 @@ fun XElement.isConstructor(): Boolean {
         returns(true) implies (this@isConstructor is XConstructorElement)
     }
     return this is XConstructorElement
+}
+
+/**
+ * Attempts to get a Javac [Element] representing the originating element for attribution
+ * when writing a file for incremental processing.
+ *
+ * Note, instead of using this directly you can instead use the [addOriginatingElement] extension
+ * functions for JavaPoet and KotlinPoet Type builders.
+ */
+fun XElement.originatingElement(): Element? {
+    return when (this) {
+        is JavacElement -> element
+        is KspElement -> containingFileAsOriginatingElement()
+        else -> null
+    }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
@@ -23,22 +23,27 @@ import com.squareup.kotlinpoet.FileSpec
  * Code generation interface for XProcessing.
  */
 interface XFiler {
+
+    fun write(javaFile: JavaFile, mode: Mode = Mode.Isolating)
+
+    fun write(fileSpec: FileSpec, mode: Mode = Mode.Isolating)
+
     /**
-     * @param aggregating Specifies whether this
-     * file represents aggregating or isolating inputs for incremental build purposes. This does
-     * not apply in Javac processing because aggregating vs isolating is set on the processor
-     * level. For more on KSP's definitions of isolating vs aggregating see the documentation at
+     * Specifies whether a file represents aggregating or isolating inputs for incremental
+     * build purposes. This does not apply in Javac processing because aggregating vs isolating
+     * is set on the processor level. For more on KSP's definitions of isolating vs aggregating
+     * see the documentation at
      * https://github.com/google/ksp/blob/master/docs/incremental.md
      */
-    fun write(javaFile: JavaFile, aggregating: Boolean = false)
-
-    fun write(fileSpec: FileSpec, aggregating: Boolean = false)
+    enum class Mode {
+        Aggregating, Isolating
+    }
 }
 
-fun JavaFile.writeTo(generator: XFiler, aggregating: Boolean = false) {
-    generator.write(this, aggregating)
+fun JavaFile.writeTo(generator: XFiler, mode: XFiler.Mode = XFiler.Mode.Isolating) {
+    generator.write(this, mode)
 }
 
-fun FileSpec.writeTo(generator: XFiler, aggregating: Boolean = false) {
-    generator.write(this, aggregating)
+fun FileSpec.writeTo(generator: XFiler, mode: XFiler.Mode = XFiler.Mode.Isolating) {
+    generator.write(this, mode)
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
@@ -35,6 +35,10 @@ interface XFiler {
     fun write(fileSpec: FileSpec, aggregating: Boolean = false)
 }
 
-fun JavaFile.writeTo(generator: XFiler, aggregating: Boolean = false) = generator.write(this, aggregating)
+fun JavaFile.writeTo(generator: XFiler, aggregating: Boolean = false) {
+    generator.write(this, aggregating)
+}
 
-fun FileSpec.writeTo(generator: XFiler, aggregating: Boolean = false) = generator.write(this, aggregating)
+fun FileSpec.writeTo(generator: XFiler, aggregating: Boolean = false) {
+    generator.write(this, aggregating)
+}

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XFiler.kt
@@ -23,11 +23,18 @@ import com.squareup.kotlinpoet.FileSpec
  * Code generation interface for XProcessing.
  */
 interface XFiler {
-    fun write(javaFile: JavaFile)
+    /**
+     * @param aggregating Specifies whether this
+     * file represents aggregating or isolating inputs for incremental build purposes. This does
+     * not apply in Javac processing because aggregating vs isolating is set on the processor
+     * level. For more on KSP's definitions of isolating vs aggregating see the documentation at
+     * https://github.com/google/ksp/blob/master/docs/incremental.md
+     */
+    fun write(javaFile: JavaFile, aggregating: Boolean = false)
 
-    fun write(fileSpec: FileSpec)
+    fun write(fileSpec: FileSpec, aggregating: Boolean = false)
 }
 
-fun JavaFile.writeTo(generator: XFiler) = generator.write(this)
+fun JavaFile.writeTo(generator: XFiler, aggregating: Boolean = false) = generator.write(this, aggregating)
 
-fun FileSpec.writeTo(generator: XFiler) = generator.write(this)
+fun FileSpec.writeTo(generator: XFiler, aggregating: Boolean = false) = generator.write(this, aggregating)

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
@@ -22,11 +22,13 @@ import com.squareup.kotlinpoet.FileSpec
 import javax.annotation.processing.ProcessingEnvironment
 
 internal class JavacFiler(val processingEnv: ProcessingEnvironment) : XFiler {
-    override fun write(javaFile: JavaFile) {
+
+    // "aggregating" is ignored in javac, and only applicable in KSP
+    override fun write(javaFile: JavaFile, aggregating: Boolean) {
         javaFile.writeTo(processingEnv.filer)
     }
 
-    override fun write(fileSpec: FileSpec) {
+    override fun write(fileSpec: FileSpec, aggregating: Boolean) {
         require(processingEnv.options.containsKey("kapt.kotlin.generated")) {
             val filePath = fileSpec.packageName.replace('.', '/')
             "Could not generate kotlin file $filePath/${fileSpec.name}.kt. The " +

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacFiler.kt
@@ -23,12 +23,12 @@ import javax.annotation.processing.ProcessingEnvironment
 
 internal class JavacFiler(val processingEnv: ProcessingEnvironment) : XFiler {
 
-    // "aggregating" is ignored in javac, and only applicable in KSP
-    override fun write(javaFile: JavaFile, aggregating: Boolean) {
+    // "mode" is ignored in javac, and only applicable in KSP
+    override fun write(javaFile: JavaFile, mode: XFiler.Mode) {
         javaFile.writeTo(processingEnv.filer)
     }
 
-    override fun write(fileSpec: FileSpec, aggregating: Boolean) {
+    override fun write(fileSpec: FileSpec, mode: XFiler.Mode) {
         require(processingEnv.options.containsKey("kapt.kotlin.generated")) {
             val filePath = fileSpec.packageName.replace('.', '/')
             "Could not generate kotlin file $filePath/${fileSpec.name}.kt. The " +

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSFileAsOriginatingElement.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSFileAsOriginatingElement.kt
@@ -30,7 +30,7 @@ import javax.lang.model.type.TypeMirror
  * This wrapper class helps us wrap a KSFile as an originating element and KspFiler unwraps it to
  * get the actual KSFile out of it.
  */
-internal class KSFileAsOriginatingElement(
+internal data class KSFileAsOriginatingElement(
     val ksFile: KSFile
 ) : Element {
     override fun getAnnotationMirrors(): List<AnnotationMirror> {
@@ -74,10 +74,6 @@ internal class KSFileAsOriginatingElement(
 
     override fun <R : Any?, P : Any?> accept(v: ElementVisitor<R, P>?, p: P): R? {
         return null
-    }
-
-    override fun toString(): String {
-        return ksFile.toString()
     }
 
     private class NameImpl(private val str: String) : Name, CharSequence by str {

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFiler.kt
@@ -32,7 +32,7 @@ internal class KspFiler(
     private val delegate: CodeGenerator,
     private val messager: XMessager,
 ) : XFiler {
-    override fun write(javaFile: JavaFile) {
+    override fun write(javaFile: JavaFile, aggregating: Boolean) {
         val originatingFiles = javaFile.typeSpec.originatingElements
             .map(::originatingFileFor)
 
@@ -40,7 +40,8 @@ internal class KspFiler(
             originatingFiles = originatingFiles,
             packageName = javaFile.packageName,
             fileName = javaFile.typeSpec.name,
-            extensionName = "java"
+            extensionName = "java",
+            aggregating = aggregating
         ).use { outputStream ->
             outputStream.bufferedWriter(Charsets.UTF_8).use {
                 javaFile.writeTo(it)
@@ -48,7 +49,7 @@ internal class KspFiler(
         }
     }
 
-    override fun write(fileSpec: FileSpec) {
+    override fun write(fileSpec: FileSpec, aggregating: Boolean) {
         val originatingFiles = fileSpec.members
             .filterIsInstance<TypeSpec>()
             .flatMap { it.originatingElements }
@@ -58,7 +59,8 @@ internal class KspFiler(
             originatingFiles = originatingFiles,
             packageName = fileSpec.packageName,
             fileName = fileSpec.name,
-            extensionName = "kt"
+            extensionName = "kt",
+            aggregating = aggregating
         ).use { outputStream ->
             outputStream.bufferedWriter(Charsets.UTF_8).use {
                 fileSpec.writeTo(it)
@@ -77,7 +79,8 @@ internal class KspFiler(
         originatingFiles: List<KSFile>,
         packageName: String,
         fileName: String,
-        extensionName: String
+        extensionName: String,
+        aggregating: Boolean
     ): OutputStream {
         val dependencies = if (originatingFiles.isEmpty()) {
             messager.printMessage(
@@ -91,7 +94,7 @@ internal class KspFiler(
             Dependencies.ALL_FILES
         } else {
             Dependencies(
-                aggregating = false,
+                aggregating = aggregating,
                 sources = originatingFiles.distinct().toTypedArray()
             )
         }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFiler.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspFiler.kt
@@ -32,7 +32,7 @@ internal class KspFiler(
     private val delegate: CodeGenerator,
     private val messager: XMessager,
 ) : XFiler {
-    override fun write(javaFile: JavaFile, aggregating: Boolean) {
+    override fun write(javaFile: JavaFile, mode: XFiler.Mode) {
         val originatingFiles = javaFile.typeSpec.originatingElements
             .map(::originatingFileFor)
 
@@ -41,7 +41,7 @@ internal class KspFiler(
             packageName = javaFile.packageName,
             fileName = javaFile.typeSpec.name,
             extensionName = "java",
-            aggregating = aggregating
+            aggregating = mode == XFiler.Mode.Aggregating
         ).use { outputStream ->
             outputStream.bufferedWriter(Charsets.UTF_8).use {
                 javaFile.writeTo(it)
@@ -49,7 +49,7 @@ internal class KspFiler(
         }
     }
 
-    override fun write(fileSpec: FileSpec, aggregating: Boolean) {
+    override fun write(fileSpec: FileSpec, mode: XFiler.Mode) {
         val originatingFiles = fileSpec.members
             .filterIsInstance<TypeSpec>()
             .flatMap { it.originatingElements }
@@ -60,7 +60,7 @@ internal class KspFiler(
             packageName = fileSpec.packageName,
             fileName = fileSpec.name,
             extensionName = "kt",
-            aggregating = aggregating
+            aggregating = mode == XFiler.Mode.Aggregating
         ).use { outputStream ->
             outputStream.bufferedWriter(Charsets.UTF_8).use {
                 fileSpec.writeTo(it)

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
@@ -50,7 +50,7 @@ class OriginatingElementsTest {
         ) {
             val element = it.processingEnv.requireTypeElement("foo.bar.Baz")
 
-            val originatingElement = element.originatingElement()
+            val originatingElement = element.originatingElementForPoet()
             assertThat(originatingElement).isNotNull()
 
             if (it.isKsp) {
@@ -100,7 +100,7 @@ class OriginatingElementsTest {
             assertThat(javaPoetTypeSpec.originatingElements).apply {
                 hasSize(1)
                 containsExactlyElementsIn(kotlinPoetTypeSpec.originatingElements)
-                containsExactly(xTypeElement.originatingElement())
+                containsExactly(xTypeElement.originatingElementForPoet())
             }
         }
     }

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
+import androidx.room.compiler.processing.ksp.KspTypeElement
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.runProcessorTest
+import com.google.common.truth.Truth.assertThat
+import com.squareup.javapoet.TypeSpec
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import javax.lang.model.element.TypeElement
+
+@RunWith(JUnit4::class)
+class OriginatingElementsTest {
+
+    @Test
+    fun xElementIsConvertedToOriginatingElement() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "foo.bar.Baz",
+                    """
+                package foo.bar;
+                public class Baz {
+                    private void foo() {}
+                    public String bar(String[] param1) {
+                        return "";
+                    }
+                }
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val element = it.processingEnv.requireTypeElement("foo.bar.Baz")
+
+            val originatingElement = element.originatingElement()
+            assertThat(originatingElement).isNotNull()
+
+            if (it.isKsp) {
+                assertThat(originatingElement).isInstanceOf(KSFileAsOriginatingElement::class.java)
+
+                val originatingFile = (originatingElement as KSFileAsOriginatingElement).ksFile
+                assertThat(originatingFile)
+                    .isEqualTo(
+                        (element as KspTypeElement).declaration.containingFile
+                    )
+            } else {
+                assertThat(originatingElement).isInstanceOf(TypeElement::class.java)
+                assertThat((originatingElement as TypeElement).qualifiedName.toString())
+                    .isEqualTo("foo.bar.Baz")
+            }
+        }
+    }
+
+    @Test
+    fun originatingElementIsAddedToPoet() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "foo.bar.Baz",
+                    """
+                package foo.bar;
+                public class Baz {
+                    private void foo() {}
+                    public String bar(String[] param1) {
+                        return "";
+                    }
+                }
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val xTypeElement = it.processingEnv.requireTypeElement("foo.bar.Baz")
+
+            val javaPoetTypeSpec = TypeSpec.classBuilder("Foo")
+                .addOriginatingElement(xTypeElement)
+                .build()
+
+            val kotlinPoetTypeSpec = com.squareup.kotlinpoet.TypeSpec.classBuilder("Foo")
+                .addOriginatingElement(xTypeElement)
+                .build()
+
+            assertThat(javaPoetTypeSpec.originatingElements).apply {
+                hasSize(1)
+                containsExactlyElementsIn(kotlinPoetTypeSpec.originatingElements)
+                containsExactly(xTypeElement.originatingElement())
+            }
+        }
+    }
+}

--- a/room/compiler/src/test/kotlin/androidx/room/writer/AutoMigrationWriterTest.kt
+++ b/room/compiler/src/test/kotlin/androidx/room/writer/AutoMigrationWriterTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.room.writer
 
-import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.runProcessorTest
 import androidx.room.migration.bundle.FieldBundle
@@ -26,7 +25,6 @@ import loadTestSource
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import org.mockito.Mockito.mock
 
 @RunWith(JUnit4::class)
 class AutoMigrationWriterTest {
@@ -73,7 +71,10 @@ class AutoMigrationWriterTest {
                     removedOrRenamedTables = listOf()
                 ),
             )
-            AutoMigrationWriter(mock(XElement::class.java), autoMigrationResultWithNewAddedColumn)
+            AutoMigrationWriter(
+                autoMigrationResultWithNewAddedColumn.element,
+                autoMigrationResultWithNewAddedColumn
+            )
                 .write(invocation.processingEnv)
 
             invocation.assertCompilationResult {
@@ -131,7 +132,10 @@ class AutoMigrationWriterTest {
                     removedOrRenamedTables = listOf()
                 ),
             )
-            AutoMigrationWriter(mock(XElement::class.java), autoMigrationResultWithNewAddedColumn)
+            AutoMigrationWriter(
+                autoMigrationResultWithNewAddedColumn.element,
+                autoMigrationResultWithNewAddedColumn
+            )
                 .write(invocation.processingEnv)
 
             invocation.assertCompilationResult {


### PR DESCRIPTION
## Proposed Changes
Right now the compiler processing library only exposes a way to set originating elements when generating a file with JavaPoet, and KotlinPoet should be supported for the case of creating kotlin files. Additionally when writing a file with KSP the incremental mode defaults to isolating with no way to specify that it should be aggregating.

This change:
  - Adds a new boolean parameter to XFiler `write` functions to optionally specify isolating vs aggregating behavior (defaults to isolating)
  - Adds a kotlinpoet extension function to add originating elements.
  - Exposes a public function to convert XElement to an originating element in case users need to access it directly

## Testing

Test: OriginatingElementsTest

Unit tests that check originating elements are created from XElement and added to kotlin and java poet type builders.

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/184568922
