### PR TITLE
[Fragment] Add lint warning for calling LayoutInflater.from() in DialogFragment

### DIFF
--- a/fragment/fragment-lint/src/main/java/androidx/fragment/lint/FragmentIssueRegistry.kt
+++ b/fragment/fragment-lint/src/main/java/androidx/fragment/lint/FragmentIssueRegistry.kt
@@ -30,6 +30,7 @@ class FragmentIssueRegistry : IssueRegistry() {
         FragmentTagDetector.ISSUE,
         UnsafeFragmentLifecycleObserverDetector.BACK_PRESSED_ISSUE,
         UnsafeFragmentLifecycleObserverDetector.LIVEDATA_ISSUE,
-        UseRequireInsteadOfGet.ISSUE
+        UseRequireInsteadOfGet.ISSUE,
+        UseGetLayoutInflater.ISSUE
     )
 }

--- a/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
+++ b/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
@@ -38,6 +38,24 @@ import org.jetbrains.uast.getContainingUClass
  */
 class UseGetLayoutInflater : Detector(), SourceCodeScanner {
 
+    companion object Issues {
+        val ISSUE = Issue.create(
+            id = "UseGetLayoutInflater",
+            briefDescription = "Use getLayoutInflater() to get the LayoutInflater instead of " +
+                "calling LayoutInflater.from(Context).",
+            explanation = """Using LayoutInflater.from(Context) can return a LayoutInflater  \
+                that does not have the correct theme.""",
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                UseGetLayoutInflater::class.java,
+                Scope.JAVA_FILE_SCOPE
+            ),
+            androidSpecific = true
+        )
+    }
+
     override fun getApplicableMethodNames(): List<String>? {
         return listOf(UNWANTED_METHOD)
     }
@@ -105,24 +123,6 @@ class UseGetLayoutInflater : Detector(), SourceCodeScanner {
             .build()
     }
 
-
-    companion object Issues {
-        val ISSUE = Issue.create(
-            id = "UseGetLayoutInflater",
-            briefDescription = "Use getLayoutInflater() to get the LayoutInflater instead of " +
-                "calling LayoutInflater.from(Context).",
-            explanation = """Using LayoutInflater.from(Context) can return a LayoutInflater  \
-                that does not have the correct theme.""",
-            category = Category.CORRECTNESS,
-            priority = 9,
-            severity = Severity.WARNING,
-            implementation = Implementation(
-                UseGetLayoutInflater::class.java,
-                Scope.JAVA_FILE_SCOPE
-            ),
-            androidSpecific = true
-        )
-    }
 }
 
 private const val UNWANTED_CLASS = "android.view.LayoutInflater"

--- a/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
+++ b/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package androidx.fragment.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.isKotlin
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.getContainingUClass
+
+/**
+ * Lint check for detecting calls to [android.view.LayoutInflater.from]
+ * while being invoked from DialogFragment
+ */
+class UseGetLayoutInflater : Detector(), SourceCodeScanner {
+
+    override fun getApplicableMethodNames(): List<String>? {
+        return listOf(UNWANTED_METHOD)
+    }
+
+    override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+        val containingClass = method.containingClass ?: return
+        val evaluator = context.evaluator
+        if (evaluator.getQualifiedName(containingClass) == UNWANTED_CLASS &&
+            evaluator.getParameterCount(method) == 1
+        ) {
+            if (!isKotlin(context.psiFile)) {
+                startLintForJava(context, node)
+            } else {
+                startLintForKotlin(context, node)
+            }
+        }
+    }
+
+    private fun startLintForJava(context: JavaContext, node: UCallExpression) {
+        if (node.getContainingUClass()?.superClassType?.name != DIALOG_FRAGMENT_CLASS) {
+            return
+        }
+        val methodParameter = node.valueArguments[0].toString()
+
+        context.report(
+            issue = ISSUE,
+            location = context.getLocation(node),
+            message = "Use of LayoutInflater.from($methodParameter) detected. Consider using " +
+                "${correctMethod(context)} instead",
+            quickfixData = createFix(correctMethod(context), methodParameter)
+        )
+    }
+
+    private fun startLintForKotlin(context: JavaContext, node: UCallExpression) {
+        if (node.getContainingUClass()?.javaPsi?.text?.contains
+                ("${DIALOG_FRAGMENT_CLASS}()") == false
+        ) {
+            return
+        }
+
+        context.report(
+            issue = ISSUE,
+            location = context.getLocation(node),
+            message = "Use of LayoutInflater.from(Context) detected. Consider using " +
+                "${correctMethod(context)} instead",
+            quickfixData = null
+        )
+    }
+
+    private fun correctMethod(context: JavaContext): String {
+        return if (isKotlin(context.psiFile)) {
+            "layoutInflater"
+        } else {
+            "getLayoutInflater()"
+        }
+    }
+
+    private fun createFix(correctMethod: String, parameter: String?): LintFix {
+        return fix()
+            .replace()
+            .text("LayoutInflater.from($parameter)")
+            .name("Replace with $correctMethod")
+            .with(correctMethod)
+            .autoFix()
+            .build()
+    }
+
+
+    companion object Issues {
+        val ISSUE = Issue.create(
+            id = "UseGetLayoutInflater",
+            briefDescription = "Use getLayoutInflater() to get the LayoutInflater instead of " +
+                "calling LayoutInflater.from(Context).",
+            explanation = """Using LayoutInflater.from(Context) can return a LayoutInflater  \
+                that does not have the correct theme.""",
+            category = Category.CORRECTNESS,
+            priority = 9,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                UseGetLayoutInflater::class.java,
+                Scope.JAVA_FILE_SCOPE
+            ),
+            androidSpecific = true
+        )
+    }
+}
+
+private const val UNWANTED_CLASS = "android.view.LayoutInflater"
+private const val UNWANTED_METHOD = "from"
+private const val DIALOG_FRAGMENT_CLASS = "DialogFragment"

--- a/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
+++ b/fragment/fragment-lint/src/main/java/androidx/fragment/lint/UseGetLayoutInflater.kt
@@ -91,7 +91,7 @@ class UseGetLayoutInflater : Detector(), SourceCodeScanner {
 
     private fun startLintForKotlin(context: JavaContext, node: UCallExpression) {
         if (node.getContainingUClass()?.javaPsi?.text?.contains
-                ("${DIALOG_FRAGMENT_CLASS}()") == false
+            ("$DIALOG_FRAGMENT_CLASS()") == false
         ) {
             return
         }
@@ -122,7 +122,6 @@ class UseGetLayoutInflater : Detector(), SourceCodeScanner {
             .autoFix()
             .build()
     }
-
 }
 
 private const val UNWANTED_CLASS = "android.view.LayoutInflater"

--- a/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
+++ b/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
@@ -32,6 +32,44 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
 
     override fun getIssues(): MutableList<Issue> = mutableListOf(UseGetLayoutInflater.ISSUE)
 
+    private val dialogFragmentCorrectImplementationStubJava = java(
+        """
+            package foo;
+            import android.os.Bundle;
+            import android.view.View;
+            import android.view.ViewGroup;
+            import androidx.annotation.NonNull;
+            import androidx.annotation.Nullable;
+            import androidx.fragment.app.DialogFragment;
+            
+            public class TestFragment extends DialogFragment {
+            
+                @NonNull
+                @Override
+                public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+                    getLayoutInflater().inflate(R.layout.some_layout, null);
+                    return super.onCreateDialog(savedInstanceState);
+                }
+            }
+            """
+    ).indented()
+
+    private val dialogFragmentCorrectImplementationStubKotlin = kotlin(
+        """
+            package foo
+            import android.app.Dialog
+            import android.os.Bundle
+            import androidx.fragment.app.DialogFragment
+            
+            class Test : DialogFragment() {
+                override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+                    layoutInflater.inflate(R.layout.some_layout, null)
+                    return super.onCreateDialog(savedInstanceState)
+                }
+            }
+            """
+    ).indented()
+
     private val dialogFragmentStubJava = java(
         """
             package foo;
@@ -130,7 +168,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
     ).indented()
 
     @Test
-    fun `pass java check`() {
+    fun `java expect fail dialog fragment with fix`() {
         lint().files(dialogFragmentStubJava)
             .run()
             .expect(
@@ -153,14 +191,21 @@ src/foo/TestFragment.java:18: Warning: Use of LayoutInflater.from(requireContext
     }
 
     @Test
-    fun `pass java check without dialog fragment`() {
+    fun `java expect clean non dialog fragment`() {
         lint().files(fragmentStubJava)
             .run()
             .expectClean()
     }
 
     @Test
-    fun `pass kotlin check`() {
+    fun `java expect clean dialog fragment`() {
+        lint().files(dialogFragmentCorrectImplementationStubJava)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `kotlin expect fail dialog fragment`() {
         lint().files(dialogFragmentStubKotlin)
             .run()
             .expect(
@@ -175,8 +220,15 @@ src/foo/TestFragment.kt:15: Warning: Use of LayoutInflater.from(Context) detecte
     }
 
     @Test
-    fun `pass kotlin check without dialog fragment`() {
+    fun `kotlin expect clean non dialog fragment`() {
         lint().files(fragmentStubKotlin)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `kotlin expect clean dialog fragment`() {
+        lint().files(dialogFragmentCorrectImplementationStubKotlin)
             .run()
             .expectClean()
     }

--- a/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
+++ b/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
@@ -81,13 +81,12 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             public class TestFragment extends DialogFragment {
                 @Nullable
                 @Override
-                public View onCreateView(@NonNull LayoutInflater inflater, 
-                                            @Nullable ViewGroup container, 
+                public View onCreateView(@NonNull LayoutInflater inflater,
+                                            @Nullable ViewGroup container,
                                             @Nullable Bundle savedInstanceState) {
                     LayoutInflater li = LayoutInflater.from(requireContext());
-                    
                     // this  will not be triggered
-                    LayoutInflater123 li123 = LayoutInflater123.from(requireContext()); 
+                    LayoutInflater123 li123 = LayoutInflater123.from(requireContext());
                     return super.onCreateView(inflater, container, savedInstanceState);
                 }
             }
@@ -107,8 +106,8 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             public class TestFragment extends Fragment {
                 @Nullable
                 @Override
-                public View onCreateView(@NonNull LayoutInflater inflater, 
-                                            @Nullable ViewGroup container, 
+                public View onCreateView(@NonNull LayoutInflater inflater,
+                                            @Nullable ViewGroup container,
                                             @Nullable Bundle savedInstanceState) {
                     LayoutInflater li = LayoutInflater.from(requireContext());
                     return super.onCreateView(inflater, container, savedInstanceState);
@@ -128,8 +127,8 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.Nullable
             import androidx.fragment.app.DialogFragment
             class TestFragment : DialogFragment() {
-                override fun onCreateView(inflater: LayoutInflater, 
-                                            container: ViewGroup?, 
+                override fun onCreateView(inflater: LayoutInflater,
+                                            container: ViewGroup?,
                                             savedInstanceState: Bundle?): View? {
                     val li = LayoutInflater.from(requireContext())
                     return super.onCreateView(inflater, container, savedInstanceState)

--- a/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
+++ b/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
@@ -41,9 +41,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.NonNull;
             import androidx.annotation.Nullable;
             import androidx.fragment.app.DialogFragment;
-            
             public class TestFragment extends DialogFragment {
-            
                 @NonNull
                 @Override
                 public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
@@ -60,7 +58,6 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import android.app.Dialog
             import android.os.Bundle
             import androidx.fragment.app.DialogFragment
-            
             class Test : DialogFragment() {
                 override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
                     layoutInflater.inflate(R.layout.some_layout, null)
@@ -81,9 +78,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.NonNull;
             import androidx.annotation.Nullable;
             import androidx.fragment.app.DialogFragment;
-            
             public class TestFragment extends DialogFragment {
-            
                 @Nullable
                 @Override
                 public View onCreateView(@NonNull LayoutInflater inflater, 
@@ -109,9 +104,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.NonNull;
             import androidx.annotation.Nullable;
             import androidx.fragment.app.DialogFragment;
-            
             public class TestFragment extends Fragment {
-            
                 @Nullable
                 @Override
                 public View onCreateView(@NonNull LayoutInflater inflater, 
@@ -134,9 +127,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.NonNull
             import androidx.annotation.Nullable
             import androidx.fragment.app.DialogFragment
-            
             class TestFragment : DialogFragment() {
-
                 override fun onCreateView(inflater: LayoutInflater, 
                                             container: ViewGroup?, 
                                             savedInstanceState: Bundle?): View? {
@@ -157,9 +148,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             import androidx.annotation.NonNull
             import androidx.annotation.Nullable
             import androidx.fragment.app.DialogFragment
-            
             class TestFragment : Fragment() {
-
                 fun someFunction() {
                     val li = LayoutInflater.from(requireContext())
                 }
@@ -173,7 +162,7 @@ class UseGetLayoutInflaterTest : LintDetectorTest() {
             .run()
             .expect(
                 """
-src/foo/TestFragment.java:18: Warning: Use of LayoutInflater.from(requireContext()) detected. Consider using getLayoutInflater() instead [UseGetLayoutInflater]
+src/foo/TestFragment.java:16: Warning: Use of LayoutInflater.from(requireContext()) detected. Consider using getLayoutInflater() instead [UseGetLayoutInflater]
         LayoutInflater li = LayoutInflater.from(requireContext());
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 0 errors, 1 warnings
@@ -182,8 +171,8 @@ src/foo/TestFragment.java:18: Warning: Use of LayoutInflater.from(requireContext
             .expectWarningCount(1)
             .expectFixDiffs(
                 """
-                    Fix for src/foo/TestFragment.java line 18: Replace with getLayoutInflater():
-                    @@ -18 +18
+                    Fix for src/foo/TestFragment.java line 16: Replace with getLayoutInflater():
+                    @@ -16 +16
                     -         LayoutInflater li = LayoutInflater.from(requireContext());
                     +         LayoutInflater li = getLayoutInflater();
                 """.trimIndent()
@@ -210,7 +199,7 @@ src/foo/TestFragment.java:18: Warning: Use of LayoutInflater.from(requireContext
             .run()
             .expect(
                 """
-src/foo/TestFragment.kt:15: Warning: Use of LayoutInflater.from(Context) detected. Consider using layoutInflater instead [UseGetLayoutInflater]
+src/foo/TestFragment.kt:13: Warning: Use of LayoutInflater.from(Context) detected. Consider using layoutInflater instead [UseGetLayoutInflater]
         val li = LayoutInflater.from(requireContext())
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 0 errors, 1 warnings

--- a/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
+++ b/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.fragment.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+/* ktlint-enable max-line-length */
+/* ktlint-disable max-line-length */
+@RunWith(JUnit4::class)
+class UseGetLayoutInflaterTest : LintDetectorTest() {
+
+    override fun getDetector(): Detector = UseGetLayoutInflater()
+
+    override fun getIssues(): MutableList<Issue> = mutableListOf(UseGetLayoutInflater.ISSUE)
+
+    private val dialogFragmentStubJava = java(
+        """
+            package foo;
+            import android.os.Bundle;
+            import android.view.LayoutInflater;
+            import android.view.LayoutInflater123;
+            import android.view.View;
+            import android.view.ViewGroup;
+            import androidx.annotation.NonNull;
+            import androidx.annotation.Nullable;
+            import androidx.fragment.app.DialogFragment;
+            
+            public class TestFragment extends DialogFragment {
+            
+                @Nullable
+                @Override
+                public View onCreateView(@NonNull LayoutInflater inflater, 
+                                            @Nullable ViewGroup container, 
+                                            @Nullable Bundle savedInstanceState) {
+                    LayoutInflater li = LayoutInflater.from(requireContext());
+                    
+                    // this  will not be triggered
+                    LayoutInflater123 li123 = LayoutInflater123.from(requireContext()); 
+                    return super.onCreateView(inflater, container, savedInstanceState);
+                }
+            }
+            """
+    ).indented()
+
+    private val fragmentStubJava = java(
+        """
+            package foo;
+            import android.os.Bundle;
+            import android.view.LayoutInflater;
+            import android.view.View;
+            import android.view.ViewGroup;
+            import androidx.annotation.NonNull;
+            import androidx.annotation.Nullable;
+            import androidx.fragment.app.DialogFragment;
+            
+            public class TestFragment extends Fragment {
+            
+                @Nullable
+                @Override
+                public View onCreateView(@NonNull LayoutInflater inflater, 
+                                            @Nullable ViewGroup container, 
+                                            @Nullable Bundle savedInstanceState) {
+                    LayoutInflater li = LayoutInflater.from(requireContext());
+                    return super.onCreateView(inflater, container, savedInstanceState);
+                }
+            }
+            """
+    ).indented()
+
+    private val dialogFragmentStubKotlin = kotlin(
+        """
+            package foo
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.annotation.NonNull
+            import androidx.annotation.Nullable
+            import androidx.fragment.app.DialogFragment
+            
+            class TestFragment : DialogFragment() {
+
+                override fun onCreateView(inflater: LayoutInflater, 
+                                            container: ViewGroup?, 
+                                            savedInstanceState: Bundle?): View? {
+                    val li = LayoutInflater.from(requireContext())
+                    return super.onCreateView(inflater, container, savedInstanceState)
+                }
+            }
+            """
+    ).indented()
+
+    private val fragmentStubKotlin = kotlin(
+        """
+            package foo
+            import android.os.Bundle
+            import android.view.LayoutInflater
+            import android.view.View
+            import android.view.ViewGroup
+            import androidx.annotation.NonNull
+            import androidx.annotation.Nullable
+            import androidx.fragment.app.DialogFragment
+            
+            class TestFragment : Fragment() {
+
+                fun someFunction() {
+                    val li = LayoutInflater.from(requireContext())
+                }
+            }
+            """
+    ).indented()
+
+    @Test
+    fun `pass java check`() {
+        lint().files(dialogFragmentStubJava)
+            .run()
+            .expect(
+                """
+src/foo/TestFragment.java:18: Warning: Use of LayoutInflater.from(requireContext()) detected. Consider using getLayoutInflater() instead [UseGetLayoutInflater]
+        LayoutInflater li = LayoutInflater.from(requireContext());
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+0 errors, 1 warnings
+            """
+            )
+            .expectWarningCount(1)
+            .expectFixDiffs(
+                """
+                    Fix for src/foo/TestFragment.java line 18: Replace with getLayoutInflater():
+                    @@ -18 +18
+                    -         LayoutInflater li = LayoutInflater.from(requireContext());
+                    +         LayoutInflater li = getLayoutInflater();
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `pass java check without dialog fragment`() {
+        lint().files(fragmentStubJava)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `pass kotlin check`() {
+        lint().files(dialogFragmentStubKotlin)
+            .run()
+            .expect(
+                """
+src/foo/TestFragment.kt:15: Warning: Use of LayoutInflater.from(Context) detected. Consider using layoutInflater instead [UseGetLayoutInflater]
+        val li = LayoutInflater.from(requireContext())
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+0 errors, 1 warnings
+            """
+            )
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun `pass kotlin check without dialog fragment`() {
+        lint().files(fragmentStubKotlin)
+            .run()
+            .expectClean()
+    }
+
+}

--- a/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
+++ b/fragment/fragment-lint/src/test/java/androidx/fragment/lint/UseGetLayoutInflaterTest.kt
@@ -232,5 +232,4 @@ src/foo/TestFragment.kt:15: Warning: Use of LayoutInflater.from(Context) detecte
             .run()
             .expectClean()
     }
-
 }


### PR DESCRIPTION
## Proposed Changes

Lint check for detecting calls to `android.view.LayoutInflater.from` while being invoked from DialogFragment.
For Java it allows autofix but for Kotlin it does not, just shows the lint warning. For Kotlin I could not get arguments which is passed to `from` method to create proper autofix. Java PSI is much easier for such tasks.

## Testing

Test:  ./gradlew fragment:fragment-lint:test

## Issues Fixed

Implements: The feature request on [https://issuetracker.google.com/issues/170781346](https://issuetracker.google.com/issues/170781346) being implemented
