### PR TITLE
Add support for Firebase Test Lab

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -569,6 +569,25 @@ jobs:
           name: artifacts_${{ env.artifact-id }}
           path: ~/dist
 
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+      - name: "Run application tests on Firebase Test Lab"
+        uses: eskatos/gradle-command-action@v1
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+        with:
+          arguments: firebaseTestLabTests ${{ needs.setup.outputs.gradlew_flags }}
+          build-root-directory: ${{ env.project-root }}
+          configuration-cache-enabled: true
+          dependencies-cache-enabled: true
+          gradle-executable: ${{ env.project-root }}/gradlew
+          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
+          wrapper-cache-enabled: true
+
       - name: "Report job status"
         id: output-status
         if: always()

--- a/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/AndroidXPlaygroundRootPlugin.kt
@@ -17,6 +17,7 @@
 package androidx.build
 
 import androidx.build.AndroidXRootPlugin.Companion.PROJECT_OR_ARTIFACT_EXT_NAME
+import androidx.build.ftl.FirebaseTestLabHelper
 import androidx.build.gradle.getByType
 import androidx.build.gradle.isRoot
 import com.android.build.gradle.LibraryExtension
@@ -70,8 +71,9 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
         config = PlaygroundProperties.load(rootProject)
         repos = PlaygroundRepositories(config)
         rootProject.repositories.addPlaygroundRepositories()
+        val ftlUtilities = FirebaseTestLabHelper(target)
         rootProject.subprojects {
-            configureSubProject(it)
+            configureSubProject(it, ftlUtilities)
         }
 
         // TODO(b/185539993): Re-enable InvalidFragmentVersionForActivityResult which was
@@ -97,7 +99,10 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
         }
     }
 
-    private fun configureSubProject(project: Project) {
+    private fun configureSubProject(
+        project: Project,
+        firebaseTestLabHelper: FirebaseTestLabHelper
+    ) {
         project.repositories.addPlaygroundRepositories()
         project.extra.set(PROJECT_OR_ARTIFACT_EXT_NAME, projectOrArtifactClosure)
         project.configurations.all { configuration ->
@@ -105,6 +110,7 @@ class AndroidXPlaygroundRootPlugin : Plugin<Project> {
                 substitution.replaceIfSnapshot()
             }
         }
+        firebaseTestLabHelper.setupFTL(project)
     }
 
     /**

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build.ftl
+
+import androidx.build.gradle.isRoot
+import com.android.build.gradle.TestedExtension
+import com.android.build.gradle.internal.tasks.factory.dependsOn
+import org.gradle.api.Project
+
+/**
+ * Helper class to setup Firebase Test Lab for instrumentation tests
+ */
+internal class FirebaseTestLabHelper(
+    private val rootProject: Project
+) {
+    init {
+        check(rootProject.isRoot) {
+            "FTL Utilities can only be created for root projects"
+        }
+    }
+
+    private val anchorTask by lazy {
+        rootProject.tasks.register(ANCHOR_TASK_NAME) {
+            it.description = "Anchor task that depends on all firebase test lab tests"
+            it.group = "Verification"
+        }
+    }
+
+    fun setupFTL(project: Project) {
+        AGP_PLUGIN_IDS.forEach { agpPluginId ->
+            // using base plugin at this stage does not work as base plugin is applied before the
+            // Android Extension is created.
+            // see the comment on [AGP_PLUGIN_IDS] for details.
+            project.pluginManager.withPlugin(agpPluginId) {
+                project.extensions.findByType(TestedExtension::class.java)?.let {
+                    configure(project, it)
+                }
+            }
+        }
+    }
+
+    private fun configure(project: Project, testedExtension: TestedExtension) {
+        testedExtension.testVariants.all { testVariant ->
+            RunTestOnFTLTask.create(project, testVariant)?.let { ftlTask ->
+                anchorTask.dependsOn(ftlTask)
+            }
+        }
+    }
+
+    companion object {
+        const val ANCHOR_TASK_NAME = "firebaseTestLabTests"
+        /**
+         * AGP base plugin is applied before the extension is created so instead we use plugin
+         * ids here.
+         * see: https://github.com/google/ksp/issues/314
+         * see: https://github.com/google/ksp/pull/318
+         */
+        private val AGP_PLUGIN_IDS = listOf(
+            "com.android.application",
+            "com.android.library",
+            "com.android.dynamic-feature"
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
@@ -63,6 +63,7 @@ internal class FirebaseTestLabHelper(
 
     companion object {
         const val ANCHOR_TASK_NAME = "firebaseTestLabTests"
+
         /**
          * AGP base plugin is applied before the extension is created so instead we use plugin
          * ids here.

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/FirebaseTestLabHelper.kt
@@ -71,8 +71,10 @@ internal class FirebaseTestLabHelper(
          */
         private val AGP_PLUGIN_IDS = listOf(
             "com.android.application",
-            "com.android.library",
-            "com.android.dynamic-feature"
+            // TODO enable library and dynamic feature when we can synthesize
+            //  an APK for them
+            //  "com.android.library",
+            //  "com.android.dynamic-feature"
         )
     }
 }

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -19,7 +19,7 @@ package androidx.build.ftl
 import com.google.gson.Gson
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
-import org.gradle.api.Project
+import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.util.Locale
@@ -34,8 +34,9 @@ import java.util.Locale
  * documentation for FTL:
  * https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
  */
+@Suppress("UnstableApiUsage") // ExecOperations
 internal class GCloudCLIWrapper(
-    private val rootProject: Project
+    private val execOperations: ExecOperations
 ) {
     private val gson = Gson()
 
@@ -44,7 +45,7 @@ internal class GCloudCLIWrapper(
      */
     private val executable: String by lazy {
         val output = ByteArrayOutputStream()
-        rootProject.exec {
+        execOperations.exec {
             it.commandLine("which", "gcloud")
             it.standardOutput = output
             it.errorOutput = System.err
@@ -56,7 +57,7 @@ internal class GCloudCLIWrapper(
         vararg params: String
     ): T {
         val output = ByteArrayOutputStream()
-        rootProject.exec {
+        execOperations.exec {
             it.executable = executable
             it.args = params.toList() + "--format=json"
             it.standardOutput = output

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -104,7 +104,11 @@ internal class GCloudCLIWrapper(
         val testDetails: String
     ) {
         val passed
-            get() = outcome.toLowerCase(Locale.US) == "passed"
+            get() = outcome.toLowerCase(Locale.US) in SUCCESS_OUTCOMES
+
+        companion object {
+            private val SUCCESS_OUTCOMES = listOf("passed", "flaky")
+        }
     }
 }
 

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build.ftl
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
+import org.gradle.api.Project
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.Locale
+
+/**
+ * Wrapper around GCloud CLI.
+ *
+ * https://cloud.google.com/sdk/gcloud
+ *
+ * Note that this wrapper requires gcloud to be available on the host machine.
+ *
+ * documentation for FTL:
+ * https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+ */
+internal class GCloudCLIWrapper(
+    private val rootProject: Project
+) {
+    private val gson = Gson()
+
+    /**
+     * Path to the gcloud executable, derived from `which gcloud` call.
+     */
+    private val executable: String by lazy {
+        val output = ByteArrayOutputStream()
+        rootProject.exec {
+            it.commandLine("which", "gcloud")
+            it.standardOutput = output
+            it.errorOutput = System.err
+        }
+        output.toString(Charsets.UTF_8).trim()
+    }
+
+    private inline fun <reified T> executeGcloud(
+        vararg params: String
+    ): T {
+        val output = ByteArrayOutputStream()
+        rootProject.exec {
+            it.executable = executable
+            it.args = params.toList() + "--format=json"
+            it.standardOutput = output
+        }
+        val commandOutput = output.toString(Charsets.UTF_8)
+        return gson.parse(commandOutput)
+    }
+
+    /**
+     * https://cloud.google.com/sdk/gcloud/reference/firebase/test/android/run
+     */
+    fun runTest(
+        testedApk: File,
+        testApk: File
+    ) : List<TestResult> {
+        return executeGcloud(
+            "firebase", "test", "android", "run",
+            "--type", "instrumentation",
+            "--test", testApk.canonicalPath,
+            "--app", testedApk.canonicalPath,
+            "--num-flaky-test-attempts", "3",
+        )
+    }
+
+
+    /**
+     * Data structure format for gcloud FTL command
+     */
+    internal data class TestResult(
+        @SerializedName("axis_value")
+        val axisValue: String,
+        val outcome: String,
+        @SerializedName("test_details")
+        val testDetails: String
+    ) {
+        val passed
+            get() = outcome.toLowerCase(Locale.US) == "passed"
+    }
+}
+
+private inline fun<reified T> Gson.parse(
+    input: String
+): T {
+    val typeToken = object: TypeToken<T>() {}.type
+    return this.fromJson(input, typeToken)
+}

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -51,13 +51,13 @@ abstract class RunTestOnFTLTask @Inject constructor(
     /**
      * The test APK for the instrumentation test.
      */
-    @get:[InputFile PathSensitive(PathSensitivity.RELATIVE)]
+    @get:[InputFile PathSensitive(PathSensitivity.NONE)]
     abstract val testApk: RegularFileProperty
 
     /**
      * The tested application APK.
      */
-    @get:[InputFile PathSensitive(PathSensitivity.RELATIVE)]
+    @get:[InputFile PathSensitive(PathSensitivity.NONE)]
     abstract val testedApk: RegularFileProperty
 
     /**

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build.ftl
+
+import com.android.build.gradle.api.ApkVariantOutput
+import com.android.build.gradle.api.LibraryVariant
+import com.android.build.gradle.api.TestVariant
+import com.google.gson.Gson
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Task to run instrumentation tests on FTL.
+ *
+ * This task is only enabled on playground projects and requires gcloud CLI to be available on
+ * the device with the right permissions.
+ *
+ * Due to the limitations of FTL, this task only support application instrumentation tests for now.
+ */
+@Suppress("UnstableApiUsage") // for gradle property APIs
+abstract class RunTestOnFTLTask : DefaultTask() {
+    /**
+     * The test APK for the instrumentation test.
+     */
+    @InputFile
+    val testApk: RegularFileProperty = project.objects.fileProperty()
+
+    /**
+     * The tested application APK.
+     */
+    @InputFile
+    val testedApk: RegularFileProperty = project.objects.fileProperty()
+
+    /**
+     * Output file to write the results
+     */
+    @OutputFile
+    val testResults: RegularFileProperty = project.objects.fileProperty()
+    @TaskAction
+    fun executeTest() {
+        val testApk = testApk.asFile.get()
+        val testedApk = testedApk.asFile.get()
+        println(testApk.path + "/" + testedApk.path)
+        val gcloud = GCloudCLIWrapper(project)
+        val result = gcloud.runTest(
+            testedApk = testedApk,
+            testApk = testApk
+        )
+        val outFile = testResults.asFile.get()
+        outFile.parentFile.mkdirs()
+        val gson = Gson()
+        outFile.bufferedWriter(Charsets.UTF_8).use {
+            gson.toJson(
+                result,
+                it
+            )
+        }
+        val failed = result.filterNot {
+            it.passed
+        }
+        if (failed.isNotEmpty()) {
+            throw GradleException("These tests failed: $failed")
+        }
+    }
+
+    companion object {
+        private const val TASK_SUFFIX = "OnFirebaseTestLab"
+        private const val TEST_OUTPUT_FILE_NAME = "testResults.json"
+
+        /**
+         * Creates an FTL test runner task and returns it.
+         * Note that only application tests are supported hence this will return `null` for
+         * library projects.
+         */
+        fun create(project: Project, testVariant: TestVariant): TaskProvider<RunTestOnFTLTask>? {
+            if (testVariant.testedVariant is LibraryVariant) {
+                // TODO add support for library project, which might require synthesizing another
+                //  APK :facepalm:
+                // see: // https://stackoverflow.com/questions/59827750/execute-instrumented-test-for-an-android-library-with-firebase-test-lab
+                return null
+            }
+            val taskName = testVariant.name + TASK_SUFFIX
+            return project.tasks.register(taskName, RunTestOnFTLTask::class.java) { task ->
+                task.description = "Run ${testVariant.name} tests on Firebase Test Lab"
+                task.group = "Verification"
+                task.testResults.set(
+                    project.layout.buildDirectory.dir(
+                        "ftl-results"
+                    ).map {
+                        it.file(TEST_OUTPUT_FILE_NAME)
+                    }
+                )
+                task.dependsOn(testVariant.assembleProvider)
+                task.dependsOn(testVariant.testedVariant.assembleProvider)
+                testVariant.outputs.withType(ApkVariantOutput::class.java).firstOrNull()
+                task.testApk.set(
+                    testVariant.outputs.withType(ApkVariantOutput::class.java).firstOrNull()
+                        ?.outputFile
+                )
+                task.testedApk.set(
+                    testVariant.testedVariant.outputs
+                        .withType(ApkVariantOutput::class.java)
+                        .firstOrNull()
+                        ?.outputFile
+                )
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -63,8 +63,9 @@ abstract class RunTestOnFTLTask @Inject constructor(
     /**
      * Output file to write the results
      */
-    @get:[OutputFile PathSensitive(PathSensitivity.RELATIVE)]
+    @get:OutputFile
     abstract val testResults: RegularFileProperty
+
     @TaskAction
     fun executeTest() {
         workerExecutor.noIsolation().submit(

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -85,7 +85,7 @@ abstract class RunTestOnFTLTask @Inject constructor(
 
     abstract class RunFTLTestWorkAction @Inject constructor(
         private val execOperations: ExecOperations
-    ): WorkAction<RunFTLTestParams> {
+    ) : WorkAction<RunFTLTestParams> {
         override fun execute() {
             val testApk = parameters.testApk.asFile.get()
             val testedApk = parameters.testedApk.asFile.get()


### PR DESCRIPTION
This CL introduces a basic setup in AndroidX to run instrumentation
tests on Firebase Test Lab.

This is limited to only application tests for now because FTL requires
two APKs. We can probably work around it if we want to start using FTL
extensively.

Bug: n/a
Test: not sure how to test this so for now, none :)