### PR TITLE
[Navigation] Make trailing slash in deep links not required

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1111,4 +1111,24 @@ class NavDeepLinkTest {
             .that(matchArgs?.isEmpty)
             .isTrue()
     }
+
+    @Test
+    fun deepLinkWithTrailingSlash() {
+        val deepLinkString = "$DEEP_LINK_EXACT_HTTP/users/"
+        val deepLink = NavDeepLink(deepLinkString)
+
+        assertWithMessage("Should match to link without trailing slash")
+            .that(deepLink.matches(Uri.parse(deepLinkString.trimEnd('/'))))
+            .isTrue()
+    }
+
+    @Test
+    fun deepLinkWithoutTrailingSlash() {
+        val deepLinkString = "$DEEP_LINK_EXACT_HTTP/users"
+        val deepLink = NavDeepLink(deepLinkString)
+
+        assertWithMessage("Should match to link with trailing slash")
+            .that(deepLink.matches(Uri.parse("$deepLinkString/")))
+            .isTrue()
+    }
 }

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -85,8 +85,10 @@ public class NavDeepLink internal constructor(
         }
         if (appendPos < uri.length) {
             // Use Pattern.quote() to treat the input string as a literal
-            uriRegex.append(Pattern.quote(uri.substring(appendPos)))
+            // Also remove trailing slashes if it exists so it should be optional
+            uriRegex.append(Pattern.quote(uri.substring(appendPos).trimEnd('/')))
         }
+        uriRegex.append("/?")
         // Match either the end of string if all params are optional or match the
         // question mark and 0 or more characters after it
         // We do not use '.*' here because the finalregex would replace it with a quoted


### PR DESCRIPTION
## Proposed Changes

Allow deep link: `myapp://example.io/messages/`  
To match both of the links:
- `myapp://example.io/messages/`
- `myapp://example.io/messages`

If a deep link pattern contains a trailing slash, make it not required.
If a deep link pattern does not contain a trailing slash, add `\?` to the pattern.

## Testing

Corresponding tests added to NavDeepLinkTest
Test: ./gradlew test connectedCheck

## Issues Fixed

https://issuetracker.google.com/issues/185532465
Fixes: 185532465
