### PR TITLE
[Lifecycle] [Lint] fixes b/184830263 Lint should use check reference too

### DIFF
--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/main/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetector.kt
@@ -30,6 +30,8 @@ import com.android.tools.lint.detector.api.UastLintUtils
 import com.android.tools.lint.detector.api.isKotlin
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiVariable
+import com.intellij.psi.impl.source.PsiImmediateClassType
+import org.jetbrains.kotlin.asJava.elements.KtLightTypeParameter
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
@@ -94,15 +96,26 @@ class NonNullableMutableLiveDataDetector : Detector(), UastScanner {
             }
 
             private fun getFieldTypeReference(element: KotlinUField): KtTypeReference? {
-                // We need to extract type from the expression
+                // If field has type reference, we need to use type reference
+                // Given the field `val liveDataField: MutableLiveData<Boolean> = MutableLiveData()`
+                // reference: `MutableLiveData<Boolean>`
+                // argument: `Boolean`
+                val typeReference = element.sourcePsi
+                    ?.children
+                    ?.firstOrNull { it is KtTypeReference } as? KtTypeReference
+                val typeArgument = typeReference?.typeElement?.typeArgumentsAsTypes?.singleOrNull()
+                if (typeArgument != null) {
+                    return typeArgument
+                }
+
+                // We need to extract type from the call expression
                 // Given the field `val liveDataField = MutableLiveData<Boolean>()`
                 // expression: `MutableLiveData<Boolean>()`
                 // argument: `Boolean`
                 val expression = element.sourcePsi
                     ?.children
                     ?.firstOrNull { it is KtCallExpression } as? KtCallExpression
-                val argument = expression?.typeArguments?.singleOrNull()
-                return argument?.typeReference
+                return expression?.typeArguments?.singleOrNull()?.typeReference
             }
 
             override fun visitCallExpression(node: UCallExpression) {
@@ -170,6 +183,9 @@ class NonNullableMutableLiveDataDetector : Detector(), UastScanner {
         context: JavaContext,
         node: UCallExpression
     ) {
+        // ignore generic types
+        if (node.isGenericTypeDefinition()) return
+
         if (liveDataType.typeElement !is KtNullableType) {
             val fixes = mutableListOf<LintFix>()
             if (context.getLocation(liveDataType).file == context.file) {
@@ -196,6 +212,12 @@ class NonNullableMutableLiveDataDetector : Detector(), UastScanner {
                 checkNullability(context, argument, "Expected non-nullable value", fixes)
             }
         }
+    }
+
+    private fun UCallExpression.isGenericTypeDefinition(): Boolean {
+        val classType = typeArguments.singleOrNull() as? PsiImmediateClassType
+        val resolveGenerics = classType?.resolveGenerics()
+        return resolveGenerics?.element is KtLightTypeParameter
     }
 
     /**

--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
@@ -793,7 +793,7 @@ Fix for src/com/example/MyClass2.kt line 30: Change `LiveData` type to nullable:
                 ) {
                 
                     fun foo(value: T) {
-                        target.value = value
+                        target.value = null
                     }
                 }
             """

--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
@@ -199,7 +199,7 @@ src/com/example/test.kt:8: Error: Cannot set non-nullable LiveData value to null
                 import androidx.lifecycle.MutableLiveData
 
                 val liveDataField = MutableLiveData<Boolean>()
-                val secondLiveDataField: MutableLiveData<String> = MutableLiveData() 
+                val secondLiveDataField: MutableLiveData<String> = MutableLiveData()
                 val thirdLiveDataField: MutableLiveData<String> = MutableLiveData<String>("Value")
 
                 fun foo() {
@@ -791,7 +791,7 @@ Fix for src/com/example/MyClass2.kt line 30: Change `LiveData` type to nullable:
                 class Foo<T>(
                     var target: MutableLiveData<T>
                 ) {
-                
+
                     fun foo(value: T) {
                         target.value = null
                     }

--- a/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
+++ b/lifecycle/lifecycle-livedata-core-ktx-lint/src/test/java/androidx/lifecycle/lint/NonNullableMutableLiveDataDetectorTest.kt
@@ -199,23 +199,28 @@ src/com/example/test.kt:8: Error: Cannot set non-nullable LiveData value to null
                 import androidx.lifecycle.MutableLiveData
 
                 val liveDataField = MutableLiveData<Boolean>()
-                val secondLiveDataField = MutableLiveData<String>()
+                val secondLiveDataField: MutableLiveData<String> = MutableLiveData() 
+                val thirdLiveDataField: MutableLiveData<String> = MutableLiveData<String>("Value")
 
                 fun foo() {
                     liveDataField.value = null
                     secondLiveDataField.value = null
+                    thirdLiveDataField.value = null
                 }
             """
             ).indented()
         ).expect(
             """
-src/com/example/test.kt:9: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+src/com/example/test.kt:10: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
     liveDataField.value = null
                           ~~~~
-src/com/example/test.kt:10: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+src/com/example/test.kt:11: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
     secondLiveDataField.value = null
                                 ~~~~
-2 errors, 0 warnings
+src/com/example/test.kt:12: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData]
+    thirdLiveDataField.value = null
+                               ~~~~
+3 errors, 0 warnings
         """
         )
     }
@@ -754,6 +759,41 @@ Fix for src/com/example/MyClass2.kt line 30: Change `LiveData` type to nullable:
                 val foo = object : LiveData<Int>() {
                     private fun bar() {
                         value = 0
+                    }
+                }
+            """
+            ).indented()
+        ).expectClean()
+    }
+
+    @Test
+    fun justKotlinObject() {
+        check(
+            kotlin(
+                """
+                package com.example
+
+                object Foo
+            """
+            ).indented()
+        ).expectClean()
+    }
+
+    @Test
+    fun genericParameterDefinition() {
+        check(
+            kotlin(
+                """
+                package com.example
+
+                import androidx.lifecycle.MutableLiveData
+
+                class Foo<T>(
+                    var target: MutableLiveData<T>
+                ) {
+                
+                    fun foo(value: T) {
+                        target.value = value
                     }
                 }
             """


### PR DESCRIPTION
## Proposed Changes

  - Fix NonNullableMutableLiveDataDetector for  [different cases](https://issuetracker.google.com/issues/184830263). It is possible to only set type reference and omit call's generic argument. 
  -  Added check for generic values because default upper bound of generic (if none specified) is Any?.  If generic is not specified as `<T : Any>`, `T` can be defined null at call site. https://kotlinlang.org/docs/generics.html#upper-bounds 
  

## Testing 

Test: Run NonNullableMutableLiveDataDetectorTest with new edge cases.
`nullLiteralFailMultipleFields` : Added type reference
`justKotlinObject` : Add additional test to prevent ArrayIndexOutOfBoundsException. It is fixed in https://github.com/androidx/androidx/commit/428f0ec685ff80035c0511c0cdb12b9770b6159c but not tested. It is reported here with [b/184830262](https://issuetracker.google.com/issues/184830262)
`genericParameterDefinition` : Generics are assumed as nullable, lint should ignore.

## Issues Fixed

Fixes: The bug on [b/184830263](https://issuetracker.google.com/issues/184830263) being fixed
Fixes: Tests [b/184830262](https://issuetracker.google.com/issues/184830263) 
