### PR TITLE
[Room][Compiler Processing] Adds configuration to define processor target language

### DIFF
--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -22,16 +22,21 @@ import javax.lang.model.SourceVersion
 @Suppress("VisibleForTests")
 @ExperimentalProcessingApi
 class SyntheticJavacProcessor private constructor(
-    private val impl: SyntheticProcessorImpl
+    private val impl: SyntheticProcessorImpl,
+    private val targetLanguage: XProcessingEnv.Language
 ) : JavacTestProcessor(), SyntheticProcessor by impl {
-    constructor(handlers: List<(XTestInvocation) -> Unit>) : this(
-        SyntheticProcessorImpl(handlers)
+    constructor(
+        handlers: List<(XTestInvocation) -> Unit>,
+        targetLanguage: XProcessingEnv.Language
+    ) : this(
+        SyntheticProcessorImpl(handlers),
+        targetLanguage
     )
     override fun doProcess(annotations: Set<XTypeElement>, roundEnv: XRoundEnv): Boolean {
         if (!impl.canRunAnotherRound()) {
             return true
         }
-        val xEnv = XProcessingEnv.create(processingEnv)
+        val xEnv = XProcessingEnv.create(processingEnv, targetLanguage)
         val testInvocation = XTestInvocation(
             processingEnv = xEnv,
             roundEnv = roundEnv

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
@@ -56,7 +56,8 @@ class SyntheticKspProcessor private constructor(
             options,
             resolver,
             codeGenerator,
-            logger
+            logger,
+            XProcessingEnv.Language.JAVA
         )
         val testInvocation = XTestInvocation(
             processingEnv = xEnv,

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
@@ -25,10 +25,15 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 
 @ExperimentalProcessingApi
 class SyntheticKspProcessor private constructor(
-    private val impl: SyntheticProcessorImpl
+    private val impl: SyntheticProcessorImpl,
+    private val targetLanguage: XProcessingEnv.Language
 ) : SymbolProcessor, SyntheticProcessor by impl {
-    constructor(handlers: List<(XTestInvocation) -> Unit>) : this(
-        SyntheticProcessorImpl(handlers)
+    constructor(
+        handlers: List<(XTestInvocation) -> Unit>,
+        targetLanguage: XProcessingEnv.Language
+    ) : this(
+        SyntheticProcessorImpl(handlers),
+        targetLanguage
     )
 
     private lateinit var options: Map<String, String>
@@ -57,7 +62,7 @@ class SyntheticKspProcessor private constructor(
             resolver,
             codeGenerator,
             logger,
-            XProcessingEnv.Language.JAVA
+            targetLanguage
         )
         val testInvocation = XTestInvocation(
             processingEnv = xEnv,

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing.util
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.util.runner.CompilationTestRunner
@@ -81,6 +82,7 @@ fun runProcessorTestWithoutKsp(
     sources: List<Source> = emptyList(),
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) {
     runTests(
@@ -88,6 +90,7 @@ fun runProcessorTestWithoutKsp(
             sources = sources,
             classpath = classpath,
             options = options,
+            targetLanguage = targetLanguage,
             handlers = listOf(handler)
         ),
         JavacCompilationTestRunner,
@@ -115,11 +118,13 @@ fun runProcessorTest(
     sources: List<Source> = emptyList(),
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) = runProcessorTest(
     sources = sources,
     classpath = classpath,
     options = options,
+    targetLanguage = targetLanguage,
     handlers = listOf(handler)
 )
 
@@ -141,13 +146,15 @@ fun runProcessorTest(
     sources: List<Source> = emptyList(),
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     createProcessingStep: () -> XProcessingStep,
     onCompilationResult: (CompilationResultSubject) -> Unit
 ) {
     runProcessorTest(
         sources = sources,
         classpath = classpath,
-        options = options
+        options = options,
+        targetLanguage = targetLanguage
     ) { invocation ->
         val step = createProcessingStep()
         val elements =
@@ -173,6 +180,7 @@ fun runProcessorTest(
     sources: List<Source> = emptyList(),
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
     val javaApRunner = if (sources.any { it is Source.KotlinSource }) {
@@ -185,6 +193,7 @@ fun runProcessorTest(
             sources = sources,
             classpath = classpath,
             options = options,
+            targetLanguage = targetLanguage,
             handlers = handlers
         ),
         javaApRunner,
@@ -202,11 +211,13 @@ fun runJavaProcessorTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) = runJavaProcessorTest(
     sources = sources,
     classpath = classpath,
     options = options,
+    targetLanguage = targetLanguage,
     handlers = listOf(handler)
 )
 
@@ -218,6 +229,7 @@ fun runJavaProcessorTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
     runTests(
@@ -225,6 +237,7 @@ fun runJavaProcessorTest(
             sources = sources,
             classpath = classpath,
             options = options,
+            targetLanguage = targetLanguage,
             handlers = handlers
         ),
         JavacCompilationTestRunner
@@ -239,11 +252,13 @@ fun runKaptTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) = runKaptTest(
     sources = sources,
     classpath = classpath,
     options = options,
+    targetLanguage = targetLanguage,
     handlers = listOf(handler)
 )
 
@@ -255,6 +270,7 @@ fun runKaptTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
     runTests(
@@ -262,6 +278,7 @@ fun runKaptTest(
             sources = sources,
             classpath = classpath,
             options = options,
+            targetLanguage = targetLanguage,
             handlers = handlers
         ),
         KaptCompilationTestRunner
@@ -276,11 +293,13 @@ fun runKspTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) = runKspTest(
     sources = sources,
     classpath = classpath,
     options = options,
+    targetLanguage = targetLanguage,
     handlers = listOf(handler)
 )
 
@@ -292,6 +311,7 @@ fun runKspTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
+    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
     runTests(
@@ -299,6 +319,7 @@ fun runKspTest(
             sources = sources,
             classpath = classpath,
             options = options,
+            targetLanguage = targetLanguage,
             handlers = handlers
         ),
         KspCompilationTestRunner

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/ProcessorTestExt.kt
@@ -183,7 +183,10 @@ fun runProcessorTest(
     targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
-    val javaApRunner = if (sources.any { it is Source.KotlinSource }) {
+    val javaApRunner = if (
+        sources.any { it is Source.KotlinSource } ||
+        targetLanguage == XProcessingEnv.Language.KOTLIN
+    ) {
         KaptCompilationTestRunner
     } else {
         JavacCompilationTestRunner
@@ -211,13 +214,11 @@ fun runJavaProcessorTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
-    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handler: (XTestInvocation) -> Unit
 ) = runJavaProcessorTest(
     sources = sources,
     classpath = classpath,
     options = options,
-    targetLanguage = targetLanguage,
     handlers = listOf(handler)
 )
 
@@ -229,7 +230,6 @@ fun runJavaProcessorTest(
     sources: List<Source>,
     classpath: List<File> = emptyList(),
     options: Map<String, String> = emptyMap(),
-    targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     handlers: List<(XTestInvocation) -> Unit>
 ) {
     runTests(
@@ -237,7 +237,7 @@ fun runJavaProcessorTest(
             sources = sources,
             classpath = classpath,
             options = options,
-            targetLanguage = targetLanguage,
+            targetLanguage = XProcessingEnv.Language.JAVA,
             handlers = handlers
         ),
         JavacCompilationTestRunner

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/CompilationTestRunner.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/CompilationTestRunner.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing.util.runner
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.util.CompilationResult
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.XTestInvocation
@@ -40,5 +41,6 @@ internal data class TestCompilationParameters(
     val sources: List<Source> = emptyList(),
     val classpath: List<File> = emptyList(),
     val options: Map<String, String> = emptyMap(),
+    val targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA,
     val handlers: List<(XTestInvocation) -> Unit>
 )

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/JavacCompilationTestRunner.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/JavacCompilationTestRunner.kt
@@ -33,7 +33,10 @@ internal object JavacCompilationTestRunner : CompilationTestRunner {
     }
 
     override fun compile(params: TestCompilationParameters): CompilationResult {
-        val syntheticJavacProcessor = SyntheticJavacProcessor(params.handlers)
+        val syntheticJavacProcessor = SyntheticJavacProcessor(
+            params.handlers,
+            params.targetLanguage
+        )
         val sources = if (params.sources.isEmpty()) {
             // synthesize a source to trigger compilation
             listOf(

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/JavacCompilationTestRunner.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/JavacCompilationTestRunner.kt
@@ -18,10 +18,12 @@ package androidx.room.compiler.processing.util.runner
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
 import androidx.room.compiler.processing.SyntheticJavacProcessor
+import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.util.CompilationResult
 import androidx.room.compiler.processing.util.JavaCompileTestingCompilationResult
 import androidx.room.compiler.processing.util.Source
 import com.google.testing.compile.Compiler
+import org.jetbrains.kotlin.types.model.requireOrDescribe
 
 @ExperimentalProcessingApi
 internal object JavacCompilationTestRunner : CompilationTestRunner {
@@ -33,9 +35,12 @@ internal object JavacCompilationTestRunner : CompilationTestRunner {
     }
 
     override fun compile(params: TestCompilationParameters): CompilationResult {
+        require(params.targetLanguage != XProcessingEnv.Language.KOTLIN) {
+            "Javac processor is not meant to process Kotlin code. Use KAPT instead."
+        }
         val syntheticJavacProcessor = SyntheticJavacProcessor(
             params.handlers,
-            params.targetLanguage
+            XProcessingEnv.Language.JAVA
         )
         val sources = if (params.sources.isEmpty()) {
             // synthesize a source to trigger compilation

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KaptCompilationTestRunner.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KaptCompilationTestRunner.kt
@@ -34,7 +34,10 @@ internal object KaptCompilationTestRunner : CompilationTestRunner {
     }
 
     override fun compile(params: TestCompilationParameters): CompilationResult {
-        val syntheticJavacProcessor = SyntheticJavacProcessor(params.handlers)
+        val syntheticJavacProcessor = SyntheticJavacProcessor(
+            params.handlers,
+            params.targetLanguage
+        )
         val outputStream = ByteArrayOutputStream()
         val compilation = KotlinCompilationUtil.prepareCompilation(
             sources = params.sources,

--- a/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
+++ b/room/compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
@@ -50,7 +50,7 @@ internal object KspCompilationTestRunner : CompilationTestRunner {
         } else {
             params.sources
         }
-        val syntheticKspProcessor = SyntheticKspProcessor(params.handlers)
+        val syntheticKspProcessor = SyntheticKspProcessor(params.handlers, params.targetLanguage)
 
         val combinedOutputStream = ByteArrayOutputStream()
         val kspCompilation = KotlinCompilationUtil.prepareCompilation(

--- a/room/compiler-processing-testing/src/test/java/androidx/room/compiler/processing/util/TestRunnerTest.kt
+++ b/room/compiler-processing-testing/src/test/java/androidx/room/compiler/processing/util/TestRunnerTest.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing.util
 
 import androidx.room.compiler.processing.ExperimentalProcessingApi
+import androidx.room.compiler.processing.XProcessingEnv
 import com.google.common.truth.Truth.assertThat
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.JavaFile
@@ -190,5 +191,111 @@ class TestRunnerTest {
             assertThat(kspResult.exceptionOrNull()).hasMessageThat()
                 .contains(errorMessage)
         }
+    }
+
+    @Test
+    fun targetLanguageIsPassedDown() {
+        val src = Source.java(
+            "test.Foo",
+            """
+            package test;
+            public class Foo { }
+            """.trimIndent()
+        )
+        val handler: (XTestInvocation) -> Unit = { invocation ->
+            assertThat(invocation.processingEnv.targetLanguage)
+                .isEqualTo(XProcessingEnv.Language.JAVA)
+        }
+
+        runProcessorTest(
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handler = handler
+        )
+        runProcessorTest(
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handlers = listOf(handler)
+        )
+        runProcessorTestWithoutKsp(
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handler = handler
+        )
+        runJavaProcessorTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handler = handler
+        )
+        runJavaProcessorTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handlers = listOf(handler)
+        )
+        runKaptTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handler = handler
+        )
+        runKaptTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handlers = listOf(handler)
+        )
+        runKspTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handler = handler
+        )
+        runKspTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.JAVA,
+            handlers = listOf(handler)
+        )
+    }
+
+    @Test
+    fun targetLanguageIsPassedDown_kotlin() {
+        val src = Source.kotlin(
+            "Foo.kt",
+            """
+            package foo
+            class Foo { }
+            """.trimIndent()
+        )
+        val handler: (XTestInvocation) -> Unit = { invocation ->
+            assertThat(invocation.processingEnv.targetLanguage)
+                .isEqualTo(XProcessingEnv.Language.KOTLIN)
+        }
+
+        runProcessorTest(
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handler = handler
+        )
+        runProcessorTest(
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handlers = listOf(handler)
+        )
+        runProcessorTestWithoutKsp(
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handler = handler
+        )
+        runKaptTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handler = handler
+        )
+        runKaptTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handlers = listOf(handler)
+        )
+        runKspTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handler = handler
+        )
+        runKspTest(
+            sources = listOf(src),
+            targetLanguage = XProcessingEnv.Language.KOTLIN,
+            handlers = listOf(handler)
+        )
     }
 }

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -35,7 +35,7 @@ interface XProcessingEnv {
     val backend: Backend
 
     /**
-     * The target language the processor is set to expect
+     * The expected language of the sources to be processed and generated.
      */
     val targetLanguage: Language
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -134,6 +134,11 @@ interface XProcessingEnv {
         KSP
     }
 
+    /**
+     * The target language for XProcessingEnv.
+     * This value controls certain logic when processing code,
+     * see the documentation for [XProcessingEnv.targetLanguage] for details.
+     */
     enum class Language {
         JAVA,
         KOTLIN

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -33,6 +33,12 @@ import kotlin.reflect.KClass
 interface XProcessingEnv {
 
     val backend: Backend
+
+    /**
+     * The target language the processor is set to expect
+     */
+    val targetLanguage: Language
+
     /**
      * The logger interface to log messages
      */
@@ -128,12 +134,20 @@ interface XProcessingEnv {
         KSP
     }
 
+    enum class Language {
+        JAVA,
+        KOTLIN
+    }
+
     companion object {
         /**
          * Creates a new [XProcessingEnv] implementation derived from the given Java [env].
          */
         @JvmStatic
-        fun create(env: ProcessingEnvironment): XProcessingEnv = JavacProcessingEnv(env)
+        fun create(
+            env: ProcessingEnvironment,
+            targetLanguage: Language = Language.JAVA
+        ): XProcessingEnv = JavacProcessingEnv(env, targetLanguage)
 
         /**
          * Creates a new [XProcessingEnv] implementation derived from the given KSP environment.
@@ -143,7 +157,8 @@ interface XProcessingEnv {
             options: Map<String, String>,
             resolver: Resolver,
             codeGenerator: CodeGenerator,
-            logger: KSPLogger
+            logger: KSPLogger,
+            targetLanguage: Language = Language.JAVA
         ): XProcessingEnv = KspProcessingEnv(
             options = options,
             codeGenerator = codeGenerator,

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -163,12 +163,13 @@ interface XProcessingEnv {
             resolver: Resolver,
             codeGenerator: CodeGenerator,
             logger: KSPLogger,
-            targetLanguage: Language = Language.JAVA
+            targetLanguage: Language
         ): XProcessingEnv = KspProcessingEnv(
             options = options,
             codeGenerator = codeGenerator,
             logger = logger,
-            resolver = resolver
+            resolver = resolver,
+            targetLanguage = targetLanguage
         )
     }
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingStep.kt
@@ -56,11 +56,13 @@ interface XProcessingStep {
          */
         @JvmStatic
         fun XProcessingStep.asAutoCommonProcessor(
-            env: ProcessingEnvironment
+            env: ProcessingEnvironment,
+            targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA
         ): BasicAnnotationProcessor.Step {
             return JavacProcessingStepDelegate(
                 env = env,
-                delegate = this
+                delegate = this,
+                targetLanguage = targetLanguage
             )
         }
 
@@ -79,7 +81,8 @@ interface XProcessingStep {
 
 internal class JavacProcessingStepDelegate(
     val env: ProcessingEnvironment,
-    val delegate: XProcessingStep
+    val delegate: XProcessingStep,
+    val targetLanguage: XProcessingEnv.Language
 ) : BasicAnnotationProcessor.Step {
     override fun annotations(): Set<String> = delegate.annotations()
 
@@ -90,7 +93,7 @@ internal class JavacProcessingStepDelegate(
         val converted = mutableMapOf<String, Set<XElement>>()
         // create a new x processing environment for each step to ensure it can freely cache
         // whatever it wants and we don't keep elements references across rounds.
-        val xEnv = JavacProcessingEnv(env)
+        val xEnv = JavacProcessingEnv(env, targetLanguage)
         annotations().forEach { annotation ->
             val elements = elementsByAnnotation[annotation].mapNotNull { element ->
                 xEnv.wrapAnnotatedElement(element, annotation)

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -39,7 +39,8 @@ import javax.lang.model.util.Elements
 import javax.lang.model.util.Types
 
 internal class JavacProcessingEnv(
-    val delegate: ProcessingEnvironment
+    val delegate: ProcessingEnvironment,
+    override val targetLanguage: XProcessingEnv.Language
 ) : XProcessingEnv {
     override val backend: XProcessingEnv.Backend = XProcessingEnv.Backend.JAVAC
 

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
@@ -41,10 +41,10 @@ internal class KspProcessingEnv(
     override val options: Map<String, String>,
     codeGenerator: CodeGenerator,
     logger: KSPLogger,
-    val resolver: Resolver
+    val resolver: Resolver,
+    override val targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.JAVA
 ) : XProcessingEnv {
     override val backend: XProcessingEnv.Backend = XProcessingEnv.Backend.KSP
-    override val targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.KOTLIN
     private val ksFileMemberContainers = mutableMapOf<KSFile, KspFileMemberContainer>()
 
     private val typeElementStore =

--- a/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
+++ b/room/compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspProcessingEnv.kt
@@ -44,6 +44,7 @@ internal class KspProcessingEnv(
     val resolver: Resolver
 ) : XProcessingEnv {
     override val backend: XProcessingEnv.Backend = XProcessingEnv.Backend.KSP
+    override val targetLanguage: XProcessingEnv.Language = XProcessingEnv.Language.KOTLIN
     private val ksFileMemberContainers = mutableMapOf<KSFile, KspFileMemberContainer>()
 
     private val typeElementStore =

--- a/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
+++ b/room/compiler-processing/src/test/java/androidx/room/compiler/processing/XProcessingStepTest.kt
@@ -327,7 +327,8 @@ class XProcessingStepTest {
                             emptyMap(),
                             resolver,
                             codeGenerator,
-                            logger
+                            logger,
+                            XProcessingEnv.Language.JAVA
                         )
                         return processingStep.executeInKsp(env)
                             .also { returned = it }

--- a/room/compiler/src/main/kotlin/androidx/room/RoomKspProcessor.kt
+++ b/room/compiler/src/main/kotlin/androidx/room/RoomKspProcessor.kt
@@ -38,7 +38,8 @@ class RoomKspProcessor(
             options,
             resolver,
             codeGenerator,
-            logger
+            logger,
+            XProcessingEnv.Language.JAVA
         )
 
         return DatabaseProcessingStep().executeInKsp(


### PR DESCRIPTION
## Proposed Changes

Adds configuration that defines if a processing environment should
expect to work as if on a regular Java setup or if it's Kotlin only.
This defines internal behavior as to how some things will be modelled,
for example if we can expect top level methods to be modelled as such,
or if we should synthesize a `Kt` type to hold it instead.

For JavaAP, the `XProcessingStep.asAutoCommonProcessor()` method now
expects the language to be specified. If not specified, it will default
to expect Java language. Same is applied for KSP.

## Testing
Test:

    ./gradlew \
        test connectedCheck \
        -x :room:room-benchmark:cC \
        -x :room:integration-tests:room-incremental-annotation-processing:test

## Issues Fixed

Fixes: [b/185760236](https://issuetracker.google.com/issues/185760236)
