### PR TITLE
Pull FTL results back into DIST_DIR

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -560,15 +560,6 @@ jobs:
           wrapper-directory: ${{ env.project-root }}/gradle/wrapper
           wrapper-cache-enabled: true
 
-
-      - name: "upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:
@@ -588,6 +579,13 @@ jobs:
           wrapper-directory: ${{ env.project-root }}/gradle/wrapper
           wrapper-cache-enabled: true
 
+      - name: "upload build artifacts"
+        continue-on-error: true
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts_${{ env.artifact-id }}
+          path: ~/dist
       - name: "Report job status"
         id: output-status
         if: always()

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -186,7 +186,7 @@ internal class GCloudCLIWrapper(
         /**
          * The GS Bucket directory where the results will be saved
          */
-        val resultsBucketDir: String = makeResultsDir(projectPath),
+        val resultsBucketDir: String = buildRelativeResultDirPath(projectPath),
         /**
          * The local folder where we will download the test results
          */
@@ -209,13 +209,13 @@ internal class GCloudCLIWrapper(
             const val TEST_OUTPUT_FILE_NAME = "testResults.json"
 
             /**
-             * Generates a folder for test results.
+             * Generates a relative path for test results.
              *
              * If run on Github Actions CI, this method will use the environment variables to
              * create a unique path for the action.
              * If run locally, this will create a random UUID for the folder.
              */
-            fun makeResultsDir(
+            private fun buildRelativeResultDirPath(
                 projectPath: String
             ): String {
                 // github action env variables:

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -136,11 +136,11 @@ internal class GCloudCLIWrapper(
         if (result.exitValue != 0) {
             throw GradleException(
                 """
-                    Unable to find $name CLI executable.
-                    `which $name` returned exit code ${result.exitValue}.
-                    Make sure gcloud CLI is installed, authenticated and is part of your PATH.
-                    See https://cloud.google.com/sdk/gcloud for installation instructions.
-                    """.trimIndent()
+                Unable to find $name CLI executable.
+                `which $name` returned exit code ${result.exitValue}.
+                Make sure gcloud CLI is installed, authenticated and is part of your PATH.
+                See https://cloud.google.com/sdk/gcloud for installation instructions.
+                """.trimIndent()
             )
         }
         return output.toString(Charsets.UTF_8).trim()

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -113,7 +113,6 @@ internal class GCloudCLIWrapper(
         )
         // finally, write the command response into the folder as well
         val testResultOutput = params.resultsLocalDir.resolve(TEST_OUTPUT_FILE_NAME)
-        val gson = Gson()
         testResultOutput.bufferedWriter(Charsets.UTF_8).use {
             gson.toJson(
                 testResults,

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -47,46 +47,14 @@ internal class GCloudCLIWrapper(
      * Path to the gcloud executable, derived from `which gcloud` call.
      */
     private val gcloud: String by lazy {
-        val output = ByteArrayOutputStream()
-        val result = execOperations.exec {
-            it.commandLine("which", "gcloud")
-            it.standardOutput = output
-            it.isIgnoreExitValue = true
-        }
-        if (result.exitValue != 0) {
-            throw GradleException(
-                """
-                Unable to find gcloud CLI executable.
-                `which gcloud` returned exit code ${result.exitValue}.
-                Make sure gcloud CLI is installed, authenticated and is part of your PATH.
-                See https://cloud.google.com/sdk/gcloud for installation instructions.
-                """.trimIndent()
-            )
-        }
-        output.toString(Charsets.UTF_8).trim()
+        findExecutable("gcloud")
     }
 
     /**
      * Path to the gsutil executable, derived from `which gsutil` call.
      */
     private val gsutil: String by lazy {
-        val output = ByteArrayOutputStream()
-        val result = execOperations.exec {
-            it.commandLine("which", "gsutil")
-            it.standardOutput = output
-            it.isIgnoreExitValue = true
-        }
-        if (result.exitValue != 0) {
-            throw GradleException(
-                """
-                Unable to find gsutil CLI executable.
-                `which gsutil` returned exit code ${result.exitValue}.
-                Make sure gsutil CLI is installed, authenticated and is part of your PATH.
-                See https://cloud.google.com/sdk/gcloud for installation instructions.
-                """.trimIndent()
-            )
-        }
-        output.toString(Charsets.UTF_8).trim()
+        findExecutable("gsutil")
     }
 
     private inline fun <reified T> executeGcloud(
@@ -153,6 +121,29 @@ internal class GCloudCLIWrapper(
             )
         }
         return testResults
+    }
+
+    /**
+     * find the given executable's path in the PATH via `which` command.
+     */
+    private fun findExecutable(name: String): String {
+        val output = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            it.commandLine("which", name)
+            it.standardOutput = output
+            it.isIgnoreExitValue = true
+        }
+        if (result.exitValue != 0) {
+            throw GradleException(
+                """
+                    Unable to find $name CLI executable.
+                    `which $name` returned exit code ${result.exitValue}.
+                    Make sure gcloud CLI is installed, authenticated and is part of your PATH.
+                    See https://cloud.google.com/sdk/gcloud for installation instructions.
+                    """.trimIndent()
+            )
+        }
+        return output.toString(Charsets.UTF_8).trim()
     }
 
     /**

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/GCloudCLIWrapper.kt
@@ -106,12 +106,11 @@ internal class GCloudCLIWrapper(
             "--results-dir=${params.resultsBucketDir}",
             "--results-history-name=${params.projectPath}"
         )
-        // copy the test results from the bucket to the build folder
-        val localFolder = params.resultsLocalDir
+        // copy the test results from the bucket to the build directory
         execGsUtil(
-            "cp", "-r", params.cloudBucketPath() + "/*", localFolder.canonicalPath
+            "cp", "-r", params.cloudBucketPath() + "/*", params.resultsLocalDir.canonicalPath
         )
-        // finally, write the command response into the folder as well
+        // finally, write the command response into the directory as well
         val testResultOutput = params.resultsLocalDir.resolve(TEST_OUTPUT_FILE_NAME)
         testResultOutput.bufferedWriter(Charsets.UTF_8).use {
             gson.toJson(
@@ -188,7 +187,7 @@ internal class GCloudCLIWrapper(
          */
         val resultsBucketDir: String = buildRelativeResultDirPath(projectPath),
         /**
-         * The local folder where we will download the test results
+         * The local directory where we will download the test results
          */
         val resultsLocalDir: File,
     ) {
@@ -213,7 +212,7 @@ internal class GCloudCLIWrapper(
              *
              * If run on Github Actions CI, this method will use the environment variables to
              * create a unique path for the action.
-             * If run locally, this will create a random UUID for the folder.
+             * If run locally, this will create a random UUID for the directory.
              */
             private fun buildRelativeResultDirPath(
                 projectPath: String

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -16,16 +16,21 @@
 
 package androidx.build.ftl
 
+import androidx.build.getDistributionDirectory
+import androidx.build.getSupportRootFolder
 import com.android.build.gradle.api.ApkVariant
 import com.android.build.gradle.api.ApkVariantOutput
 import com.android.build.gradle.api.TestVariant
-import com.google.gson.Gson
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
@@ -45,6 +50,7 @@ import javax.inject.Inject
  * Due to the limitations of FTL, this task only support application instrumentation tests for now.
  */
 @Suppress("UnstableApiUsage") // for gradle property APIs
+@CacheableTask
 abstract class RunTestOnFTLTask @Inject constructor(
     private val workerExecutor: WorkerExecutor
 ) : DefaultTask() {
@@ -63,8 +69,8 @@ abstract class RunTestOnFTLTask @Inject constructor(
     /**
      * Output file to write the results
      */
-    @get:OutputFile
-    abstract val testResults: RegularFileProperty
+    @get:OutputDirectory
+    abstract val testResults: DirectoryProperty
 
     @TaskAction
     fun executeTest() {
@@ -74,35 +80,37 @@ abstract class RunTestOnFTLTask @Inject constructor(
             it.testApk.set(testApk)
             it.testedApk.set(testedApk)
             it.testResults.set(testResults)
+            it.projectPath.set(project.relativeResultPath())
         }
     }
 
     interface RunFTLTestParams : WorkParameters {
+        val projectPath: Property<String>
         val testApk: RegularFileProperty
         val testedApk: RegularFileProperty
-        val testResults: RegularFileProperty
+        val testResults: DirectoryProperty
     }
 
     abstract class RunFTLTestWorkAction @Inject constructor(
         private val execOperations: ExecOperations
     ) : WorkAction<RunFTLTestParams> {
         override fun execute() {
+            val localTestResultDir = parameters.testResults.asFile.get()
+            localTestResultDir.apply {
+                deleteRecursively()
+                mkdirs()
+            }
             val testApk = parameters.testApk.asFile.get()
             val testedApk = parameters.testedApk.asFile.get()
             val gcloud = GCloudCLIWrapper(execOperations)
-            val result = gcloud.runTest(
+            val params = GCloudCLIWrapper.RunTestParameters(
                 testedApk = testedApk,
-                testApk = testApk
+                testApk = testApk,
+                projectPath = parameters.projectPath.get(),
+                resultsLocalDir = localTestResultDir
+
             )
-            val outFile = parameters.testResults.asFile.get()
-            outFile.parentFile.mkdirs()
-            val gson = Gson()
-            outFile.bufferedWriter(Charsets.UTF_8).use {
-                gson.toJson(
-                    result,
-                    it
-                )
-            }
+            val result = gcloud.runTest(params)
             val failed = result.filterNot {
                 it.passed
             }
@@ -114,7 +122,6 @@ abstract class RunTestOnFTLTask @Inject constructor(
 
     companion object {
         private const val TASK_SUFFIX = "OnFirebaseTestLab"
-        private const val TEST_OUTPUT_FILE_NAME = "testResults.json"
 
         /**
          * Creates an FTL test runner task and returns it.
@@ -128,16 +135,26 @@ abstract class RunTestOnFTLTask @Inject constructor(
             val testedVariant = testVariant.testedVariant as? ApkVariant
                 ?: return null
             val taskName = testVariant.name + TASK_SUFFIX
+            val testResultDir = project.layout.buildDirectory.dir(
+                "ftl-results"
+            )
+            // create task to copy results into dist directory
+            val copyToDistTask = project.tasks.register(
+                "copyResultsOf${taskName}ToDist",
+                Copy::class.java
+            ) {
+                it.description = "Copy test results from $taskName into DIST folder"
+                it.group = "build"
+                it.from(testResultDir)
+                it.into(
+                    project.getDistributionDirectory()
+                        .resolve("ftl-results/${project.relativeResultPath()}/${taskName}")
+                )
+            }
             return project.tasks.register(taskName, RunTestOnFTLTask::class.java) { task ->
                 task.description = "Run ${testVariant.name} tests on Firebase Test Lab"
                 task.group = "Verification"
-                task.testResults.set(
-                    project.layout.buildDirectory.dir(
-                        "ftl-results"
-                    ).map {
-                        it.file(TEST_OUTPUT_FILE_NAME)
-                    }
-                )
+                task.testResults.set(testResultDir)
                 task.dependsOn(testVariant.packageApplicationProvider)
                 task.dependsOn(testedVariant.packageApplicationProvider)
 
@@ -153,7 +170,16 @@ abstract class RunTestOnFTLTask @Inject constructor(
                         .firstOrNull()
                         ?.outputFile
                 )
+                task.finalizedBy(copyToDistTask)
             }
         }
     }
 }
+
+/**
+ * Returns the relative path of the project wrt the support root. This path is used for both
+ * local dist path and cloud bucket paths.
+ */
+private fun Project.relativeResultPath() = projectDir.relativeTo(
+    project.getSupportRootFolder()
+).path

--- a/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/ftl/RunTestOnFTLTask.kt
@@ -148,7 +148,7 @@ abstract class RunTestOnFTLTask @Inject constructor(
                 it.from(testResultDir)
                 it.into(
                     project.getDistributionDirectory()
-                        .resolve("ftl-results/${project.relativeResultPath()}/${taskName}")
+                        .resolve("ftl-results/${project.relativeResultPath()}/$taskName")
                 )
             }
             return project.tasks.register(taskName, RunTestOnFTLTask::class.java) { task ->


### PR DESCRIPTION
This CL adds support for specifying a Bucket to keep results, which
defaults to a generic bucket I've created for FTL tests.

By default, the bucket path is inferred from github environment
variables when available, otherwise, a random UUID is chosen for uniqueness.

FTL outputs a bunch of things into this bucket, including a video of the
test running. All of it is pulled back into the out folder after the
test runs. I've also configured a finalizer task to copy that output
into the DIST folder.

Since we only rely on APK contents, I marked the task cacheable.

Bug: n/a
Test: production :(. verified build cache locally but required --build-cache