### PR TITLE
Only allow workflows to run _after_ they have been approved.

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,12 +1,15 @@
 name: AndroidX Presubmits
 on:
   push:
+    branches:
+      - androidx-main
   pull_request_target:
-    types: [opened, synchronize, reopened, 'labeled']
-  workflow_dispatch:
+    types: ['labeled']
 
 jobs:
   setup:
+    # Both `run_workflow` and `retry_workflow` will trigger the workflow
+    if: ${{ (github.event_name == 'push' || contains(github.event.issue.labels.*.name, 'workflow')) }}
     runs-on: ubuntu-latest
     outputs:
       gradlew_flags: ${{ steps.global-constants.outputs.gradlew_flags }}


### PR DESCRIPTION
* This ensures that changes have been vetted.
* We continue to allow `workflow_dispatch`.

Test: N/A
