### PR TITLE
Limit Firebase Tests to the main repository

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -565,12 +565,14 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
+        if: ${{ github.repository == 'androidX/androidx' }}
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
       - name: "Run application tests on Firebase Test Lab"
         uses: eskatos/gradle-command-action@v1
+        if: ${{ github.repository == 'androidX/androidx' }}
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:


### PR DESCRIPTION
FTL authentication only exists for the main repo hence don't run them in forks.

Bug: n/a
Test: CI
