### PR TITLE
[Navigation] update KotlinPoet to 1.8.0 for navigation safe-args

### DIFF
--- a/buildSrc/src/main/kotlin/androidx/build/dependencies/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/androidx/build/dependencies/Dependencies.kt
@@ -72,11 +72,7 @@ const val JAVAPOET = "com.squareup:javapoet:1.13.0"
 const val JSQLPARSER = "com.github.jsqlparser:jsqlparser:3.1"
 const val JSR250 = "javax.annotation:javax.annotation-api:1.2"
 const val JUNIT = "junit:junit:4.12"
-const val KOTLINPOET = "com.squareup:kotlinpoet:1.4.0"
-const val KOTLINPOET_METADATA = "com.squareup:kotlinpoet-metadata:1.4.0"
-const val KOTLINPOET_METADATA_SPECS = "com.squareup:kotlinpoet-metadata-specs:1.4.0"
-const val KOTLINPOET_CLASSINSPECTOR_ELEMENTS =
-    "com.squareup:kotlinpoet-classinspector-elements:1.4.0"
+const val KOTLINPOET = "com.squareup:kotlinpoet:1.8.0"
 const val KOTLIN_COMPILE_TESTING = "com.github.tschuchortdev:kotlin-compile-testing:1.3.6"
 const val KOTLIN_COMPILE_TESTING_KSP = "com.github.tschuchortdev:kotlin-compile-testing-ksp:1.3.6"
 

--- a/navigation/navigation-safe-args-generator/build.gradle
+++ b/navigation/navigation-safe-args-generator/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation(KOTLIN_STDLIB)
 
     implementation(JAVAPOET)
-    implementation("com.squareup:kotlinpoet:1.8.0")
+    implementation(KOTLINPOET)
 
     testImplementation(JUNIT)
     testImplementation(GOOGLE_COMPILE_TESTING)

--- a/navigation/navigation-safe-args-generator/build.gradle
+++ b/navigation/navigation-safe-args-generator/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation(KOTLIN_STDLIB)
 
     implementation(JAVAPOET)
-    implementation("com.squareup:kotlinpoet:1.7.2")
+    implementation("com.squareup:kotlinpoet:1.8.0")
 
     testImplementation(JUNIT)
     testImplementation(GOOGLE_COMPILE_TESTING)


### PR DESCRIPTION
## Proposed Changes

Update KotlinPoet to 1.8.0 for navigation safe-args.

## Testing

Test: ./gradlew test

## Issues Fixed

Fixes: The bug on [https://issuetracker.google.com/issues/183990444](https://issuetracker.google.com/issues/183990444) being fixed
