### PR TITLE
[Navigation] Make NamedNavArgument's fields public

### DIFF
--- a/navigation/navigation-compose/api/current.txt
+++ b/navigation/navigation-compose/api/current.txt
@@ -11,6 +11,12 @@ package androidx.navigation.compose {
   }
 
   public final class NamedNavArgument {
+    method public operator String component1();
+    method public operator androidx.navigation.NavArgument component2();
+    method public androidx.navigation.NavArgument getArgument();
+    method public String getName();
+    property public final androidx.navigation.NavArgument argument;
+    property public final String name;
   }
 
   public final class NamedNavArgumentKt {

--- a/navigation/navigation-compose/api/public_plus_experimental_current.txt
+++ b/navigation/navigation-compose/api/public_plus_experimental_current.txt
@@ -11,6 +11,12 @@ package androidx.navigation.compose {
   }
 
   public final class NamedNavArgument {
+    method public operator String component1();
+    method public operator androidx.navigation.NavArgument component2();
+    method public androidx.navigation.NavArgument getArgument();
+    method public String getName();
+    property public final androidx.navigation.NavArgument argument;
+    property public final String name;
   }
 
   public final class NamedNavArgumentKt {

--- a/navigation/navigation-compose/api/restricted_current.txt
+++ b/navigation/navigation-compose/api/restricted_current.txt
@@ -11,6 +11,12 @@ package androidx.navigation.compose {
   }
 
   public final class NamedNavArgument {
+    method public operator String component1();
+    method public operator androidx.navigation.NavArgument component2();
+    method public androidx.navigation.NavArgument getArgument();
+    method public String getName();
+    property public final androidx.navigation.NavArgument argument;
+    property public final String name;
   }
 
   public final class NamedNavArgumentKt {

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NamedNavArgument.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NamedNavArgument.kt
@@ -33,9 +33,9 @@ public fun navArgument(
  * Construct a named [NavArgument] by using the [navArgument] method.
  */
 public class NamedNavArgument internal constructor(
-    private val name: String,
-    private val argument: NavArgument
+    public val name: String,
+    public val argument: NavArgument
 ) {
-    internal operator fun component1(): String = name
-    internal operator fun component2(): NavArgument = argument
+    public operator fun component1(): String = name
+    public operator fun component2(): NavArgument = argument
 }

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NamedNavArgument.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NamedNavArgument.kt
@@ -33,9 +33,24 @@ public fun navArgument(
  * Construct a named [NavArgument] by using the [navArgument] method.
  */
 public class NamedNavArgument internal constructor(
+
+    /**
+     * The name the argument is associated with
+     */
     public val name: String,
+
+    /**
+     * The [NavArgument] associated with the name
+     */
     public val argument: NavArgument
 ) {
+    /**
+     * Provides destructuring access to this [NamedNavArgument]'s [name]
+     */
     public operator fun component1(): String = name
+
+    /**
+     * Provides destructuring access to this [NamedNavArgument]'s [argument]
+     */
     public operator fun component2(): NavArgument = argument
 }


### PR DESCRIPTION
## Proposed Changes

Relnote: NamedNavArgument's `name`, `argument` and destructuring functions are now public

## Testing

Test: N/A

## Issues Fixed

Fixes: b/181320559
