### PR TITLE
[Navigation] Introduce NavBackStackEntry#provideToCompositionLocals

### DIFF
--- a/navigation/navigation-compose/api/current.txt
+++ b/navigation/navigation-compose/api/current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/current.txt
+++ b/navigation/navigation-compose/api/current.txt
@@ -23,6 +23,10 @@ package androidx.navigation.compose {
     method @androidx.navigation.NavDestinationDsl public static androidx.navigation.compose.NamedNavArgument navArgument(String name, kotlin.jvm.functions.Function1<? super androidx.navigation.NavArgumentBuilder,kotlin.Unit> builder);
   }
 
+  public final class NavBackStackEntryProviderKt {
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+  }
+
   public final class NavGraphBuilderKt {
     method public static void composable(androidx.navigation.NavGraphBuilder, String route, optional java.util.List<androidx.navigation.compose.NamedNavArgument> arguments, optional java.util.List<androidx.navigation.NavDeepLink> deepLinks, kotlin.jvm.functions.Function1<? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
     method public static void navigation(androidx.navigation.NavGraphBuilder, String startDestination, String route, kotlin.jvm.functions.Function1<? super androidx.navigation.NavGraphBuilder,kotlin.Unit> builder);

--- a/navigation/navigation-compose/api/current.txt
+++ b/navigation/navigation-compose/api/current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/current.txt
+++ b/navigation/navigation-compose/api/current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void LocalOwnersProvider(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/public_plus_experimental_current.txt
+++ b/navigation/navigation-compose/api/public_plus_experimental_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/public_plus_experimental_current.txt
+++ b/navigation/navigation-compose/api/public_plus_experimental_current.txt
@@ -23,6 +23,10 @@ package androidx.navigation.compose {
     method @androidx.navigation.NavDestinationDsl public static androidx.navigation.compose.NamedNavArgument navArgument(String name, kotlin.jvm.functions.Function1<? super androidx.navigation.NavArgumentBuilder,kotlin.Unit> builder);
   }
 
+  public final class NavBackStackEntryProviderKt {
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+  }
+
   public final class NavGraphBuilderKt {
     method public static void composable(androidx.navigation.NavGraphBuilder, String route, optional java.util.List<androidx.navigation.compose.NamedNavArgument> arguments, optional java.util.List<androidx.navigation.NavDeepLink> deepLinks, kotlin.jvm.functions.Function1<? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
     method public static void navigation(androidx.navigation.NavGraphBuilder, String startDestination, String route, kotlin.jvm.functions.Function1<? super androidx.navigation.NavGraphBuilder,kotlin.Unit> builder);

--- a/navigation/navigation-compose/api/public_plus_experimental_current.txt
+++ b/navigation/navigation-compose/api/public_plus_experimental_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/public_plus_experimental_current.txt
+++ b/navigation/navigation-compose/api/public_plus_experimental_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void LocalOwnersProvider(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/restricted_current.txt
+++ b/navigation/navigation-compose/api/restricted_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/restricted_current.txt
+++ b/navigation/navigation-compose/api/restricted_current.txt
@@ -23,6 +23,10 @@ package androidx.navigation.compose {
     method @androidx.navigation.NavDestinationDsl public static androidx.navigation.compose.NamedNavArgument navArgument(String name, kotlin.jvm.functions.Function1<? super androidx.navigation.NavArgumentBuilder,kotlin.Unit> builder);
   }
 
+  public final class NavBackStackEntryProviderKt {
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+  }
+
   public final class NavGraphBuilderKt {
     method public static void composable(androidx.navigation.NavGraphBuilder, String route, optional java.util.List<androidx.navigation.compose.NamedNavArgument> arguments, optional java.util.List<androidx.navigation.NavDeepLink> deepLinks, kotlin.jvm.functions.Function1<? super androidx.navigation.NavBackStackEntry,kotlin.Unit> content);
     method public static void navigation(androidx.navigation.NavGraphBuilder, String startDestination, String route, kotlin.jvm.functions.Function1<? super androidx.navigation.NavGraphBuilder,kotlin.Unit> builder);

--- a/navigation/navigation-compose/api/restricted_current.txt
+++ b/navigation/navigation-compose/api/restricted_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void provideToCompositionLocals(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/api/restricted_current.txt
+++ b/navigation/navigation-compose/api/restricted_current.txt
@@ -24,7 +24,7 @@ package androidx.navigation.compose {
   }
 
   public final class NavBackStackEntryProviderKt {
-    method @androidx.compose.runtime.Composable public static void CompositionLocalProvider(androidx.navigation.NavBackStackEntry, optional androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
+    method @androidx.compose.runtime.Composable public static void LocalOwnersProvider(androidx.navigation.NavBackStackEntry, androidx.compose.runtime.saveable.SaveableStateHolder saveableStateHolder, kotlin.jvm.functions.Function0<kotlin.Unit> content);
   }
 
   public final class NavGraphBuilderKt {

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import android.os.Bundle
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavDestination
+import androidx.navigation.NavigatorState
+import androidx.navigation.testing.TestNavigatorState
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
+import androidx.testutils.TestNavigator
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.random.Random
+
+@RunWith(AndroidJUnit4::class)
+class NavBackStackEntryProviderTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testViewModelStoreOwnerProvided() {
+        val testNavigator = TestNavigator()
+        val testNavigatorState = TestNavigatorState()
+        val backStackEntry = testNavigatorState.createActiveBackStackEntry(
+            testNavigator.createDestination(),
+            null
+        )
+        var viewModelStoreOwner: ViewModelStoreOwner? = null
+
+        composeTestRule.setContent {
+            val saveableStateHolder = rememberSaveableStateHolder()
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                viewModelStoreOwner = LocalViewModelStoreOwner.current
+            }
+        }
+
+        assertWithMessage("ViewModelStoreOwner is provided by $backStackEntry")
+            .that(viewModelStoreOwner).isEqualTo(backStackEntry)
+    }
+
+    @Test
+    fun testLifecycleOwnerProvided() {
+        val testNavigator = TestNavigator()
+        val navigatorState = TestNavigatorState()
+        val backStackEntry =
+            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
+        var lifecycleOwner: LifecycleOwner? = null
+
+        composeTestRule.setContent {
+            val saveableStateHolder = rememberSaveableStateHolder()
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                lifecycleOwner = LocalLifecycleOwner.current
+            }
+        }
+
+        assertWithMessage("LifecycleOwner is provided by $backStackEntry")
+            .that(lifecycleOwner).isEqualTo(backStackEntry)
+    }
+
+    @Test
+    fun testLocalSavedStateRegistryOwnerProvided() {
+        val testNavigator = TestNavigator()
+        val navigatorState = TestNavigatorState()
+        val backStackEntry =
+            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
+        var localSavedStateRegistryOwner: SavedStateRegistryOwner? = null
+
+        composeTestRule.setContent {
+            val saveableStateHolder = rememberSaveableStateHolder()
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                localSavedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+            }
+        }
+
+        assertWithMessage("LocalSavedStateRegistryOwner is provided by $backStackEntry")
+            .that(localSavedStateRegistryOwner).isEqualTo(backStackEntry)
+    }
+
+    @Test
+    fun testSaveableValueInContentIsSaved() {
+        val restorationTester = StateRestorationTester(composeTestRule)
+        var array: IntArray? = null
+
+        val testNavigator = TestNavigator()
+        val navigatorState = TestNavigatorState()
+        val backStackEntry =
+            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
+
+        restorationTester.setContent {
+            val saveableStateHolder = rememberSaveableStateHolder()
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                array = rememberSaveable {
+                    intArrayOf(0)
+                }
+            }
+        }
+
+        assertThat(array).isEqualTo(intArrayOf(0))
+
+        composeTestRule.runOnUiThread {
+            array!![0] = 1
+            // we null it to ensure recomposition happened
+            array = null
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        assertThat(array).isEqualTo(intArrayOf(1))
+    }
+
+    // By default, NavBackStackEntrys are in the INITIALIZED state and then get moved to the next
+    // appropriate state by the NavController. In case we aren't testing with a NavController,
+    // this sets the entry's lifecycle state to the passed state so that the entry is active.
+    private fun NavigatorState.createActiveBackStackEntry(
+        destination: NavDestination,
+        arguments: Bundle? = null,
+        lifecycleState: Lifecycle.State = Lifecycle.State.RESUMED
+    ) = createBackStackEntry(destination, arguments).apply {
+        runOnUiThread { maxLifecycle = lifecycleState }
+    }
+
+}

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -52,7 +52,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 viewModelStoreOwner = LocalViewModelStoreOwner.current
             }
         }
@@ -68,7 +68,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 lifecycleOwner = LocalLifecycleOwner.current
             }
         }
@@ -84,7 +84,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 localSavedStateRegistryOwner = LocalSavedStateRegistryOwner.current
             }
         }
@@ -101,7 +101,7 @@ class NavBackStackEntryProviderTest {
 
         restorationTester.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 array = rememberSaveable {
                     intArrayOf(0)
                 }
@@ -130,7 +130,7 @@ class NavBackStackEntryProviderTest {
 
         restorationTester.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 nonSaveable = remember { initialValue }
             }
         }

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.navigation.compose
 
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -25,9 +26,11 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.navigation.NavBackStackEntry
 import androidx.navigation.testing.TestNavigatorState
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
 import androidx.testutils.TestNavigator
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
@@ -35,6 +38,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@LargeTest
 @RunWith(AndroidJUnit4::class)
 class NavBackStackEntryProviderTest {
 
@@ -43,15 +47,7 @@ class NavBackStackEntryProviderTest {
 
     @Test
     fun testViewModelStoreOwnerProvided() {
-        val testNavigator = TestNavigator()
-        val testNavigatorState = TestNavigatorState()
-        testNavigator.onAttach(testNavigatorState)
-        val backStackEntry = testNavigatorState.createBackStackEntry(
-            testNavigator.createDestination(),
-            null
-        )
-        testNavigator.navigate(listOf(backStackEntry), null, null)
-
+        val backStackEntry = createBackStackEntry()
         var viewModelStoreOwner: ViewModelStoreOwner? = null
 
         composeTestRule.setContent {
@@ -67,15 +63,7 @@ class NavBackStackEntryProviderTest {
 
     @Test
     fun testLifecycleOwnerProvided() {
-        val testNavigator = TestNavigator()
-        val testNavigatorState = TestNavigatorState()
-        testNavigator.onAttach(testNavigatorState)
-        val backStackEntry = testNavigatorState.createBackStackEntry(
-            testNavigator.createDestination(),
-            null
-        )
-        testNavigator.navigate(listOf(backStackEntry), null, null)
-
+        val backStackEntry = createBackStackEntry()
         var lifecycleOwner: LifecycleOwner? = null
 
         composeTestRule.setContent {
@@ -91,15 +79,7 @@ class NavBackStackEntryProviderTest {
 
     @Test
     fun testLocalSavedStateRegistryOwnerProvided() {
-        val testNavigator = TestNavigator()
-        val testNavigatorState = TestNavigatorState()
-        testNavigator.onAttach(testNavigatorState)
-        val backStackEntry = testNavigatorState.createBackStackEntry(
-            testNavigator.createDestination(),
-            null
-        )
-        testNavigator.navigate(listOf(backStackEntry), null, null)
-
+        val backStackEntry = createBackStackEntry()
         var localSavedStateRegistryOwner: SavedStateRegistryOwner? = null
 
         composeTestRule.setContent {
@@ -115,15 +95,7 @@ class NavBackStackEntryProviderTest {
 
     @Test
     fun testSaveableValueInContentIsSaved() {
-        val testNavigator = TestNavigator()
-        val testNavigatorState = TestNavigatorState()
-        testNavigator.onAttach(testNavigatorState)
-        val backStackEntry = testNavigatorState.createBackStackEntry(
-            testNavigator.createDestination(),
-            null
-        )
-        testNavigator.navigate(listOf(backStackEntry), null, null)
-
+        val backStackEntry = createBackStackEntry()
         val restorationTester = StateRestorationTester(composeTestRule)
         var array: IntArray? = null
 
@@ -147,5 +119,18 @@ class NavBackStackEntryProviderTest {
         restorationTester.emulateSavedInstanceStateRestore()
 
         assertThat(array).isEqualTo(intArrayOf(1))
+    }
+
+    private fun createBackStackEntry(): NavBackStackEntry {
+        val testNavigator = TestNavigator()
+        val testNavigatorState = TestNavigatorState()
+        testNavigator.onAttach(testNavigatorState)
+        val backStackEntry = testNavigatorState.createBackStackEntry(
+            testNavigator.createDestination(),
+            null
+        )
+        // We navigate to move the NavBackStackEntry to the correct state
+        testNavigator.navigate(listOf(backStackEntry), null, null)
+        return backStackEntry
     }
 }

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -121,6 +121,33 @@ class NavBackStackEntryProviderTest {
         assertThat(array).isEqualTo(intArrayOf(1))
     }
 
+    @Test
+    fun testNonSaveableValueInContentIsNotSaved() {
+        val backStackEntry = createBackStackEntry()
+        val restorationTester = StateRestorationTester(composeTestRule)
+        var nonSaveable: IntArray? = null
+        val initialValue = intArrayOf(10)
+
+        restorationTester.setContent {
+            val saveableStateHolder = rememberSaveableStateHolder()
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                nonSaveable = remember { initialValue }
+            }
+        }
+
+        assertThat(nonSaveable).isEqualTo(initialValue)
+
+        composeTestRule.runOnUiThread {
+            nonSaveable!![0] = 1
+            // we null it to ensure recomposition happened
+            nonSaveable = null
+        }
+
+        restorationTester.emulateSavedInstanceStateRestore()
+
+        assertThat(nonSaveable).isEqualTo(initialValue)
+    }
+
     private fun createBackStackEntry(): NavBackStackEntry {
         val testNavigator = TestNavigator()
         val testNavigatorState = TestNavigatorState()

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -16,37 +16,24 @@
 
 package androidx.navigation.compose
 
-import android.os.Bundle
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.compose.ui.test.junit4.StateRestorationTester
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import androidx.navigation.NavDestination
-import androidx.navigation.NavigatorState
 import androidx.navigation.testing.TestNavigatorState
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.internal.runner.junit4.statement.UiThreadStatement.runOnUiThread
 import androidx.testutils.TestNavigator
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
-import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.random.Random
 
 @RunWith(AndroidJUnit4::class)
 class NavBackStackEntryProviderTest {
@@ -58,10 +45,13 @@ class NavBackStackEntryProviderTest {
     fun testViewModelStoreOwnerProvided() {
         val testNavigator = TestNavigator()
         val testNavigatorState = TestNavigatorState()
-        val backStackEntry = testNavigatorState.createActiveBackStackEntry(
+        testNavigator.onAttach(testNavigatorState)
+        val backStackEntry = testNavigatorState.createBackStackEntry(
             testNavigator.createDestination(),
             null
         )
+        testNavigator.navigate(listOf(backStackEntry), null, null)
+
         var viewModelStoreOwner: ViewModelStoreOwner? = null
 
         composeTestRule.setContent {
@@ -78,9 +68,14 @@ class NavBackStackEntryProviderTest {
     @Test
     fun testLifecycleOwnerProvided() {
         val testNavigator = TestNavigator()
-        val navigatorState = TestNavigatorState()
-        val backStackEntry =
-            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
+        val testNavigatorState = TestNavigatorState()
+        testNavigator.onAttach(testNavigatorState)
+        val backStackEntry = testNavigatorState.createBackStackEntry(
+            testNavigator.createDestination(),
+            null
+        )
+        testNavigator.navigate(listOf(backStackEntry), null, null)
+
         var lifecycleOwner: LifecycleOwner? = null
 
         composeTestRule.setContent {
@@ -97,9 +92,14 @@ class NavBackStackEntryProviderTest {
     @Test
     fun testLocalSavedStateRegistryOwnerProvided() {
         val testNavigator = TestNavigator()
-        val navigatorState = TestNavigatorState()
-        val backStackEntry =
-            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
+        val testNavigatorState = TestNavigatorState()
+        testNavigator.onAttach(testNavigatorState)
+        val backStackEntry = testNavigatorState.createBackStackEntry(
+            testNavigator.createDestination(),
+            null
+        )
+        testNavigator.navigate(listOf(backStackEntry), null, null)
+
         var localSavedStateRegistryOwner: SavedStateRegistryOwner? = null
 
         composeTestRule.setContent {
@@ -115,13 +115,17 @@ class NavBackStackEntryProviderTest {
 
     @Test
     fun testSaveableValueInContentIsSaved() {
+        val testNavigator = TestNavigator()
+        val testNavigatorState = TestNavigatorState()
+        testNavigator.onAttach(testNavigatorState)
+        val backStackEntry = testNavigatorState.createBackStackEntry(
+            testNavigator.createDestination(),
+            null
+        )
+        testNavigator.navigate(listOf(backStackEntry), null, null)
+
         val restorationTester = StateRestorationTester(composeTestRule)
         var array: IntArray? = null
-
-        val testNavigator = TestNavigator()
-        val navigatorState = TestNavigatorState()
-        val backStackEntry =
-            navigatorState.createActiveBackStackEntry(testNavigator.createDestination())
 
         restorationTester.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
@@ -144,16 +148,4 @@ class NavBackStackEntryProviderTest {
 
         assertThat(array).isEqualTo(intArrayOf(1))
     }
-
-    // By default, NavBackStackEntrys are in the INITIALIZED state and then get moved to the next
-    // appropriate state by the NavController. In case we aren't testing with a NavController,
-    // this sets the entry's lifecycle state to the passed state so that the entry is active.
-    private fun NavigatorState.createActiveBackStackEntry(
-        destination: NavDestination,
-        arguments: Bundle? = null,
-        lifecycleState: Lifecycle.State = Lifecycle.State.RESUMED
-    ) = createBackStackEntry(destination, arguments).apply {
-        runOnUiThread { maxLifecycle = lifecycleState }
-    }
-
 }

--- a/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
+++ b/navigation/navigation-compose/src/androidTest/java/androidx/navigation/compose/NavBackStackEntryProviderTest.kt
@@ -52,7 +52,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 viewModelStoreOwner = LocalViewModelStoreOwner.current
             }
         }
@@ -68,7 +68,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 lifecycleOwner = LocalLifecycleOwner.current
             }
         }
@@ -84,7 +84,7 @@ class NavBackStackEntryProviderTest {
 
         composeTestRule.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 localSavedStateRegistryOwner = LocalSavedStateRegistryOwner.current
             }
         }
@@ -101,7 +101,7 @@ class NavBackStackEntryProviderTest {
 
         restorationTester.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 array = rememberSaveable {
                     intArrayOf(0)
                 }
@@ -130,7 +130,7 @@ class NavBackStackEntryProviderTest {
 
         restorationTester.setContent {
             val saveableStateHolder = rememberSaveableStateHolder()
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 nonSaveable = remember { initialValue }
             }
         }

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
@@ -30,7 +30,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavBackStackEntry
 import java.util.UUID
 
-
 /**
  * Provides [this] [NavBackStackEntry] as [LocalViewModelStoreOwner], [LocalLifecycleOwner] and
  * [LocalSavedStateRegistryOwner] to the [content] and saves the [content]'s saveable states with

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
@@ -19,7 +19,6 @@ package androidx.navigation.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.saveable.SaveableStateHolder
-import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.SavedStateHandle
@@ -34,12 +33,14 @@ import java.util.UUID
  * [LocalSavedStateRegistryOwner] to the [content] and saves the [content]'s saveable states with
  * the given [saveableStateHolder].
  *
- * @param saveableStateHolder The [SaveableStateHolder] that holds the saved states
+ * @param saveableStateHolder The [SaveableStateHolder] that holds the saved states. The same
+ * holder should be used for all [NavBackStackEntry]s in the encapsulating [Composable] and the
+ * holder should be hoisted.
  * @param content The content [Composable]
  */
 @Composable
-public fun NavBackStackEntry.CompositionLocalProvider(
-    saveableStateHolder: SaveableStateHolder = rememberSaveableStateHolder(),
+public fun NavBackStackEntry.LocalOwnersProvider(
+    saveableStateHolder: SaveableStateHolder,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.SavedStateHandle
@@ -41,7 +42,7 @@ import java.util.UUID
 @SuppressLint("ComposableNaming")
 @Composable
 public fun NavBackStackEntry.provideToCompositionLocals(
-    saveableStateHolder: SaveableStateHolder,
+    saveableStateHolder: SaveableStateHolder = rememberSaveableStateHolder(),
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
@@ -16,7 +16,6 @@
 
 package androidx.navigation.compose
 
-import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.saveable.SaveableStateHolder
@@ -38,9 +37,8 @@ import java.util.UUID
  * @param saveableStateHolder The [SaveableStateHolder] that holds the saved states
  * @param content The content [Composable]
  */
-@SuppressLint("ComposableNaming")
 @Composable
-public fun NavBackStackEntry.provideToCompositionLocals(
+public fun NavBackStackEntry.CompositionLocalProvider(
     saveableStateHolder: SaveableStateHolder = rememberSaveableStateHolder(),
     content: @Composable () -> Unit
 ) {
@@ -49,9 +47,7 @@ public fun NavBackStackEntry.provideToCompositionLocals(
         LocalLifecycleOwner provides this,
         LocalSavedStateRegistryOwner provides this
     ) {
-        saveableStateHolder.SaveableStateProvider {
-            content()
-        }
+        saveableStateHolder.SaveableStateProvider(content)
     }
 }
 

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavBackStackEntryProvider.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.navigation.compose
+
+import android.annotation.SuppressLint
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.saveable.SaveableStateHolder
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavBackStackEntry
+import java.util.UUID
+
+
+/**
+ * Provides [this] [NavBackStackEntry] as [LocalViewModelStoreOwner], [LocalLifecycleOwner] and
+ * [LocalSavedStateRegistryOwner] to the [content] and saves the [content]'s saveable states with
+ * the given [saveableStateHolder].
+ *
+ * @param saveableStateHolder The [SaveableStateHolder] that holds the saved states
+ * @param content The content [Composable]
+ */
+@SuppressLint("ComposableNaming")
+@Composable
+public fun NavBackStackEntry.provideToCompositionLocals(
+    saveableStateHolder: SaveableStateHolder,
+    content: @Composable () -> Unit
+) {
+    CompositionLocalProvider(
+        LocalViewModelStoreOwner provides this,
+        LocalLifecycleOwner provides this,
+        LocalSavedStateRegistryOwner provides this
+    ) {
+        saveableStateHolder.SaveableStateProvider {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun SaveableStateHolder.SaveableStateProvider(content: @Composable () -> Unit) {
+    val viewModel = viewModel<BackStackEntryIdViewModel>()
+    viewModel.saveableStateHolder = this
+    SaveableStateProvider(viewModel.id, content)
+}
+
+internal class BackStackEntryIdViewModel(handle: SavedStateHandle) : ViewModel() {
+
+    private val IdKey = "SaveableStateHolder_BackStackEntryKey"
+
+    // we create our own id for each back stack entry to support multiple entries of the same
+    // destination. this id will be restored by SavedStateHandle
+    val id: UUID = handle.get<UUID>(IdKey) ?: UUID.randomUUID().also { handle.set(IdKey, it) }
+
+    var saveableStateHolder: SaveableStateHolder? = null
+
+    // onCleared will be called on the entries removed from the back stack. here we notify
+    // RestorableStateHolder that we shouldn't save the state for this id, so when we open this
+    // destination again the state will not be restored.
+    override fun onCleared() {
+        super.onCleared()
+        saveableStateHolder?.removeState(id)
+    }
+}

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -129,7 +129,7 @@ public fun NavHost(
         // while in the scope of the composable, we provide the navBackStackEntry as the
         // ViewModelStoreOwner and LifecycleOwner
         Box(modifier, propagateMinConstraints = true) {
-            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
+            backStackEntry.LocalOwnersProvider(saveableStateHolder) {
                 destination.content(backStackEntry)
             }
         }

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -129,7 +129,7 @@ public fun NavHost(
         // while in the scope of the composable, we provide the navBackStackEntry as the
         // ViewModelStoreOwner and LifecycleOwner
         Box(modifier, propagateMinConstraints = true) {
-            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+            backStackEntry.CompositionLocalProvider(saveableStateHolder) {
                 destination.content(backStackEntry)
             }
         }

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -19,28 +19,21 @@ package androidx.navigation.compose
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.SaveableStateHolder
 import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.compose.ui.platform.LocalSavedStateRegistryOwner
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.SavedStateHandle
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavDestination
 import androidx.navigation.NavGraph
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.Navigator
 import androidx.navigation.get
-import java.util.UUID
 
 /**
  * Provides in place in the Compose hierarchy for self contained navigation to occur.
@@ -136,41 +129,9 @@ public fun NavHost(
         // while in the scope of the composable, we provide the navBackStackEntry as the
         // ViewModelStoreOwner and LifecycleOwner
         Box(modifier, propagateMinConstraints = true) {
-            CompositionLocalProvider(
-                LocalViewModelStoreOwner provides backStackEntry,
-                LocalLifecycleOwner provides backStackEntry,
-                LocalSavedStateRegistryOwner provides backStackEntry
-            ) {
-                saveableStateHolder.SaveableStateProvider {
-                    destination.content(backStackEntry)
-                }
+            backStackEntry.provideToCompositionLocals(saveableStateHolder) {
+                destination.content(backStackEntry)
             }
         }
-    }
-}
-
-@Composable
-private fun SaveableStateHolder.SaveableStateProvider(content: @Composable () -> Unit) {
-    val viewModel = viewModel<BackStackEntryIdViewModel>()
-    viewModel.saveableStateHolder = this
-    SaveableStateProvider(viewModel.id, content)
-}
-
-internal class BackStackEntryIdViewModel(handle: SavedStateHandle) : ViewModel() {
-
-    private val IdKey = "SaveableStateHolder_BackStackEntryKey"
-
-    // we create our own id for each back stack entry to support multiple entries of the same
-    // destination. this id will be restored by SavedStateHandle
-    val id: UUID = handle.get<UUID>(IdKey) ?: UUID.randomUUID().also { handle.set(IdKey, it) }
-
-    var saveableStateHolder: SaveableStateHolder? = null
-
-    // onCleared will be called on the entries removed from the back stack. here we notify
-    // RestorableStateHolder that we shouldn't save the state for this id, so when we open this
-    // destination again the state will not be restored.
-    override fun onCleared() {
-        super.onCleared()
-        saveableStateHolder?.removeState(id)
     }
 }


### PR DESCRIPTION
…that provides the NavBackStackEntry to the composition locals needed for all Compose-related navigators.

Relnote: Introduced a new NavBackStackEntry#provideToCompositionLocals that provides the NavBackStackEntry to the relevant composition locals.

## Testing

Test: NavBackStackEntryProviderTest

`NavBackStackEntryProviderTest#testSaveableValueInContentIsSaved` is pretty much just copied from [RememberSaveableTest](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/runtime/runtime-saveable/src/androidAndroidTest/kotlin/androidx/compose/runtime/saveable/RememberSaveableTest.kt) and as always, I'll be very happy about suggestions on improving the tests and additional tests! 

## Issues Fixed

Fixes: b/187229439
