### PR TITLE
[Navigation] Return early from NavigatorProvider#addNavigator if possible

### DIFF
--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavigatorProvider.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavigatorProvider.kt
@@ -103,6 +103,9 @@ public open class NavigatorProvider {
     ): Navigator<out NavDestination>? {
         require(validateName(name)) { "navigator name cannot be an empty string" }
         val previousNavigator = _navigators[name]
+        if (previousNavigator == navigator) {
+            return navigator
+        }
         check(previousNavigator?.isAttached != true) {
             "Navigator $navigator is replacing an already attached $previousNavigator"
         }

--- a/navigation/navigation-common/src/test/java/androidx/navigation/NavigatorProviderTest.kt
+++ b/navigation/navigation-common/src/test/java/androidx/navigation/NavigatorProviderTest.kt
@@ -17,6 +17,7 @@
 package androidx.navigation
 
 import android.os.Bundle
+import androidx.navigation.testing.TestNavigatorState
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import org.junit.Assert.fail
@@ -98,6 +99,50 @@ class NavigatorProviderTest {
         provider.addNavigator(navigator)
         assertThat(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME))
             .isEqualTo(navigator)
+    }
+
+    @Test
+    fun addExistingNavigatorDoesntReplace() {
+        val navigatorState = TestNavigatorState()
+        val provider = NavigatorProvider()
+        val navigator = EmptyNavigator()
+
+        provider.addNavigator(navigator)
+        assertThat(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME))
+            .isEqualTo(navigator)
+
+        navigator.onAttach(navigatorState)
+        assertWithMessage("Navigator should be attached")
+            .that(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME).isAttached)
+            .isTrue()
+
+        // addNavigator should throw when trying to replace an existing, attached navigator, but
+        // we should have returned before that
+        try {
+            provider.addNavigator(navigator)
+        } catch (navigatorAlreadyAttached: IllegalStateException) {
+            fail(
+                "addNavigator with an existing navigator should return early and not " +
+                    "attempt to replace"
+            )
+        }
+    }
+
+    @Test
+    fun addWithSameNameButUnequalNavigatorDoesReplace() {
+        val provider = NavigatorProvider()
+        val navigatorA = EmptyNavigator()
+        val navigatorB = EmptyNavigator()
+
+        assertThat(navigatorA).isNotEqualTo(navigatorB)
+
+        provider.addNavigator(navigatorA)
+        assertThat(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME))
+            .isEqualTo(navigatorA)
+
+        provider.addNavigator(navigatorB)
+        assertThat(provider.getNavigator<EmptyNavigator>(EmptyNavigator.NAME))
+            .isEqualTo(navigatorB)
     }
 
     private val provider = NavigatorProvider()


### PR DESCRIPTION
We want to return early from `addNavigator` if the previous and to-be-added navigator are equal. This allows calling `addNavigator` as a side effect of every composition without having to worry about the Navigator being replaced every time.

Test: Added addExistingNavigatorDoesntReplace and addWithSameNameButUnequalNavigatorDoesReplace in NavigatorProviderTest.kt

Fixes: b/187443146
Change-Id: Id09b7e3306c49f261b80c724d36c614671f5a7ac
