### PR TITLE
[Fragment] FragmentManager.commit now returns int value

### DIFF
--- a/fragment/fragment-ktx/src/androidTest/java/androidx/fragment/app/FragmentManagerTest.kt
+++ b/fragment/fragment-ktx/src/androidTest/java/androidx/fragment/app/FragmentManagerTest.kt
@@ -68,6 +68,19 @@ class FragmentManagerTest {
     }
 
     @UiThreadTest
+    @Test fun commitWithBackStackId() {
+        val fragment = TestFragment()
+        val backStackId = fragmentManager.commit {
+            add(fragment, null)
+            addToBackStack("test")
+        }
+        assertThat(fragmentManager.fragments).doesNotContain(fragment)
+        fragmentManager.executePendingTransactions()
+        assertThat(fragmentManager.fragments).contains(fragment)
+        assertThat(backStackId).isGreaterThan(-1)
+    }
+
+    @UiThreadTest
     @Test fun commitAllowingStateLoss() {
         // Use a detached FragmentManager to ensure state loss.
         val fragmentManager = FragmentManagerImpl()
@@ -76,6 +89,19 @@ class FragmentManagerTest {
             add(TestFragment(), null)
         }
         assertThat(fragmentManager.fragments).isEmpty()
+    }
+
+    @UiThreadTest
+    @Test fun commitAllowingStateLossWithBackStackId() {
+        // Use a detached FragmentManager to ensure state loss.
+        val fragmentManager = FragmentManagerImpl()
+
+        val backStackId = fragmentManager.commit(allowStateLoss = true) {
+            add(TestFragment(), null)
+            addToBackStack("test")
+        }
+        assertThat(fragmentManager.fragments).isEmpty()
+        assertThat(backStackId).isGreaterThan(-1)
     }
 
     @UiThreadTest

--- a/fragment/fragment-ktx/src/main/java/androidx/fragment/app/FragmentManager.kt
+++ b/fragment/fragment-ktx/src/main/java/androidx/fragment/app/FragmentManager.kt
@@ -26,10 +26,10 @@ package androidx.fragment.app
 public inline fun FragmentManager.commit(
     allowStateLoss: Boolean = false,
     body: FragmentTransaction.() -> Unit
-) {
+): Int {
     val transaction = beginTransaction()
     transaction.body()
-    if (allowStateLoss) {
+    return if (allowStateLoss) {
         transaction.commitAllowingStateLoss()
     } else {
         transaction.commit()


### PR DESCRIPTION
## Proposed Changes

`FragmentManager.commit` in KTX now returns int value. Supports `commit` and `commitAllowingState()` as well. This feature was missing from the KTX library.

## Testing

Test:  ./gradlew fragment:fragment-ktx:connectedCheck

## Issues Fixed

Fixes: The feature request on [https://issuetracker.google.com/issues/158846153](https://issuetracker.google.com/issues/158846153) being implemented
