### PR TITLE
Add missing gson dependency for androidx plugin

### DIFF
--- a/androidx-plugin/gradle-plugin/build.gradle
+++ b/androidx-plugin/gradle-plugin/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation(libs.kotlinPoet)
 
     implementation(libs.dokkaGradlePlugin)
+    implementation(libs.gson)
 
     implementation(libs.androidLint)
 

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -57,6 +57,7 @@ buildscript {
         classpath(libs.kotlinGradlePlugin)
         classpath(libs.kgpLeakPatcher)
         classpath(libs.kspGradlePlugin)
+        classpath(libs.gson)
         classpath "androidx.build:gradle-plugin:0.1.0"
         classpath(libs.shadow)
     }

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -26,7 +26,7 @@ org.gradle.jvmargs=-Xmx2048m
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=7357356
+androidx.playground.snapshotBuildId=7378367
 androidx.playground.metalavaBuildId=7255182
 androidx.playground.dokkaBuildId=7299536
 androidx.studio.type=playground


### PR DESCRIPTION
This PR fixes the androidx plugin for kotlin 1.5 update.
Also updated prebuilts.

Bug: n/a
Test: presubmit