### PR TITLE
[Compose] Add policy as a parameter to observeAsState.

### DIFF
--- a/compose/runtime/runtime-livedata/src/main/java/androidx/compose/runtime/livedata/LiveDataAdapter.kt
+++ b/compose/runtime/runtime-livedata/src/main/java/androidx/compose/runtime/livedata/LiveDataAdapter.kt
@@ -51,9 +51,12 @@ fun <T> LiveData<T>.observeAsState(): State<T?> = observeAsState(value)
  * @sample androidx.compose.runtime.livedata.samples.LiveDataWithInitialSample
  */
 @Composable
-fun <R, T : R> LiveData<T>.observeAsState(initial: R): State<R> {
+fun <R, T : R> LiveData<T>.observeAsState(
+    initial: R,
+    policy: SnapshotMutationPolicy<R> = structuralEqualityPolicy()
+): State<R> {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val state = remember { mutableStateOf(initial) }
+    val state = remember { mutableStateOf(initial, policy) }
     DisposableEffect(this, lifecycleOwner) {
         val observer = Observer<T> { state.value = it }
         observe(lifecycleOwner, observer)


### PR DESCRIPTION
## Proposed Changes
Add SnapshotMutationPolicy parameter to observeAsState() to make it possible to control it from outside.

Explanation.

Using unidirectional data flow requires solving a SingleLiveEvent problem. In accordance to official examples on how to operate with LiveData there is a utility class which makes it possible to issue a single event https://github.com/android/architecture-samples/blob/dev-todo-mvvm-live/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/SingleLiveEvent.java

Some libraries doesn't support Compose and require using AndroidView as interop.
For example, map library. Usually it holds state inside and provides some methods to operate with it, like ZoomIn() or ZoomOut().
In this case connecting all these two things together will give something like this:

```
@Composable
fun HomeContent(viewModel: HomeViewModel = viewModel(), onNavigate: (Int) -> Unit) {
    val event: MapControlEvent by viewModel.mapControlEvents.observeAsState(MapControlEvent.CENTER_ON_USER)

    AndroidView(
        factory = { createMapView(it) },
        update = { view -> updateMapView(view, event) }
    )
    Hud(viewModel = viewModel, onNavigate = onNavigate)
}
```

This code won't trigger map updates as intended in case events are the same. For example clicking zoom in (emitting `MapControlEvent.ZOOM_IN`) multiple times at row will only trigger update once.
It happens because of comparison mechanism inside `mutableStateOf()` which makes Compose only trigger on changes (and it is cool).
But in case of SingleLiveEvent it works against. Even snackbar or other single events won't trigger if there is the same message.

## Testing

Test: didn't do anything special, as it provides the same default value mutableStateOf() itself.
