### PR TITLE
[Room][XProcessing] Get all annotations on element

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
@@ -37,8 +37,14 @@ internal fun XAnnotation.unwrapRepeatedAnnotationsFromContainer(): List<XAnnotat
         // type and check that it matches "this" type. However, there seems to be a KSP bug where
         // the value of Repeatable is not present so the best we can do is check that all the nested
         // members are annotated with repeatable.
+        // https://github.com/google/ksp/issues/358
         val isRepeatable = nestedAnnotations.all {
-            it.type.typeElement?.hasAnnotation(Repeatable::class) == true
+            // The java and kotlin versions of Repeatable are not interchangeable.
+            // https://github.com/google/ksp/issues/459 asks whether the built in type mapper
+            // should convert them, but it may not be possible because there are differences
+            // to how they work (eg different parameters).
+            it.type.typeElement?.hasAnnotation(Repeatable::class) == true ||
+            it.type.typeElement?.hasAnnotation(kotlin.annotation.Repeatable::class) == true
         }
 
         if (isRepeatable) nestedAnnotations else null

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import java.lang.annotation.Repeatable
+
+@PublishedApi
+internal interface InternalXAnnotation : XAnnotation {
+    fun <T : Annotation> asAnnotationBox(annotationClass: Class<T>): XAnnotationBox<T>
+}
+
+internal fun XAnnotation.unwrapRepeatedAnnotationsFromContainer(): List<XAnnotation>? {
+    val nestedAnnotations = try {
+        getAsAnnotationList("value")
+    } catch (e: Throwable) {
+        return null
+    }
+
+    // Ideally we would read the value of the Repeatable annotation to get the container class
+    // type and check that it matches "this" type. However, there seems to be a KSP bug where
+    // the value of Repeatable is not present so the best we can do is check that all the nested
+    // members are annotated with repeatable.
+    val isRepeatable = nestedAnnotations.all {
+        it.type.typeElement?.hasAnnotation(Repeatable::class) == true
+    }
+    return if (isRepeatable) nestedAnnotations else null
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
@@ -44,7 +44,7 @@ internal fun XAnnotation.unwrapRepeatedAnnotationsFromContainer(): List<XAnnotat
             // should convert them, but it may not be possible because there are differences
             // to how they work (eg different parameters).
             it.type.typeElement?.hasAnnotation(Repeatable::class) == true ||
-            it.type.typeElement?.hasAnnotation(kotlin.annotation.Repeatable::class) == true
+                it.type.typeElement?.hasAnnotation(kotlin.annotation.Repeatable::class) == true
         }
 
         if (isRepeatable) nestedAnnotations else null

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
@@ -64,9 +64,8 @@ interface XAnnotated {
 
     /**
      * Returns `true` if this element has an annotation that is declared in the given package.
+     * Alternatively, all annotations can be accessed with [getAllAnnotations].
      */
-    // a very sad method but helps avoid abstraction annotation
-    // Possibly deprecate in favor of `getAllAnnotations`?
     fun hasAnnotationWithPackage(pkg: String): Boolean
 
     /**

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
@@ -36,6 +36,15 @@ interface XAnnotated {
         annotation: KClass<T>
     ): List<XAnnotationBox<T>>
 
+    /**
+     * Returns all annotations on this element represented as [XAnnotation].
+     *
+     * As opposed to other functions like [getAnnotations] this does not require you to have a
+     * reference to each annotation class, and thus it can represent annotations in the module
+     * sources being compiled. However, note that the returned [XAnnotation] cannot provide
+     * an instance of the annotation (like [XAnnotationBox.value] can) and instead all values
+     * must be accessed dynamically.
+     */
     fun getAllAnnotations(): List<XAnnotation>
 
     /**

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
@@ -36,6 +36,8 @@ interface XAnnotated {
         annotation: KClass<T>
     ): List<XAnnotationBox<T>>
 
+    fun getAllAnnotations(): List<XAnnotation>
+
     /**
      * Returns `true` if this element is annotated with the given [annotation].
      *
@@ -52,6 +54,7 @@ interface XAnnotated {
      * Returns `true` if this element has an annotation that is declared in the given package.
      */
     // a very sad method but helps avoid abstraction annotation
+    // Possibly deprecate in favor of `getAllAnnotations`?
     fun hasAnnotationWithPackage(pkg: String): Boolean
 
     /**

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotated.kt
@@ -44,6 +44,9 @@ interface XAnnotated {
      * sources being compiled. However, note that the returned [XAnnotation] cannot provide
      * an instance of the annotation (like [XAnnotationBox.value] can) and instead all values
      * must be accessed dynamically.
+     *
+     * The returned [XAnnotation]s can be converted to [XAnnotationBox] via
+     * [XAnnotation.asAnnotationBox] if the annotation class is on the class path.
      */
     fun getAllAnnotations(): List<XAnnotation>
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
@@ -20,7 +20,7 @@ package androidx.room.compiler.processing
  * This wraps annotations that may be declared in sources, and thus not representable with a
  * compiled type. This is an equivalent to the Java AnnotationMirror API.
  *
- * Values in the annotation can be accessed via [valueArguments], the [XAnnotation.get] extension
+ * Values in the annotation can be accessed via [annotationValues], the [XAnnotation.get] extension
  * function, or any of the "getAs*" helper functions.
  *
  * In comparison, [XAnnotationBox] is used in situations where the annotation class is already
@@ -34,6 +34,12 @@ interface XAnnotation {
     val name: String
 
     /**
+     * The fully qualified name of the annotation class.
+     * Accessing this forces the type to be resolved.
+     */
+    val qualifiedName: String
+
+    /**
      * The [XType] representing the annotation class.
      *
      * Accessing this requires resolving the type, and is thus more expensive that just accessing
@@ -42,9 +48,9 @@ interface XAnnotation {
     val type: XType
 
     /**
-     * All properties declared in the annotation class.
+     * All values declared in the annotation class.
      */
-    val valueArguments: List<XValueArgument>
+    val annotationValues: List<XAnnotationValue>
 
     /**
      * Returns the value of the given [methodName] as a type reference.
@@ -90,7 +96,7 @@ interface XAnnotation {
  * For convenience, wrapper functions are provided for these types, eg [XAnnotation.getAsType]
  */
 inline fun <reified T> XAnnotation.get(methodName: String): T {
-    val argument = valueArguments.firstOrNull { it.name == methodName }
+    val argument = annotationValues.firstOrNull { it.name == methodName }
         ?: error("No property named $methodName was found in annotation $name")
 
     return argument.value as? T ?: error(

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import kotlin.reflect.KClass
+
+/**
+ * This wraps annotations that may be declared in sources, and thus not representable with a
+ * compiled type. This is an equivalent to the Java AnnotationMirror API.
+ *
+ * In comparison, [XAnnotationBox] is used in situations where the annotation class is already
+ * compiled and can be referenced. This can be converted with [asAnnotationBox] if the annotation
+ * class is already compiled.
+ */
+interface XAnnotation {
+    /**
+     * The simple name of the annotation class.
+     */
+    val simpleName: String
+
+    /**
+     * The [XType] representing the annotation class.
+     *
+     * Accessing this requires resolving the type, and is thus more expensive that just accessing
+     * [simpleName].
+     */
+    val type: XType
+
+    /**
+     * Returns the value of the given [methodName], throwing an exception if the method is not
+     * found or if the given type [T] does not match the actual type.
+     *
+     * Note that non primitive types are wrapped by interfaces in order to allow them to be
+     * represented by the process:
+     * - "Class" types are represented with [XType]
+     * - Annotations are represented with [XAnnotation]
+     * - Enums are represented with [XEnumEntry]
+     *
+     * For convenience, wrapper functions are provided for these types, eg [getAsType]
+     */
+    fun <T> get(methodName: String): T {
+        val argument = valueArguments.firstOrNull { it.name == methodName }
+            ?: error("No property named $methodName was found in annotation $simpleName")
+
+        @Suppress("UNCHECKED_CAST")
+        return argument.value as T
+    }
+
+    /**
+     * Returns the value of the given [methodName] as a type reference.
+     */
+    fun getAsType(methodName: String): XType? {
+        return get(methodName) as XType?
+    }
+
+    /**
+     * Returns the value of the given [methodName] as a list of type references.
+     */
+    fun getAsTypeList(methodName: String): List<XType> {
+        return get(methodName) as List<XType>
+    }
+
+    /**
+     * Returns the value of the given [methodName] as another [XAnnotation].
+     */
+    fun getAsAnnotation(methodName: String): XAnnotation {
+        return get(methodName) as XAnnotation
+    }
+
+    /**
+     * Returns the value of the given [methodName] as a list of [XAnnotation].
+     */
+    fun getAsAnnotationList(methodName: String): List<XAnnotation> {
+        return get(methodName) as List<XAnnotation>
+    }
+
+    /**
+     * Returns the value of the given [methodName] as a [XEnumEntry].
+     */
+    fun getAsEnum(methodName: String): XEnumEntry {
+        return get(methodName) as XEnumEntry
+    }
+
+    /**
+     * Returns the value of the given [methodName] as a list of [XEnumEntry].
+     */
+    fun getAsEnumList(methodName: String): List<XEnumEntry> {
+        return get(methodName) as List<XEnumEntry>
+    }
+
+    /**
+     * Information about all properties declared in the annotation class.
+     */
+    val valueArguments: List<XValueArgument>
+}
+
+/**
+ * Get a representation of this [XAnnotation] as a [XAnnotationBox].
+ *
+ * Only possible if the annotation class is available (ie it is in the classpath and not in
+ * the compiled sources).
+ */
+inline fun <reified T : Annotation> XAnnotation.asAnnotationBox(): XAnnotationBox<T> {
+    return (this as InternalXAnnotation).asAnnotationBox(T::class.java)
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotation.kt
@@ -31,13 +31,13 @@ interface XAnnotation {
     /**
      * The simple name of the annotation class.
      */
-    val simpleName: String
+    val name: String
 
     /**
      * The [XType] representing the annotation class.
      *
      * Accessing this requires resolving the type, and is thus more expensive that just accessing
-     * [simpleName].
+     * [name].
      */
     val type: XType
 
@@ -91,7 +91,7 @@ interface XAnnotation {
  */
 inline fun <reified T> XAnnotation.get(methodName: String): T {
     val argument = valueArguments.firstOrNull { it.name == methodName }
-        ?: error("No property named $methodName was found in annotation $simpleName")
+        ?: error("No property named $methodName was found in annotation $name")
 
     return argument.value as? T ?: error(
         "Value of $methodName of type ${argument.value?.javaClass} " +
@@ -100,7 +100,8 @@ inline fun <reified T> XAnnotation.get(methodName: String): T {
 }
 
 /**
- * Get a representation of this [XAnnotation] as a [XAnnotationBox].
+ * Get a representation of this [XAnnotation] as a [XAnnotationBox]. This is helpful for converting
+ * to [XAnnotationBox] after getting annotations with [XAnnotated.getAllAnnotations].
  *
  * Only possible if the annotation class is available (ie it is in the classpath and not in
  * the compiled sources).

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotationBox.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotationBox.kt
@@ -19,7 +19,7 @@ package androidx.room.compiler.processing
 /**
  * This wraps an annotation element that is both accessible from the processor and runtime.
  *
- * It won't scale to a general purpose processing APIs where an equivelant of the AnnotationMirror
+ * It won't scale to a general purpose processing APIs where an equivalent of the AnnotationMirror
  * API needs to be provided but works well for Room's case.
  */
 interface XAnnotationBox<T> {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotationValue.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XAnnotationValue.kt
@@ -19,7 +19,7 @@ package androidx.room.compiler.processing
 /**
  * This wraps information about an argument in an annotation.
  */
-interface XValueArgument {
+interface XAnnotationValue {
     /**
      * The property name.
      */
@@ -27,6 +27,14 @@ interface XValueArgument {
 
     /**
      * The value set on the annotation property, or the default value if it was not explicitly set.
+     *
+     * Possible types are:
+     * - Primitives (Boolean, Byte, Int, Long, Float, Double)
+     * - String
+     * - XEnumEntry
+     * - XAnnotation
+     * - XType
+     * - List of any of the above
      */
     val value: Any?
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XEnumEntry.kt
@@ -19,15 +19,16 @@ package androidx.room.compiler.processing
 import kotlin.contracts.contract
 
 /**
- * Type elements that represent Enum declarations.
+ * Represents a named entry within an enum class.
  */
-interface XEnumTypeElement : XTypeElement {
-    val entries: Set<XEnumEntry>
+interface XEnumEntry : XElement {
+    val enumTypeElement: XEnumTypeElement
+    val name: String
 }
 
-fun XTypeElement.isEnum(): Boolean {
+fun XTypeElement.isEnumEntry(): Boolean {
     contract {
-        returns(true) implies (this@isEnum is XEnumTypeElement)
+        returns(true) implies (this@isEnumEntry is XEnumEntry)
     }
-    return this is XEnumTypeElement
+    return this is XEnumEntry
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XEnumEntry.kt
@@ -22,8 +22,15 @@ import kotlin.contracts.contract
  * Represents a named entry within an enum class.
  */
 interface XEnumEntry : XElement {
-    val enumTypeElement: XEnumTypeElement
+    /**
+     * The name of this enum object.
+     */
     val name: String
+
+    /**
+     * The parent enum type declaration that holds all entries for this enum type..
+     */
+    val enumTypeElement: XEnumTypeElement
 }
 
 fun XTypeElement.isEnumEntry(): Boolean {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XValueArgument.kt
@@ -16,18 +16,17 @@
 
 package androidx.room.compiler.processing
 
-import kotlin.contracts.contract
-
 /**
- * Type elements that represent Enum declarations.
+ * This wraps information about an argument in an annotation.
  */
-interface XEnumTypeElement : XTypeElement {
-    val entries: Set<XEnumEntry>
-}
+interface XValueArgument {
+    /**
+     * The property name.
+     */
+    val name: String
 
-fun XTypeElement.isEnum(): Boolean {
-    contract {
-        returns(true) implies (this@isEnum is XEnumTypeElement)
-    }
-    return this is XEnumTypeElement
+    /**
+     * The value set on the annotation property, or the default value if it was not explicitly set.
+     */
+    val value: Any?
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.javac
+
+import androidx.room.compiler.processing.InternalXAnnotated
+import androidx.room.compiler.processing.InternalXAnnotation
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationBox
+import androidx.room.compiler.processing.XNullability
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XValueArgument
+import com.google.auto.common.AnnotationMirrors
+import javax.lang.model.element.AnnotationMirror
+import javax.lang.model.element.QualifiedNameable
+
+internal class JavacAnnotation(
+    val env: JavacProcessingEnv,
+    val mirror: AnnotationMirror
+) : InternalXAnnotation {
+
+
+    override val simpleName: String
+        get() = mirror.annotationType.asElement().simpleName.toString()
+
+    override val type: XType by lazy {
+        JavacDeclaredType(env, mirror.annotationType, XNullability.NONNULL)
+    }
+
+    override val valueArguments: List<XValueArgument>
+        get() {
+            return AnnotationMirrors.getAnnotationValuesWithDefaults(mirror)
+                .map { (executableElement, annotationValue) ->
+                    JavacValueArgument(env, executableElement, annotationValue)
+                }
+        }
+
+    override fun <T : Annotation> asAnnotationBox(annotationClass: Class<T>): XAnnotationBox<T> {
+        return mirror.box(env, annotationClass)
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
@@ -16,22 +16,18 @@
 
 package androidx.room.compiler.processing.javac
 
-import androidx.room.compiler.processing.InternalXAnnotated
 import androidx.room.compiler.processing.InternalXAnnotation
-import androidx.room.compiler.processing.XAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XNullability
 import androidx.room.compiler.processing.XType
 import androidx.room.compiler.processing.XValueArgument
 import com.google.auto.common.AnnotationMirrors
 import javax.lang.model.element.AnnotationMirror
-import javax.lang.model.element.QualifiedNameable
 
 internal class JavacAnnotation(
     val env: JavacProcessingEnv,
     val mirror: AnnotationMirror
 ) : InternalXAnnotation {
-
 
     override val simpleName: String
         get() = mirror.annotationType.asElement().simpleName.toString()

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
@@ -20,8 +20,9 @@ import androidx.room.compiler.processing.InternalXAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XNullability
 import androidx.room.compiler.processing.XType
-import androidx.room.compiler.processing.XValueArgument
+import androidx.room.compiler.processing.XAnnotationValue
 import com.google.auto.common.AnnotationMirrors
+import com.google.auto.common.MoreTypes
 import javax.lang.model.element.AnnotationMirror
 
 internal class JavacAnnotation(
@@ -32,11 +33,14 @@ internal class JavacAnnotation(
     override val name: String
         get() = mirror.annotationType.asElement().simpleName.toString()
 
+    override val qualifiedName: String
+        get() = MoreTypes.asTypeElement(mirror.annotationType).qualifiedName.toString()
+
     override val type: XType by lazy {
         JavacDeclaredType(env, mirror.annotationType, XNullability.NONNULL)
     }
 
-    override val valueArguments: List<XValueArgument>
+    override val annotationValues: List<XAnnotationValue>
         get() {
             return AnnotationMirrors.getAnnotationValuesWithDefaults(mirror)
                 .map { (executableElement, annotationValue) ->

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
@@ -44,7 +44,7 @@ internal class JavacAnnotation(
         get() {
             return AnnotationMirrors.getAnnotationValuesWithDefaults(mirror)
                 .map { (executableElement, annotationValue) ->
-                    JavacValueArgument(env, executableElement, annotationValue)
+                    JavacAnnotationValue(env, executableElement, annotationValue)
                 }
         }
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotation.kt
@@ -29,7 +29,7 @@ internal class JavacAnnotation(
     val mirror: AnnotationMirror
 ) : InternalXAnnotation {
 
-    override val simpleName: String
+    override val name: String
         get() = mirror.annotationType.asElement().simpleName.toString()
 
     override val type: XType by lazy {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationValue.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationValue.kt
@@ -27,7 +27,7 @@ import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.VariableElement
 import javax.lang.model.type.TypeMirror
 
-internal class JavacValueArgument(
+internal class JavacAnnotationValue(
     val env: JavacProcessingEnv,
     val element: ExecutableElement,
     val annotationValue: AnnotationValue

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacElement.kt
@@ -17,9 +17,11 @@
 package androidx.room.compiler.processing.javac
 
 import androidx.room.compiler.processing.InternalXAnnotated
+import androidx.room.compiler.processing.XAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XEquality
+import androidx.room.compiler.processing.unwrapRepeatedAnnotationsFromContainer
 import com.google.auto.common.MoreElements
 import com.google.auto.common.MoreElements.isAnnotationPresent
 import java.util.Locale
@@ -55,6 +57,13 @@ internal abstract class JavacElement(
             ?.let {
                 listOf(it)
             } ?: emptyList()
+    }
+
+    override fun getAllAnnotations(): List<XAnnotation> {
+        return element.annotationMirrors.map { mirror -> JavacAnnotation(env, mirror) }
+            .flatMap { annotation ->
+                annotation.unwrapRepeatedAnnotationsFromContainer() ?: listOf(annotation)
+            }
     }
 
     override fun hasAnnotation(

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
@@ -29,8 +29,9 @@ internal class JavacEnumEntry(
     override val name: String
         get() = element.simpleName.toString()
 
-    override val equalityItems: Array<out Any?>
-        get() = arrayOf(name, enumTypeElement)
+    override val equalityItems: Array<out Any?> by lazy {
+        arrayOf(name, enumTypeElement)
+    }
 
     override val fallbackLocationText: String
         get() = "$name enum entry in ${enumTypeElement.fallbackLocationText}"

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
@@ -19,7 +19,6 @@ package androidx.room.compiler.processing.javac
 import androidx.room.compiler.processing.XEnumEntry
 import androidx.room.compiler.processing.XEnumTypeElement
 import javax.lang.model.element.Element
-import javax.lang.model.element.VariableElement
 
 internal class JavacEnumEntry(
     env: JavacProcessingEnv,

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacEnumEntry.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.javac
+
+import androidx.room.compiler.processing.XEnumEntry
+import androidx.room.compiler.processing.XEnumTypeElement
+import javax.lang.model.element.Element
+import javax.lang.model.element.VariableElement
+
+internal class JavacEnumEntry(
+    env: JavacProcessingEnv,
+    entryElement: Element,
+    override val enumTypeElement: XEnumTypeElement,
+) : JavacElement(env, entryElement), XEnumEntry {
+
+    override val name: String
+        get() = element.simpleName.toString()
+
+    override val equalityItems: Array<out Any?>
+        get() = arrayOf(name, enumTypeElement)
+
+    override val fallbackLocationText: String
+        get() = "$name enum entry in ${enumTypeElement.fallbackLocationText}"
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacTypeElement.kt
@@ -16,6 +16,7 @@
 
 package androidx.room.compiler.processing.javac
 
+import androidx.room.compiler.processing.XEnumEntry
 import androidx.room.compiler.processing.XEnumTypeElement
 import androidx.room.compiler.processing.XFieldElement
 import androidx.room.compiler.processing.XHasModifiers
@@ -179,11 +180,11 @@ internal sealed class JavacTypeElement(
             check(element.kind == ElementKind.ENUM)
         }
 
-        override val enumConstantNames: Set<String> by lazy {
+        override val entries: Set<XEnumEntry> by lazy {
             element.enclosedElements.filter {
                 it.kind == ElementKind.ENUM_CONSTANT
             }.mapTo(mutableSetOf()) {
-                it.simpleName.toString()
+                JavacEnumEntry(env, it, this)
             }
         }
     }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
@@ -16,12 +16,10 @@
 
 package androidx.room.compiler.processing.javac
 
-import androidx.room.compiler.processing.XAnnotation
 import androidx.room.compiler.processing.XEnumTypeElement
 import androidx.room.compiler.processing.XNullability
 import androidx.room.compiler.processing.XValueArgument
 import com.google.auto.common.MoreTypes
-import java.lang.annotation.Repeatable
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
 import javax.lang.model.element.ElementKind
@@ -46,15 +44,12 @@ internal class JavacValueArgument(
         }
         return when {
             // The List implementation further wraps each value as a AnnotationValue.
-            // We don't use arrays because we don't have reified type to instantiate the array
+            // We don't expose arrays because we don't have a reified type to instantiate the array
             // with, and using "Any" prevents the array from being cast to the correct
             // type later on.
             value is List<*> -> value.map { it.unwrapIfNeeded() }
-            // Class types are represented as DeclaredType
             value is TypeMirror -> env.wrap(value, kotlinType = null, XNullability.NONNULL)
-            value is AnnotationMirror -> {
-                JavacAnnotation(env, value)
-            }
+            value is AnnotationMirror -> JavacAnnotation(env, value)
             // Enums are wrapped in a variable element with kind ENUM_CONSTANT
             value is VariableElement -> {
                 when {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.javac
+
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XEnumTypeElement
+import androidx.room.compiler.processing.XNullability
+import androidx.room.compiler.processing.XValueArgument
+import com.google.auto.common.MoreTypes
+import java.lang.annotation.Repeatable
+import javax.lang.model.element.AnnotationMirror
+import javax.lang.model.element.AnnotationValue
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.ExecutableElement
+import javax.lang.model.element.VariableElement
+import javax.lang.model.type.TypeMirror
+
+internal class JavacValueArgument(
+    val env: JavacProcessingEnv,
+    val element: ExecutableElement,
+    val annotationValue: AnnotationValue
+) : XValueArgument {
+    override val name: String
+        get() = element.simpleName.toString()
+
+    override val value: Any? by lazy { annotationValue.unwrap() }
+
+    private fun AnnotationValue.unwrap(): Any? {
+        val value = value
+        fun Any?.unwrapIfNeeded(): Any? {
+            return if (this is AnnotationValue) this.unwrap() else this
+        }
+        return when {
+            // The List implementation further wraps each value as a AnnotationValue.
+            // We don't use arrays because we don't have reified type to instantiate the array
+            // with, and using "Any" prevents the array from being cast to the correct
+            // type later on.
+            value is List<*> -> value.map { it.unwrapIfNeeded() }
+            // Class types are represented as DeclaredType
+            value is TypeMirror -> env.wrap(value, kotlinType = null, XNullability.NONNULL)
+            value is AnnotationMirror -> {
+                JavacAnnotation(env, value)
+            }
+            // Enums are wrapped in a variable element with kind ENUM_CONSTANT
+            value is VariableElement -> {
+                when {
+                    value.kind == ElementKind.ENUM_CONSTANT -> {
+                        val enumTypeElement = MoreTypes.asTypeElement(value.asType())
+                        JavacEnumEntry(
+                            env,
+                            value,
+                            JavacTypeElement.create(env, enumTypeElement) as XEnumTypeElement
+                        )
+                    }
+                    else -> error("Unexpected annotation value $value for argument $name")
+                }
+            }
+            else -> value
+        }
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacValueArgument.kt
@@ -18,7 +18,7 @@ package androidx.room.compiler.processing.javac
 
 import androidx.room.compiler.processing.XEnumTypeElement
 import androidx.room.compiler.processing.XNullability
-import androidx.room.compiler.processing.XValueArgument
+import androidx.room.compiler.processing.XAnnotationValue
 import com.google.auto.common.MoreTypes
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
@@ -31,14 +31,14 @@ internal class JavacValueArgument(
     val env: JavacProcessingEnv,
     val element: ExecutableElement,
     val annotationValue: AnnotationValue
-) : XValueArgument {
+) : XAnnotationValue {
     override val name: String
         get() = element.simpleName.toString()
 
     override val value: Any? by lazy { annotationValue.unwrap() }
 
     private fun AnnotationValue.unwrap(): Any? {
-        val value = value
+        val value = this.value
         fun Any?.unwrapIfNeeded(): Any? {
             return if (this is AnnotationValue) this.unwrap() else this
         }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotated.kt
@@ -18,21 +18,30 @@ package androidx.room.compiler.processing.ksp
 
 import androidx.room.compiler.processing.InternalXAnnotated
 import androidx.room.compiler.processing.XAnnotationBox
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.unwrapRepeatedAnnotationsFromContainer
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import kotlin.reflect.KClass
 
+@OptIn(KspExperimental::class)
 internal sealed class KspAnnotated(
     val env: KspProcessingEnv
 ) : InternalXAnnotated {
     abstract fun annotations(): Sequence<KSAnnotation>
 
     private fun <T : Annotation> findAnnotations(annotation: KClass<T>): Sequence<KSAnnotation> {
-        return annotations().filter {
-            val qName = it.annotationType.resolve().declaration.qualifiedName?.asString()
-            qName == annotation.qualifiedName
-        }
+        return annotations().filter { isSameAnnotationClass(it, annotation) }
+    }
+
+    override fun getAllAnnotations(): List<XAnnotation> {
+        return annotations().map { ksAnnotated ->
+            KspAnnotation(env, ksAnnotated)
+        }.flatMap { annotation ->
+            annotation.unwrapRepeatedAnnotationsFromContainer() ?: listOf(annotation)
+        }.toList()
     }
 
     override fun <T : Annotation> getAnnotations(
@@ -72,10 +81,26 @@ internal sealed class KspAnnotated(
         containerAnnotation: KClass<out Annotation>?
     ): Boolean {
         return annotations().any {
-            val qName = it.annotationType.resolve().declaration.qualifiedName?.asString()
-            qName == annotation.qualifiedName ||
-                (containerAnnotation != null && qName == containerAnnotation.qualifiedName)
+            isSameAnnotationClass(it, annotation) ||
+                (containerAnnotation != null && isSameAnnotationClass(it, containerAnnotation))
         }
+    }
+
+    private fun isSameAnnotationClass(
+        ksAnnotation: KSAnnotation,
+        annotationClass: KClass<out Annotation>
+    ): Boolean {
+        val declaration = ksAnnotation.annotationType.resolve().declaration
+        val qualifiedName = declaration.qualifiedName?.asString() ?: return false
+        if (qualifiedName == annotationClass.qualifiedName) return true
+
+        // In cases where a standard library annotation is looked up the KSP name is the kotlin
+        // version and the KClass is the java version, so we need to map the package names.
+        // TODO: Replace with resolver.mapKotlinNameToJava once
+        // https://github.com/google/ksp/issues/459 is fixed.
+        return annotationClass.simpleName == declaration.simpleName.asString() &&
+            annotationClass.qualifiedName?.startsWith("java.lang.annotation.") == true &&
+            qualifiedName.startsWith("kotlin.annotation")
     }
 
     private class KSAnnotatedDelegate(

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotated.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotated.kt
@@ -92,15 +92,7 @@ internal sealed class KspAnnotated(
     ): Boolean {
         val declaration = ksAnnotation.annotationType.resolve().declaration
         val qualifiedName = declaration.qualifiedName?.asString() ?: return false
-        if (qualifiedName == annotationClass.qualifiedName) return true
-
-        // In cases where a standard library annotation is looked up the KSP name is the kotlin
-        // version and the KClass is the java version, so we need to map the package names.
-        // TODO: Replace with resolver.mapKotlinNameToJava once
-        // https://github.com/google/ksp/issues/459 is fixed.
-        return annotationClass.simpleName == declaration.simpleName.asString() &&
-            annotationClass.qualifiedName?.startsWith("java.lang.annotation.") == true &&
-            qualifiedName.startsWith("kotlin.annotation")
+        return qualifiedName == annotationClass.qualifiedName
     }
 
     private class KSAnnotatedDelegate(

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
@@ -19,7 +19,7 @@ package androidx.room.compiler.processing.ksp
 import androidx.room.compiler.processing.InternalXAnnotation
 import androidx.room.compiler.processing.XAnnotationBox
 import androidx.room.compiler.processing.XType
-import androidx.room.compiler.processing.XValueArgument
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.isArray
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -36,11 +36,14 @@ internal class KspAnnotation(
     override val name: String
         get() = ksAnnotated.shortName.asString()
 
+    override val qualifiedName: String
+        get() = ksType.declaration.qualifiedName?.asString() ?: ""
+
     override val type: XType by lazy {
         env.wrap(ksType, allowPrimitives = true)
     }
 
-    override val valueArguments: List<XValueArgument> by lazy {
+    override val annotationValues: List<XAnnotationValue> by lazy {
         ksAnnotated.arguments.map { arg ->
             KspValueArgument(
                 env, arg,

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.InternalXAnnotation
+import androidx.room.compiler.processing.XAnnotationBox
+import androidx.room.compiler.processing.XType
+import androidx.room.compiler.processing.XValueArgument
+import com.google.devtools.ksp.symbol.KSAnnotation
+
+internal class KspAnnotation(
+    val env: KspProcessingEnv,
+    val ksAnnotated: KSAnnotation
+) : InternalXAnnotation {
+
+    val ksType by lazy { ksAnnotated.annotationType.resolve() }
+
+    override val simpleName: String
+        get() = ksAnnotated.shortName.asString()
+
+    override val type: XType by lazy {
+        env.wrap(ksType, allowPrimitives = true)
+    }
+
+    override val valueArguments: List<XValueArgument> by lazy {
+        ksAnnotated.arguments.map { arg -> KspValueArgument(env, arg) }
+    }
+
+    override fun <T : Annotation> asAnnotationBox(annotationClass: Class<T>): XAnnotationBox<T> {
+        return KspAnnotationBox(
+            env = env,
+            annotationClass = annotationClass,
+            annotation = ksAnnotated
+        )
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
@@ -45,7 +45,7 @@ internal class KspAnnotation(
 
     override val annotationValues: List<XAnnotationValue> by lazy {
         ksAnnotated.arguments.map { arg ->
-            KspValueArgument(
+            KspAnnotationValue(
                 env, arg,
                 isListType = {
                     (ksType.declaration as KSClassDeclaration).getConstructors()

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
@@ -29,7 +29,7 @@ internal class KspAnnotation(
 
     val ksType by lazy { ksAnnotated.annotationType.resolve() }
 
-    override val simpleName: String
+    override val name: String
         get() = ksAnnotated.shortName.asString()
 
     override val type: XType by lazy {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotation.kt
@@ -42,13 +42,16 @@ internal class KspAnnotation(
 
     override val valueArguments: List<XValueArgument> by lazy {
         ksAnnotated.arguments.map { arg ->
-            KspValueArgument(env, arg, isListType = {
-                (ksType.declaration as KSClassDeclaration).getConstructors()
-                    .singleOrNull()
-                    ?.parameters
-                    ?.firstOrNull { it.name == arg.name }
-                    ?.let { env.wrap(it.type).isArray() } == true
-            })
+            KspValueArgument(
+                env, arg,
+                isListType = {
+                    (ksType.declaration as KSClassDeclaration).getConstructors()
+                        .singleOrNull()
+                        ?.parameters
+                        ?.firstOrNull { it.name == arg.name }
+                        ?.let { env.wrap(it.type).isArray() } == true
+                }
+            )
         }
     }
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationValue.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationValue.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSValueArgument
 
-internal class KspValueArgument(
+internal class KspAnnotationValue(
     val env: KspProcessingEnv,
     val valueArgument: KSValueArgument,
     val isListType: () -> Boolean,

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspEnumEntry.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.XEnumEntry
+import androidx.room.compiler.processing.XEnumTypeElement
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+internal class KspEnumEntry(
+    env: KspProcessingEnv,
+    element: KSClassDeclaration,
+    override val enumTypeElement: XEnumTypeElement,
+) : KspTypeElement(env, element), XEnumEntry {
+
+    override val name: String
+        get() = declaration.simpleName.asString()
+
+    companion object {
+        fun create(
+            env: KspProcessingEnv,
+            declaration: KSClassDeclaration,
+        ): KspEnumEntry {
+            require(declaration.classKind == ClassKind.ENUM_ENTRY) {
+                "Expected declaration to be an enum entry but was ${declaration.classKind}"
+            }
+
+            return KspEnumEntry(
+                env,
+                declaration,
+                KspTypeElement.create(
+                    env,
+                    declaration.requireEnclosingMemberContainer(env).declaration as KSClassDeclaration
+                ) as XEnumTypeElement
+            )
+        }
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspEnumEntry.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspEnumEntry.kt
@@ -44,7 +44,9 @@ internal class KspEnumEntry(
                 declaration,
                 KspTypeElement.create(
                     env,
-                    declaration.requireEnclosingMemberContainer(env).declaration as KSClassDeclaration
+                    declaration
+                        .requireEnclosingMemberContainer(env)
+                        .declaration as KSClassDeclaration
                 ) as XEnumTypeElement
             )
         }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeElement.kt
@@ -18,6 +18,7 @@ package androidx.room.compiler.processing.ksp
 
 import androidx.room.compiler.processing.XAnnotated
 import androidx.room.compiler.processing.XConstructorElement
+import androidx.room.compiler.processing.XEnumEntry
 import androidx.room.compiler.processing.XEnumTypeElement
 import androidx.room.compiler.processing.XFieldElement
 import androidx.room.compiler.processing.XHasModifiers
@@ -356,12 +357,13 @@ internal sealed class KspTypeElement(
         env: KspProcessingEnv,
         declaration: KSClassDeclaration
     ) : KspTypeElement(env, declaration), XEnumTypeElement {
-        override val enumConstantNames: Set<String> by lazy {
-            declaration.declarations.filter {
-                it is KSClassDeclaration && it.classKind == ClassKind.ENUM_ENTRY
-            }.mapTo(mutableSetOf()) {
-                it.simpleName.asString()
-            }
+        override val entries: Set<XEnumEntry> by lazy {
+            declaration.declarations
+                .filterIsInstance<KSClassDeclaration>()
+                .filter { it.classKind == ClassKind.ENUM_ENTRY }
+                .mapTo(mutableSetOf()) {
+                    KspEnumEntry(env, it, this)
+                }
         }
     }
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeMapper.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeMapper.kt
@@ -81,7 +81,7 @@ object KspTypeMapper {
         mapping["java.util.List"] = "kotlin.collections.MutableList"
         mapping["java.util.ListIterator"] = "kotlin.collections.ListIterator"
         mapping["java.util.Map"] = "kotlin.collections.MutableMap"
-        mapping["java.util.Map.Entry"] = "Map.kotlin.collections.MutableEntry"
+        mapping["java.util.Map.Entry"] = "kotlin.collections.MutableEntry"
     }
 
     fun swapWithKotlinType(javaType: String): String = mapping[javaType] ?: javaType

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing.ksp
+
+import androidx.room.compiler.processing.XEnumTypeElement
+import androidx.room.compiler.processing.XValueArgument
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSValueArgument
+
+internal class KspValueArgument(
+    val env: KspProcessingEnv,
+    val valueArgument: KSValueArgument
+) :
+    XValueArgument {
+    override val name: String
+        // TODO: I don't think a null name is possible, but not sure recommended way to handle it.
+        get() = valueArgument.name?.asString()!!
+
+    override val value: Any? by lazy { valueArgument.unwrap() }
+
+    private fun KSValueArgument.unwrap(): Any? {
+        fun unwrap(value: Any?): Any? {
+            return when {
+                value is KSType -> {
+                    val declaration = value.declaration
+                    // Wrap enum entries in enum specific type elements
+                    if (declaration is KSClassDeclaration &&
+                        declaration.classKind == ClassKind.ENUM_ENTRY
+                    ) {
+                        KspEnumEntry.create(env, declaration)
+                    } else {
+                        // And otherwise represent class types as generic XType
+                        env.wrap(value, allowPrimitives = true)
+                    }
+                }
+                value is KSAnnotation -> KspAnnotation(env, value)
+                // The List implementation further wraps each value as a AnnotationValue.
+                // We don't use arrays because we don't have reified type to instantiate the array
+                // with, and using "Any" prevents the array from being cast to the correct
+                // type later on.
+                value is List<*> -> value.map { unwrap(it) }
+                else -> value
+            }
+        }
+        return unwrap(value)
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
@@ -25,7 +25,8 @@ import com.google.devtools.ksp.symbol.KSValueArgument
 
 internal class KspValueArgument(
     val env: KspProcessingEnv,
-    val valueArgument: KSValueArgument
+    val valueArgument: KSValueArgument,
+    val isListType: () -> Boolean,
 ) :
     XValueArgument {
     override val name: String
@@ -58,6 +59,16 @@ internal class KspValueArgument(
                 else -> value
             }
         }
-        return unwrap(value)
+        return unwrap(value).let { result ->
+            // TODO: 5/24/21 KSP does not wrap a single item in a list, even though the
+            // return type should be Class<?>[] (only in sources).
+            // https://github.com/google/ksp/issues/172
+            // https://github.com/google/ksp/issues/214
+            if (result !is List<*> && isListType()) {
+                listOf(result)
+            } else {
+                result
+            }
+        }
     }
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspValueArgument.kt
@@ -16,7 +16,7 @@
 
 package androidx.room.compiler.processing.ksp
 
-import androidx.room.compiler.processing.XValueArgument
+import androidx.room.compiler.processing.XAnnotationValue
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
@@ -27,8 +27,8 @@ internal class KspValueArgument(
     val env: KspProcessingEnv,
     val valueArgument: KSValueArgument,
     val isListType: () -> Boolean,
-) :
-    XValueArgument {
+) : XAnnotationValue {
+
     override val name: String
         get() = valueArgument.name?.asString()
             ?: error("Value argument $this does not have a name.")

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
@@ -1,0 +1,709 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import androidx.room.compiler.processing.testcode.JavaAnnotationWithDefaults
+import androidx.room.compiler.processing.testcode.JavaAnnotationWithPrimitiveArray
+import androidx.room.compiler.processing.testcode.JavaAnnotationWithTypeReferences
+import androidx.room.compiler.processing.testcode.JavaEnum
+import androidx.room.compiler.processing.testcode.MainAnnotation
+import androidx.room.compiler.processing.testcode.OtherAnnotation
+import androidx.room.compiler.processing.testcode.RepeatableJavaAnnotation
+import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.XTestInvocation
+import androidx.room.compiler.processing.util.compileFiles
+import androidx.room.compiler.processing.util.getField
+import androidx.room.compiler.processing.util.getMethod
+import androidx.room.compiler.processing.util.getParameter
+import androidx.room.compiler.processing.util.getSystemClasspathFiles
+import androidx.room.compiler.processing.util.runProcessorTest
+import androidx.room.compiler.processing.util.runProcessorTestWithoutKsp
+import androidx.room.compiler.processing.util.typeName
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import com.squareup.javapoet.ClassName
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class XAnnotationTest(
+    private val preCompiled: Boolean
+) {
+    private fun runTest(
+        sources: List<Source>,
+        handler: (XTestInvocation) -> Unit
+    ) {
+        if (preCompiled) {
+            val compiled = compileFiles(sources)
+            val hasKotlinSources = sources.any {
+                it is Source.KotlinSource
+            }
+            val kotlinSources = if (hasKotlinSources) {
+                listOf(
+                    Source.kotlin("placeholder.kt", "class PlaceholderKotlin")
+                )
+            } else {
+                emptyList()
+            }
+            val newSources = kotlinSources + Source.java(
+                "PlaceholderJava",
+                "public class " +
+                    "PlaceholderJava {}"
+            )
+            runProcessorTest(
+                sources = newSources,
+                handler = handler,
+                classpath = listOf(compiled) + getSystemClasspathFiles()
+            )
+        } else {
+            runProcessorTest(
+                sources = sources,
+                handler = handler
+            )
+        }
+    }
+
+    @Test
+    fun readsAnnotationsDeclaredInSources() {
+        val source = Source.kotlin(
+            "MyClass.kt",
+            """
+            annotation class MyAnnotation1(val bar: Int)
+            @MyAnnotation1(bar = 1)
+            class MyClass
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(source),
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("MyClass")
+
+            val allAnnotations = element.getAllAnnotations().filterNot {
+                // Drop metadata annotation in kapt
+                it.simpleName == "Metadata"
+            }
+            assertThat(allAnnotations).hasSize(1)
+
+            val annotation1 = allAnnotations[0]
+            assertThat(annotation1.simpleName)
+                .isEqualTo("MyAnnotation1")
+            assertThat(annotation1.type.typeElement)
+                .isEqualTo(invocation.processingEnv.requireTypeElement("MyAnnotation1"))
+            assertThat(annotation1.get<Int>("bar"))
+                .isEqualTo(1)
+            assertThat(annotation1.valueArguments).hasSize(1)
+            assertThat(annotation1.valueArguments.first().name).isEqualTo("bar")
+            assertThat(annotation1.valueArguments.first().value).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun annotationsInClassPathCanBeBoxed() {
+        val source = Source.kotlin(
+            "MyClass.kt",
+            """
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+            @TestSuppressWarnings("a", "b")
+            class MyClass
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(source)
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("MyClass")
+            val annotation = element.requireAnnotation<TestSuppressWarnings>()
+            assertThat(annotation.simpleName)
+                .isEqualTo(TestSuppressWarnings::class.simpleName)
+            assertThat(annotation.type.typeElement)
+                .isEqualTo(invocation.processingEnv.requireTypeElement(TestSuppressWarnings::class))
+            assertThat(
+                annotation.asAnnotationBox<TestSuppressWarnings>().value.value
+            ).isEqualTo(listOf("a", "b"))
+        }
+    }
+
+    @Test
+    fun readSimpleAnnotationValue() {
+        val source = Source.java(
+            "foo.bar.Baz",
+            """
+            package foo.bar;
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings;
+            @TestSuppressWarnings({"warning1", "warning 2"})
+            public class Baz {
+            }
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(source)
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("foo.bar.Baz")
+            val annotation = element.requireAnnotation<TestSuppressWarnings>()
+
+            val argument = annotation.valueArguments?.single()
+            assertThat(argument.name).isEqualTo("value")
+            assertThat(
+                argument.value
+            ).isEqualTo(
+                // TODO: 5/23/21 Should this be an array to match annotation box?
+                listOf("warning1", "warning 2")
+            )
+        }
+    }
+
+    @Test
+    fun typeReference_javac() {
+        val mySource = Source.java(
+            "foo.bar.Baz",
+            """
+            package foo.bar;
+            import androidx.room.compiler.processing.testcode.MainAnnotation;
+            import androidx.room.compiler.processing.testcode.OtherAnnotation;
+            @MainAnnotation(
+                typeList = {String.class, Integer.class},
+                singleType = Long.class,
+                intMethod = 3,
+                otherAnnotationArray = {
+                    @OtherAnnotation(
+                        value = "other list 1"
+                    ),
+                    @OtherAnnotation("other list 2"),
+                },
+                singleOtherAnnotation = @OtherAnnotation("other single")
+            )
+            public class Baz {
+            }
+            """.trimIndent()
+        )
+        runProcessorTestWithoutKsp(
+            listOf(mySource)
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("foo.bar.Baz")
+            val annotation = element.requireAnnotation<MainAnnotation>()
+
+            assertThat(
+                annotation.get<List<XType>>("typeList")
+            ).containsExactly(
+                invocation.processingEnv.requireType(java.lang.String::class),
+                invocation.processingEnv.requireType(Integer::class)
+            )
+            assertThat(
+                annotation.get<XType>("singleType")
+            ).isEqualTo(
+                invocation.processingEnv.requireType(java.lang.Long::class)
+            )
+
+            assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
+            annotation.get<XAnnotation>("singleOtherAnnotation")
+                .let { other ->
+                    assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                    assertThat(other.get<String>("value"))
+                        .isEqualTo("other single")
+                }
+            annotation.get<List<XAnnotation>>("otherAnnotationArray")
+                .let { boxArray ->
+                    assertThat(boxArray).hasSize(2)
+                    assertThat(boxArray[0].get<String>("value")).isEqualTo("other list 1")
+                    assertThat(boxArray[1].get<String>("value")).isEqualTo("other list 2")
+                }
+        }
+    }
+
+    @Test
+    fun readSimpleAnnotationValue_kotlin() {
+        val source = Source.kotlin(
+            "Foo.kt",
+            """
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+            @TestSuppressWarnings("warning1", "warning 2")
+            class Subject {
+            }
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(source)
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("Subject")
+            val annotation = element.requireAnnotation<TestSuppressWarnings>()
+
+            assertThat(annotation).isNotNull()
+            assertThat(
+                annotation.get<List<String>>("value")
+            ).isEqualTo(
+                listOf("warning1", "warning 2")
+            )
+        }
+    }
+
+    @Test
+    fun typeReference_kotlin() {
+        val mySource = Source.kotlin(
+            "Foo.kt",
+            """
+            import androidx.room.compiler.processing.testcode.MainAnnotation
+            import androidx.room.compiler.processing.testcode.OtherAnnotation
+
+            @MainAnnotation(
+                typeList = [String::class, Int::class],
+                singleType = Long::class,
+                intMethod = 3,
+                otherAnnotationArray = [
+                    OtherAnnotation(
+                        value = "other list 1"
+                    ),
+                    OtherAnnotation(
+                        value = "other list 2"
+                    )
+                ],
+                singleOtherAnnotation = OtherAnnotation("other single")
+            )
+            public class Subject {
+            }
+            """.trimIndent()
+        )
+        runTest(
+            listOf(mySource)
+        ) { invocation ->
+            val element = invocation.processingEnv.requireTypeElement("Subject")
+            val annotation = element.requireAnnotation<MainAnnotation>()
+
+            assertThat(
+                annotation.get<List<XType>>("typeList").map {
+                    it.typeName
+                }
+            ).containsExactly(
+                String::class.typeName(),
+                Int::class.typeName()
+            )
+            assertThat(
+                annotation.get<XType>("singleType")
+            ).isEqualTo(
+                invocation.processingEnv.requireType(Long::class.typeName())
+            )
+
+            assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
+            annotation.get<XAnnotation>("singleOtherAnnotation")
+                .let { other ->
+                    assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                    assertThat(other.get<String>("value"))
+                        .isEqualTo("other single")
+                }
+            annotation.get<List<XAnnotation>>("otherAnnotationArray")
+                .let { boxArray ->
+                    assertThat(boxArray).hasSize(2)
+                    assertThat(boxArray[0].get<String>("value")).isEqualTo("other list 1")
+                    assertThat(boxArray[1].get<String>("value")).isEqualTo("other list 2")
+                }
+        }
+    }
+
+    @Test
+    fun typeReferenceArray_singleItemInJava() {
+        val src = Source.java(
+            "Subject",
+            """
+            import androidx.room.compiler.processing.testcode.JavaAnnotationWithTypeReferences;
+            @JavaAnnotationWithTypeReferences(String.class)
+            class Subject {
+            }
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(src)
+        ) { invocation ->
+            val subject = invocation.processingEnv.requireTypeElement("Subject")
+            val annotation = subject.requireAnnotation<JavaAnnotationWithTypeReferences>()
+            val annotationValue = if (invocation.isKsp && !preCompiled) {
+                // TODO: 5/24/21 KSP does not wrap a single item in a list, even though the
+                // return type should be Class<?>[] (only in sources)
+                // Has a bug already been filed for this?
+                annotation.get<XType>("value")
+            } else {
+                annotation.get<List<XType>>("value").single()
+            }
+            assertThat(annotationValue.typeName).isEqualTo(
+                ClassName.get(String::class.java)
+            )
+        }
+    }
+
+    @Test
+    fun propertyAnnotations() {
+        val src = Source.kotlin(
+            "Foo.kt",
+            """
+            import androidx.room.compiler.processing.testcode.OtherAnnotation
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+            class Subject {
+                @TestSuppressWarnings("onProp1")
+                var prop1:Int = TODO()
+
+                @get:TestSuppressWarnings("onGetter2")
+                @set:TestSuppressWarnings("onSetter2")
+                @field:TestSuppressWarnings("onField2")
+                @setparam:TestSuppressWarnings("onSetterParam2")
+                var prop2:Int = TODO()
+
+                @get:TestSuppressWarnings("onGetter3")
+                @set:TestSuppressWarnings("onSetter3")
+                @setparam:TestSuppressWarnings("onSetterParam3")
+                var prop3:Int
+                    @OtherAnnotation("_onGetter3")
+                    get() = 3
+
+                    @OtherAnnotation("_onSetter3")
+                    set(@OtherAnnotation("_onSetterParam3") value) = Unit
+            }
+            """.trimIndent()
+        )
+        runTest(sources = listOf(src)) { invocation ->
+            val subject = invocation.processingEnv.requireTypeElement("Subject")
+
+            subject.getField("prop1").assertHasSuppressWithValue("onProp1")
+            subject.getMethod("getProp1").assertDoesNotHaveAnnotation()
+            subject.getMethod("setProp1").assertDoesNotHaveAnnotation()
+            subject.getMethod("setProp1").parameters.first().assertDoesNotHaveAnnotation()
+
+            subject.getField("prop2").assertHasSuppressWithValue("onField2")
+            subject.getMethod("getProp2").assertHasSuppressWithValue("onGetter2")
+            subject.getMethod("setProp2").assertHasSuppressWithValue("onSetter2")
+            subject.getMethod("setProp2").parameters.first().assertHasSuppressWithValue(
+                "onSetterParam2"
+            )
+
+            subject.getMethod("getProp3").assertHasSuppressWithValue("onGetter3")
+            subject.getMethod("setProp3").assertHasSuppressWithValue("onSetter3")
+            subject.getMethod("setProp3").parameters.first().assertHasSuppressWithValue(
+                "onSetterParam3"
+            )
+
+            assertThat(
+                subject.getMethod("getProp3").getOtherAnnotationValue()
+            ).isEqualTo("_onGetter3")
+            assertThat(
+                subject.getMethod("setProp3").getOtherAnnotationValue()
+            ).isEqualTo("_onSetter3")
+            val otherAnnotationValue =
+                subject.getMethod("setProp3").parameters.first().getOtherAnnotationValue()
+            assertThat(
+                otherAnnotationValue
+            ).isEqualTo("_onSetterParam3")
+        }
+    }
+
+    @Test
+    fun methodAnnotations() {
+        val src = Source.kotlin(
+            "Foo.kt",
+            """
+            import androidx.room.compiler.processing.testcode.OtherAnnotation
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+            class Subject {
+                fun noAnnotations(x:Int): Unit = TODO()
+                @TestSuppressWarnings("onMethod")
+                fun methodAnnotation(
+                    @TestSuppressWarnings("onParam") annotated:Int,
+                    notAnnotated:Int
+                ): Unit = TODO()
+            }
+            """.trimIndent()
+        )
+        runTest(sources = listOf(src)) { invocation ->
+            val subject = invocation.processingEnv.requireTypeElement("Subject")
+            subject.getMethod("noAnnotations").let { method ->
+                method.assertDoesNotHaveAnnotation()
+                method.getParameter("x").assertDoesNotHaveAnnotation()
+            }
+            subject.getMethod("methodAnnotation").let { method ->
+                method.assertHasSuppressWithValue("onMethod")
+                method.getParameter("annotated").assertHasSuppressWithValue("onParam")
+                method.getParameter("notAnnotated").assertDoesNotHaveAnnotation()
+            }
+        }
+    }
+
+    @Test
+    fun constructorParameterAnnotations() {
+        val src = Source.kotlin(
+            "Foo.kt",
+            """
+            import androidx.room.compiler.processing.testcode.TestSuppressWarnings
+            @TestSuppressWarnings("onClass")
+            data class Subject(
+                @field:TestSuppressWarnings("onField")
+                @param:TestSuppressWarnings("onConstructorParam")
+                @get:TestSuppressWarnings("onGetter")
+                @set:TestSuppressWarnings("onSetter")
+                var x:Int
+            )
+            """.trimIndent()
+        )
+        runTest(sources = listOf(src)) { invocation ->
+            val subject = invocation.processingEnv.requireTypeElement("Subject")
+            subject.assertHasSuppressWithValue("onClass")
+            assertThat(subject.getConstructors()).hasSize(1)
+            val constructor = subject.getConstructors().single()
+            constructor.getParameter("x").assertHasSuppressWithValue("onConstructorParam")
+            subject.getMethod("getX").assertHasSuppressWithValue("onGetter")
+            subject.getMethod("setX").assertHasSuppressWithValue("onSetter")
+            subject.getField("x").assertHasSuppressWithValue("onField")
+        }
+    }
+
+    @Test
+    fun defaultValues() {
+        val kotlinSrc = Source.kotlin(
+            "KotlinClass.kt",
+            """
+            import androidx.room.compiler.processing.testcode.JavaAnnotationWithDefaults
+            @JavaAnnotationWithDefaults
+            class KotlinClass
+            """.trimIndent()
+        )
+        val javaSrc = Source.java(
+            "JavaClass.java",
+            """
+            import androidx.room.compiler.processing.testcode.JavaAnnotationWithDefaults;
+            @JavaAnnotationWithDefaults
+            class JavaClass {}
+            """.trimIndent()
+        )
+        runTest(sources = listOf(kotlinSrc, javaSrc)) { invocation ->
+            listOf("KotlinClass", "JavaClass")
+                .map {
+                    invocation.processingEnv.requireTypeElement(it)
+                }.forEach { typeElement ->
+                    val annotation = typeElement.requireAnnotation<JavaAnnotationWithDefaults>()
+
+                    assertThat(annotation.get<Int>("intVal"))
+                        .isEqualTo(3)
+                    assertThat(annotation.get<List<Int>>("intArrayVal"))
+                        .isEqualTo(listOf(1, 3, 5))
+                    assertThat(annotation.get<List<String>>("stringArrayVal"))
+                        .isEqualTo(listOf("x", "y"))
+                    assertThat(annotation.get<String>("stringVal"))
+                        .isEqualTo("foo")
+                    assertThat(
+                        annotation.get<XType>("typeVal").rawType.typeName
+                    ).isEqualTo(
+                        ClassName.get(HashMap::class.java)
+                    )
+                    assertThat(
+                        annotation.get<List<XType>>("typeArrayVal").map {
+                            it.rawType.typeName
+                        }
+                    ).isEqualTo(
+                        listOf(ClassName.get(LinkedHashMap::class.java))
+                    )
+
+                    val enumValueEntry = annotation.get<XEnumEntry>("enumVal")
+                    assertThat(enumValueEntry.name).isEqualTo("DEFAULT")
+                    val javaEnumType = invocation.processingEnv.requireTypeElement(JavaEnum::class)
+                    assertThat(enumValueEntry.enumTypeElement)
+                        .isEqualTo(javaEnumType)
+
+                    val enumList = annotation.get<List<XEnumEntry>>("enumArrayVal")
+                    assertThat(enumList[0].name).isEqualTo("VAL1")
+                    assertThat(enumList[1].name).isEqualTo("VAL2")
+                    assertThat(enumList[0].enumTypeElement).isEqualTo(javaEnumType)
+                    assertThat(enumList[1].enumTypeElement).isEqualTo(javaEnumType)
+
+                    // TODO: KSP mistakenly sees null for the value in a default annotation in
+                    //  sources. Is there an existing KSP ticket for this?
+                    if (!invocation.isKsp && !preCompiled) {
+
+                        annotation.get<XAnnotation>("otherAnnotationVal")
+                            .let { other ->
+                                assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                                assertThat(other.get<String>("value"))
+                                    .isEqualTo("def")
+                            }
+
+                        annotation.get<List<XAnnotation>>("otherAnnotationArrayVal")
+                            .forEach { other ->
+                                assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                                assertThat(other.get<String>("value"))
+                                    .isEqualTo("v1")
+                            }
+                    }
+                }
+        }
+    }
+
+    @Test
+    fun javaPrimitiveArray() {
+        // TODO: expand this test for other primitive types: 179081610
+        val javaSrc = Source.java(
+            "JavaSubject.java",
+            """
+            import androidx.room.compiler.processing.testcode.*;
+            class JavaSubject {
+                @JavaAnnotationWithPrimitiveArray(intArray = {1, 2, 3})
+                Object annotated1;
+            }
+            """.trimIndent()
+        )
+        val kotlinSrc = Source.kotlin(
+            "KotlinSubject.kt",
+            """
+            import androidx.room.compiler.processing.testcode.*;
+            class KotlinSubject {
+                @JavaAnnotationWithPrimitiveArray(intArray = [1, 2, 3])
+                val annotated1:Any = TODO()
+            }
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(javaSrc, kotlinSrc)
+        ) { invocation ->
+            listOf("JavaSubject", "KotlinSubject").map {
+                invocation.processingEnv.requireTypeElement(it)
+            }.forEach { subject ->
+                val annotation = subject.getField("annotated1")
+                    .requireAnnotation<JavaAnnotationWithPrimitiveArray>()
+                assertThat(
+                    annotation.get<List<Int>>("intArray")
+                ).isEqualTo(
+                    listOf(1, 2, 3)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun javaRepeatableAnnotation() {
+        val javaSrc = Source.java(
+            "JavaSubject",
+            """
+            import ${RepeatableJavaAnnotation::class.qualifiedName};
+            @RepeatableJavaAnnotation("x")
+            @RepeatableJavaAnnotation("y")
+            @RepeatableJavaAnnotation("z")
+            public class JavaSubject {}
+            """.trimIndent()
+        )
+        val kotlinSrc = Source.kotlin(
+            "KotlinSubject.kt",
+            """
+            import ${RepeatableJavaAnnotation::class.qualifiedName}
+            // TODO update when https://youtrack.jetbrains.com/issue/KT-12794 is fixed.
+            // right now, kotlin does not support repeatable annotations.
+            @RepeatableJavaAnnotation.List(
+                RepeatableJavaAnnotation("x"),
+                RepeatableJavaAnnotation("y"),
+                RepeatableJavaAnnotation("z")
+            )
+            public class KotlinSubject
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(javaSrc, kotlinSrc)
+        ) { invocation ->
+            listOf("JavaSubject", "KotlinSubject")
+                .map(invocation.processingEnv::requireTypeElement)
+                .forEach { subject ->
+                    val annotations = subject.getAllAnnotations().filter {
+                        it.simpleName == "RepeatableJavaAnnotation"
+                    }
+                    val values = annotations.map { it.get<String>("value") }
+                    assertWithMessage(subject.qualifiedName)
+                        .that(values)
+                        .containsExactly("x", "y", "z")
+                }
+        }
+    }
+
+    @Test
+    fun javaRepeatableAnnotation_notRepeated() {
+        val javaSrc = Source.java(
+            "JavaSubject",
+            """
+            import ${RepeatableJavaAnnotation::class.qualifiedName};
+            @RepeatableJavaAnnotation("x")
+            public class JavaSubject {}
+            """.trimIndent()
+        )
+        val kotlinSrc = Source.kotlin(
+            "KotlinSubject.kt",
+            """
+            import ${RepeatableJavaAnnotation::class.qualifiedName}
+            @RepeatableJavaAnnotation("x")
+            public class KotlinSubject
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(javaSrc, kotlinSrc)
+        ) { invocation ->
+            listOf("JavaSubject", "KotlinSubject")
+                .map(invocation.processingEnv::requireTypeElement)
+                .forEach { subject ->
+                    val annotations = subject.getAllAnnotations().filter {
+                        it.simpleName == "RepeatableJavaAnnotation"
+                    }
+                    val values = annotations.map { it.get<String>("value") }
+                    assertWithMessage(subject.qualifiedName)
+                        .that(values)
+                        .containsExactly("x")
+                }
+        }
+    }
+
+    // helper function to read what we need
+    private fun XAnnotated.getSuppressValues(): List<String>? {
+        return this.findAnnotation<TestSuppressWarnings>()
+            ?.get<List<String>>("value")
+    }
+
+    private inline fun <reified T : Annotation> XAnnotated.requireAnnotation(): XAnnotation {
+        return findAnnotation<T>() ?: error("Annotation ${T::class} not found on $this")
+    }
+
+    private inline fun <reified T : Annotation> XAnnotated.findAnnotation(): XAnnotation? {
+        return getAllAnnotations().singleOrNull { it.simpleName == T::class.simpleName }
+    }
+
+    private fun XAnnotated.assertHasSuppressWithValue(vararg expected: String) {
+        assertWithMessage("has suppress annotation $this")
+            .that(this.findAnnotation<TestSuppressWarnings>())
+            .isNotNull()
+        assertWithMessage("$this")
+            .that(getSuppressValues())
+            .isEqualTo(expected.toList())
+    }
+
+    private fun XAnnotated.assertDoesNotHaveAnnotation() {
+        assertWithMessage("$this")
+            .that(this.findAnnotation<TestSuppressWarnings>())
+            .isNull()
+        assertWithMessage("$this")
+            .that(this.getSuppressValues())
+            .isNull()
+    }
+
+    private fun XAnnotated.getOtherAnnotationValue(): String? {
+        return this.findAnnotation<OtherAnnotation>()
+            ?.get<String>("value")
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "preCompiled_{0}")
+        fun params() = arrayOf(false, true)
+    }
+}

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
@@ -326,17 +326,10 @@ class XAnnotationTest(
         runTest(
             sources = listOf(src)
         ) { invocation ->
+            if (!invocation.isKsp) return@runTest
             val subject = invocation.processingEnv.requireTypeElement("Subject")
             val annotation = subject.requireAnnotation<JavaAnnotationWithTypeReferences>()
-            val annotationValue = if (invocation.isKsp && !preCompiled) {
-                // TODO: 5/24/21 KSP does not wrap a single item in a list, even though the
-                // return type should be Class<?>[] (only in sources).
-                // https://github.com/google/ksp/issues/172
-                // https://github.com/google/ksp/issues/214
-                annotation.get<XType>("value")
-            } else {
-                annotation.get<List<XType>>("value").single()
-            }
+            val annotationValue = annotation.get<List<XType>>("value").single()
             assertThat(annotationValue.typeName).isEqualTo(
                 ClassName.get(String::class.java)
             )

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
@@ -96,12 +96,12 @@ class XAnnotationTest(
 
             val allAnnotations = element.getAllAnnotations().filterNot {
                 // Drop metadata annotation in kapt
-                it.simpleName == "Metadata"
+                it.name == "Metadata"
             }
             assertThat(allAnnotations).hasSize(1)
 
             val annotation1 = allAnnotations[0]
-            assertThat(annotation1.simpleName)
+            assertThat(annotation1.name)
                 .isEqualTo("MyAnnotation1")
             assertThat(annotation1.type.typeElement)
                 .isEqualTo(invocation.processingEnv.requireTypeElement("MyAnnotation1"))
@@ -128,7 +128,7 @@ class XAnnotationTest(
         ) { invocation ->
             val element = invocation.processingEnv.requireTypeElement("MyClass")
             val annotation = element.requireAnnotation<TestSuppressWarnings>()
-            assertThat(annotation.simpleName)
+            assertThat(annotation.name)
                 .isEqualTo(TestSuppressWarnings::class.simpleName)
             assertThat(annotation.type.typeElement)
                 .isEqualTo(invocation.processingEnv.requireTypeElement(TestSuppressWarnings::class))
@@ -211,7 +211,7 @@ class XAnnotationTest(
             assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
             annotation.get<XAnnotation>("singleOtherAnnotation")
                 .let { other ->
-                    assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                    assertThat(other.name).isEqualTo("OtherAnnotation")
                     assertThat(other.get<String>("value"))
                         .isEqualTo("other single")
                 }
@@ -299,7 +299,7 @@ class XAnnotationTest(
             assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
             annotation.get<XAnnotation>("singleOtherAnnotation")
                 .let { other ->
-                    assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                    assertThat(other.name).isEqualTo("OtherAnnotation")
                     assertThat(other.get<String>("value"))
                         .isEqualTo("other single")
                 }
@@ -530,14 +530,14 @@ class XAnnotationTest(
 
                         annotation.getAsAnnotation("otherAnnotationVal")
                             .let { other ->
-                                assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                                assertThat(other.name).isEqualTo("OtherAnnotation")
                                 assertThat(other.get<String>("value"))
                                     .isEqualTo("def")
                             }
 
                         annotation.getAsAnnotationList("otherAnnotationArrayVal")
                             .forEach { other ->
-                                assertThat(other.simpleName).isEqualTo("OtherAnnotation")
+                                assertThat(other.name).isEqualTo("OtherAnnotation")
                                 assertThat(other.get<String>("value"))
                                     .isEqualTo("v1")
                             }
@@ -619,7 +619,7 @@ class XAnnotationTest(
                 .map(invocation.processingEnv::requireTypeElement)
                 .forEach { subject ->
                     val annotations = subject.getAllAnnotations().filter {
-                        it.simpleName == "RepeatableJavaAnnotation"
+                        it.name == "RepeatableJavaAnnotation"
                     }
                     val values = annotations.map { it.get<String>("value") }
                     assertWithMessage(subject.qualifiedName)
@@ -654,7 +654,7 @@ class XAnnotationTest(
                 .map(invocation.processingEnv::requireTypeElement)
                 .forEach { subject ->
                     val annotations = subject.getAllAnnotations().filter {
-                        it.simpleName == "RepeatableJavaAnnotation"
+                        it.name == "RepeatableJavaAnnotation"
                     }
                     val values = annotations.map { it.get<String>("value") }
                     assertWithMessage(subject.qualifiedName)
@@ -675,7 +675,7 @@ class XAnnotationTest(
     }
 
     private inline fun <reified T : Annotation> XAnnotated.findAnnotation(): XAnnotation? {
-        return getAllAnnotations().singleOrNull { it.simpleName == T::class.simpleName }
+        return getAllAnnotations().singleOrNull { it.name == T::class.simpleName }
     }
 
     private fun XAnnotated.assertHasSuppressWithValue(vararg expected: String) {

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
@@ -103,13 +103,15 @@ class XAnnotationTest(
             val annotation1 = allAnnotations[0]
             assertThat(annotation1.name)
                 .isEqualTo("MyAnnotation1")
+            assertThat(annotation1.qualifiedName)
+                .isEqualTo("MyAnnotation1")
             assertThat(annotation1.type.typeElement)
                 .isEqualTo(invocation.processingEnv.requireTypeElement("MyAnnotation1"))
             assertThat(annotation1.get<Int>("bar"))
                 .isEqualTo(1)
-            assertThat(annotation1.valueArguments).hasSize(1)
-            assertThat(annotation1.valueArguments.first().name).isEqualTo("bar")
-            assertThat(annotation1.valueArguments.first().value).isEqualTo(1)
+            assertThat(annotation1.annotationValues).hasSize(1)
+            assertThat(annotation1.annotationValues.first().name).isEqualTo("bar")
+            assertThat(annotation1.annotationValues.first().value).isEqualTo(1)
         }
     }
 
@@ -130,6 +132,8 @@ class XAnnotationTest(
             val annotation = element.requireAnnotation<TestSuppressWarnings>()
             assertThat(annotation.name)
                 .isEqualTo(TestSuppressWarnings::class.simpleName)
+            assertThat(annotation.qualifiedName)
+                .isEqualTo(TestSuppressWarnings::class.qualifiedName)
             assertThat(annotation.type.typeElement)
                 .isEqualTo(invocation.processingEnv.requireTypeElement(TestSuppressWarnings::class))
             assertThat(
@@ -156,7 +160,7 @@ class XAnnotationTest(
             val element = invocation.processingEnv.requireTypeElement("foo.bar.Baz")
             val annotation = element.requireAnnotation<TestSuppressWarnings>()
 
-            val argument = annotation.valueArguments.single()
+            val argument = annotation.annotationValues.single()
             assertThat(argument.name).isEqualTo("value")
             assertThat(
                 argument.value
@@ -211,7 +215,8 @@ class XAnnotationTest(
             assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
             annotation.get<XAnnotation>("singleOtherAnnotation")
                 .let { other ->
-                    assertThat(other.name).isEqualTo("OtherAnnotation")
+                    assertThat(other.name).isEqualTo(OtherAnnotation::class.simpleName)
+                    assertThat(other.qualifiedName).isEqualTo(OtherAnnotation::class.qualifiedName)
                     assertThat(other.get<String>("value"))
                         .isEqualTo("other single")
                 }
@@ -299,7 +304,8 @@ class XAnnotationTest(
             assertThat(annotation.get<Int>("intMethod")).isEqualTo(3)
             annotation.get<XAnnotation>("singleOtherAnnotation")
                 .let { other ->
-                    assertThat(other.name).isEqualTo("OtherAnnotation")
+                    assertThat(other.name).isEqualTo(OtherAnnotation::class.simpleName)
+                    assertThat(other.qualifiedName).isEqualTo(OtherAnnotation::class.qualifiedName)
                     assertThat(other.get<String>("value"))
                         .isEqualTo("other single")
                 }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
@@ -962,7 +962,7 @@ class XTypeElementTest {
                         containsNoneOf("VAL1", "VAL2")
                     }
                 assertWithMessage("$qName can return enum constants")
-                    .that((typeElement as XEnumTypeElement).enumConstantNames)
+                    .that((typeElement as XEnumTypeElement).entries.map { it.name })
                     .containsExactly("VAL1", "VAL2")
                 assertWithMessage("$qName  does not report enum constants in fields")
                     .that(typeElement.getAllFieldNames())

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/EnumColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/EnumColumnTypeAdapter.kt
@@ -90,7 +90,7 @@ class EnumColumnTypeAdapter(
                         beginControlFlow("if ($N == null)", param)
                         addStatement("return null")
                         nextControlFlow("switch ($N)", param)
-                        enumTypeElement.enumConstantNames.forEach { enumConstantName ->
+                        enumTypeElement.entries.map { it.name }.forEach { enumConstantName ->
                             addStatement("case $L: return $S", enumConstantName, enumConstantName)
                         }
                         addStatement(
@@ -127,7 +127,7 @@ class EnumColumnTypeAdapter(
                         beginControlFlow("if ($N == null)", param)
                         addStatement("return null")
                         nextControlFlow("switch ($N)", param)
-                        enumTypeElement.enumConstantNames.forEach { enumConstantName ->
+                        enumTypeElement.entries.map { it.name }.forEach { enumConstantName ->
                             addStatement(
                                 "case $S: return $T.$L",
                                 enumConstantName, out.typeName, enumConstantName


### PR DESCRIPTION
## Proposed Changes
Adds `getAllAnnotations` to XAnnotated to support retrieving the complete list of annotations on an element without having to query them specifically by class. This allows us to read information on annotations without prior knowledge of what they are. To represent this information I created a new XAnnotation interface because XAnnotationBox requires the class to already be compiled - however, I do have an extension function to convert XAnnotation to XAnnotationBox when the class is available.

This includes support for repeatable annotations, and non primitive types for classes, enums, and annotations (as well as the list varieties).

I ran into a few KSP problems and linked KSP github issues where appropriate.

## Testing

Test: Added XAnnotationTest, which adopts the same tests from XAnnotationBoxTest

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/188853151
