### PR TITLE
[Fragment] Fixed IndexOutOfBoundsException on fragment transition issue

### DIFF
--- a/fragment/fragment/src/main/java/androidx/fragment/app/DefaultSpecialEffectsController.java
+++ b/fragment/fragment/src/main/java/androidx/fragment/app/DefaultSpecialEffectsController.java
@@ -713,7 +713,8 @@ class DefaultSpecialEffectsController extends SpecialEffectsController {
                 }
             }
         } else {
-            if (!transitioningViews.contains(view)) {
+            if (!transitioningViews.contains(view)
+                    && ViewCompat.getTransitionName(view) != null) {
                 transitioningViews.add(view);
             }
         }


### PR DESCRIPTION
## Description
The issue is caused because transition names for elements that are not `ViewGroup` are not null checked, so elements not intended to be a part of the transition are added to the list

## Testing

Test: Could not test the fix.

## Issues Fixed

Fixes: [IndexOutOfBoundsException on fragment transition](https://issuetracker.google.com/issues/188859853) 
