### PR TITLE
Use matrix build to simply the build file

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,7 +2,7 @@ name: AndroidX Presubmits
 on:
   push:
     branches:
-      - yigit/workflow-cleanup
+      - androidx-main
   pull_request_target:
     types: ['labeled']
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -2,7 +2,7 @@ name: AndroidX Presubmits
 on:
   push:
     branches:
-      - androidx-main
+      - yigit/workflow-cleanup
   pull_request_target:
     types: ['labeled']
 
@@ -108,138 +108,22 @@ jobs:
           gradle-executable: activity/gradlew
           wrapper-directory: activity/gradle/wrapper
           wrapper-cache-enabled: true
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-activity:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "activity"
-      project-root: "activity"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-biometric:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "biometric"
-      project-root: "biometric"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-compose-compiler:
+  build-modules:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+        project: ["activity", "biometric", "compose-compiler", "fragment", "lifecycle", "navigation", "paging", "room", "work"]
+        include:
+          - project: "compose-compiler"
+            project-root: "compose/compiler"
+          - project: "navigation"
+            custom-os: "macos-latest" # run one of them on a mac to ensure mac setup works
+    runs-on: ${{ matrix.custom-os || matrix.os }}
     needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
     env:
-      artifact-id: "compose_compiler"
-      project-root: "compose/compiler"
+      artifact-id: ${{matrix.project}}
+      project-root: ${{matrix.project-root || matrix.project}}
     steps:
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
@@ -279,367 +163,13 @@ jobs:
         with:
           name: artifacts_${{ env.artifact-id }}
           path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-fragment:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "fragment"
-      project-root: "fragment"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-lifecycle:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "lifecycle"
-      project-root: "lifecycle"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-navigation:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "navigation"
-      project-root: "navigation"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-paging:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "paging"
-      project-root: "paging"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-room:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "room"
-      project-root: "room"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
-
-  build-work:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
-    needs: [setup, lint]
-    outputs:
-      status: ${{ steps.output-status.outputs.status }}
-    env:
-      artifact-id: "work"
-      project-root: "work"
-    steps:
-      - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: "Setup JDK 11"
-        id: setup-java
-        uses: actions/setup-java@v1
-        with:
-          java-version: "11"
-
-      - name: "Set environment variables"
-        shell: bash
-        run: |
-          set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
-          echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-
-      - name: "./gradlew buildOnServer"
-        uses: eskatos/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
-
-      - name: "Upload build artifacts"
-        continue-on-error: true
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
-
-      - name: "Report job status"
-        id: output-status
-        if: always()
-        run: echo ::set-output name=status::${{ job.status }}
 
   teardown:
     runs-on: ubuntu-latest
     needs: [
       setup,
       lint,
-      build-activity,
-      build-biometric,
-      build-compose-compiler,
-      build-fragment,
-      build-lifecycle,
-      build-navigation,
-      build-paging,
-      build-room,
-      build-work
+      build-modules
     ]
     if: always()
     steps:
@@ -647,16 +177,8 @@ jobs:
         id: workflow-status
         run: |
           set -x
-          if [ "${{ needs.lint.outputs.status }}" == "success" ]                  && \
-            [ "${{ needs.build-activity.outputs.status }}" == "success" ]         && \
-            [ "${{ needs.build-biometric.outputs.status }}" == "success" ]        && \
-            [ "${{ needs.build-compose-compiler.outputs.status }}" == "success" ] && \
-            [ "${{ needs.build-fragment.outputs.status }}" == "success" ]         && \
-            [ "${{ needs.build-lifecycle.outputs.status }}" == "success" ]        && \
-            [ "${{ needs.build-navigation.outputs.status }}" == "success" ]       && \
-            [ "${{ needs.build-paging.outputs.status }}" == "success" ]           && \
-            [ "${{ needs.build-room.outputs.status }}" == "success" ]             && \
-            [ "${{ needs.build-work.outputs.status }}" == "success" ]
+          if [ "${{ needs.lint.result }}" == "success" ]                  && \
+            [ "${{ needs.build-modules.result }}" == "success" ]
           then
             echo "::set-output name=result::success"
           else
@@ -678,4 +200,3 @@ jobs:
           url: 'https://androidx.dev/github/androidX/presubmit/hook'
           secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
           payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "completed", "success": false }'
-


### PR DESCRIPTION
Moved module builds to a matrix setup to clean duplicated builds.
Use job outputs instead of custom output variables.

Bug: n/a
Test: https://github.com/androidx/androidx/actions/runs/884479260