### PR TITLE
Run zip test apks tasks in server builds

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -143,7 +143,7 @@ jobs:
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
-      - name: "./gradlew buildOnServer"
+      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
         uses: eskatos/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}


### PR DESCRIPTION
buildOnServer does not build test apks anymore for library modules.

This PR adds the zip apks task to build them.

This is not fully ideal as it will zip apks into the dist (which already
gets zipped as github artifact). But using the same task has the added
benefit of staying close to the mainline.

Bug: n/a
Test: presubmit run outputs for the PR (on push target)