### PR TITLE
Build all test APKs in playground

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -144,12 +144,12 @@ jobs:
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
-      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
+      - name: "./gradlew buildOnServer buildTestApks"
         uses: eskatos/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
-          arguments: buildOnServer zipTestConfigsWithApks ${{ needs.setup.outputs.gradlew_flags }}
+          arguments: buildOnServer buildTestApks ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}
           configuration-cache-enabled: true
           dependencies-cache-enabled: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - androidx-main
-      - yigit/dist-all-test-apks
   pull_request_target:
     types: ['labeled']
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -149,7 +149,7 @@ jobs:
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
-          arguments: buildOnServer ${{ needs.setup.outputs.gradlew_flags }}
+          arguments: buildOnServer zipTestConfigsWithApks ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}
           configuration-cache-enabled: true
           dependencies-cache-enabled: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -143,7 +143,7 @@ jobs:
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
-      - name: "./gradlew buildOnServer"
+      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
         uses: eskatos/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - androidx-main
+      - yigit/dist-all-test-apks
   pull_request_target:
     types: ['labeled']
 


### PR DESCRIPTION
AOSP no longer builds all test apks in buildOnServer.
This PR updates our workflow to explicitly build library test apks so we can run their integration tests.

Bug: n/a
Test: https://github.com/androidx/androidx/actions/runs/907560247