### PR TITLE
Implement XTypeElement.getEnclosedTypeElements

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XTypeElement.kt
@@ -157,4 +157,9 @@ interface XTypeElement : XHasModifiers, XElement, XMemberContainer {
      * List of interfaces implemented by this class
      */
     fun getSuperInterfaceElements(): List<XTypeElement>
+
+    /**
+     * Returns the list of all classes nested directly within this class.
+     */
+    fun getEnclosedTypeElements(): List<XTypeElement>
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XTypeElement.kt
@@ -159,7 +159,8 @@ interface XTypeElement : XHasModifiers, XElement, XMemberContainer {
     fun getSuperInterfaceElements(): List<XTypeElement>
 
     /**
-     * Returns the list of all classes nested directly within this class.
+     * Returns the list of all classes nested directly within this class, including companion
+     * objects.
      */
     fun getEnclosedTypeElements(): List<XTypeElement>
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacTypeElement.kt
@@ -130,6 +130,12 @@ internal sealed class JavacTypeElement(
         }
     }
 
+    override fun getEnclosedTypeElements(): List<XTypeElement> {
+        return ElementFilter.typesIn(element.enclosedElements).map {
+            env.wrapTypeElement(it)
+        }
+    }
+
     override val type: JavacDeclaredType by lazy {
         env.wrap<JavacDeclaredType>(
             typeMirror = element.asType(),

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspTypeElement.kt
@@ -337,6 +337,12 @@ internal sealed class KspTypeElement(
             }
     }
 
+    override fun getEnclosedTypeElements(): List<XTypeElement> {
+        return declaration.declarations.filterIsInstance<KSClassDeclaration>()
+            .map { env.wrapClassDeclaration(it) }
+            .toList()
+    }
+
     override fun toString(): String {
         return declaration.toString()
     }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
@@ -986,6 +986,9 @@ class XTypeElementTest {
                 enum class NestedEnum {
                     A, B
                 }
+                companion object {
+                    val foo = 1
+                }
             }
             """.trimIndent()
         )
@@ -999,6 +1002,7 @@ class XTypeElementTest {
                     invocation.processingEnv.requireTypeElement("TopLevelClass.NestedObject"),
                     invocation.processingEnv.requireTypeElement("TopLevelClass.NestedInterface"),
                     invocation.processingEnv.requireTypeElement("TopLevelClass.NestedEnum"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.Companion"),
                 )
         }
     }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XTypeElementTest.kt
@@ -974,6 +974,64 @@ class XTypeElementTest {
         }
     }
 
+    @Test
+    fun enclosedTypes() {
+        val src = Source.kotlin(
+            "Foo.kt",
+            """
+            class TopLevelClass {
+                class NestedClass
+                object NestedObject
+                interface NestedInterface
+                enum class NestedEnum {
+                    A, B
+                }
+            }
+            """.trimIndent()
+        )
+        runProcessorTest(sources = listOf(src)) { invocation ->
+            val topLevelClass = invocation.processingEnv.requireTypeElement("TopLevelClass")
+            val enclosedTypeElements = topLevelClass.getEnclosedTypeElements()
+
+            assertThat(enclosedTypeElements)
+                .containsExactly(
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedClass"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedObject"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedInterface"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedEnum"),
+                )
+        }
+    }
+
+    @Test
+    fun enclosedTypes_java() {
+        val src = Source.java(
+            "Source",
+            """
+            class TopLevelClass {
+                class InnerClass { }
+                static class NestedClass { }
+                interface NestedInterface { }
+                enum NestedEnum {
+                    A, B
+                }
+            }
+            """.trimIndent()
+        )
+        runProcessorTest(sources = listOf(src)) { invocation ->
+            val topLevelClass = invocation.processingEnv.requireTypeElement("TopLevelClass")
+            val enclosedTypeElements = topLevelClass.getEnclosedTypeElements()
+
+            assertThat(enclosedTypeElements)
+                .containsExactly(
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.InnerClass"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedClass"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedInterface"),
+                    invocation.processingEnv.requireTypeElement("TopLevelClass.NestedEnum"),
+                )
+        }
+    }
+
     /**
      * it is good to exclude methods coming from Object when testing as they differ between KSP
      * and KAPT but irrelevant for Room.


### PR DESCRIPTION
## Proposed Changes
Implement XTypeElement.getEnclosedTypeElements to be able to access classes declared within another class.

## Testing

Test: Added tests to XTypeElementTest

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/190089681
