### PR TITLE
specify tools jar environment variable

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - androidx-main
-      - yigit/fix-java-tools-jar
   pull_request_target:
     types: ['labeled']
 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - androidx-main
+      - yigit/fix-java-tools-jar
   pull_request_target:
     types: ['labeled']
 
@@ -129,7 +130,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 1
-
+      - name: "Setup JDK 8 for tools.jar"
+        id: setup-java8
+        uses: actions/setup-java@v1
+        with:
+          java-version: "8"
+      - name: "set tools jar path"
+        id: setup-tools-jar
+        run: |
+          set -x
+          TOOLS_JAR=$JAVA_HOME/lib/tools.jar
+          echo "::set-output name=toolsJar::$TOOLS_JAR"
       - name: "Setup JDK 11"
         id: setup-java
         uses: actions/setup-java@v1
@@ -147,6 +158,7 @@ jobs:
         uses: eskatos/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+          JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
         with:
           arguments: buildOnServer buildTestApks ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}


### PR DESCRIPTION
this PR changes github build to also setup jdk8 to get a path to the tools.jar file, which is necessary to build Doclava

Bug: n/a
Test: on prod :)