### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -56,29 +56,10 @@ jobs:
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
-      - name: "Compute actions/checkout arguments"
-        id: checkout-args
-        run: |
-          set -x
-
-          REF=${{ github.event.pull_request.head.ref }}
-          if [ -z "$REF" ]; then
-            REF=${{ github.event.ref }}
-          fi
-          echo "::set-output name=ref::$REF"
-
-          REPOSITORY=${{ github.event.pull_request.head.repo.full_name }}
-          if [ -z "$REPOSITORY" ]; then
-            REPOSITORY=${{ github.repository }}
-          fi
-          echo "::set-output name=repository::$REPOSITORY"
-
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
         with:
-          ref: ${{ steps.checkout-args.outputs.ref }}
-          repository: ${{ steps.checkout-args.outputs.repository }}
-          fetch-depth: 0 # Need full depth for changed-files-action
+          fetch-depth: 1
 
       - name: "Get changed files in push or pull_request"
         id: changed-files
@@ -102,7 +83,7 @@ jobs:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
           arguments: -q :ktlintCheckFile ${{ steps.ktlint-file-args.outputs.ktlint-file-args }} ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: activity
+          build-root-directory: room
           configuration-cache-enabled: true
           dependencies-cache-enabled: true
           gradle-executable: activity/gradlew


### PR DESCRIPTION
Use room instead of activity for ktlint since room doesn't depend on
compose, hence more stable.
Remove custom checkout logic for lint since we don't need git history
anymore

Bug: n/a
Test: CI