### PR TITLE
Compute checkout params for builds

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -1,8 +1,6 @@
 name: AndroidX Presubmits
 on:
   push:
-    branches:
-      - androidx-main
   pull_request_target:
     types: ['labeled']
 
@@ -13,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       gradlew_flags: ${{ steps.global-constants.outputs.gradlew_flags }}
+      checkout_ref: ${{ steps.checkout-args.outputs.ref }}
+      checkout_repo: ${{ steps.checkout-args.outputs.repository }}
     steps:
       - name: "Start webhook"
         uses: androidx/github-workflow-webhook-action@main
@@ -30,6 +30,22 @@ jobs:
             -Dorg.gradle.internal.repository.initial.backoff=500             \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
+      - name: "Compute actions/checkout arguments"
+        id: checkout-args
+        run: |
+          set -x
+
+          REF=${{ github.event.pull_request.head.ref }}
+          if [ -z "$REF" ]; then
+            REF=${{ github.event.ref }}
+          fi
+          echo "::set-output name=ref::$REF"
+
+          REPOSITORY=${{ github.event.pull_request.head.repo.full_name }}
+          if [ -z "$REPOSITORY" ]; then
+            REPOSITORY=${{ github.repository }}
+          fi
+          echo "::set-output name=repository::$REPOSITORY"
 
   lint:
     runs-on: ubuntu-latest
@@ -59,6 +75,8 @@ jobs:
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
         with:
+          ref: ${{ needs.setup.outputs.checkout_ref }}
+          repository: ${{ needs.setup.outputs.checkout_repo }}
           fetch-depth: 1
 
       - name: "Get changed files in push or pull_request"
@@ -109,6 +127,8 @@ jobs:
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
         with:
+          ref: ${{ needs.setup.outputs.checkout_ref }}
+          repository: ${{ needs.setup.outputs.checkout_repo }}
           fetch-depth: 1
       - name: "Setup JDK 8 for tools.jar"
         id: setup-java8


### PR DESCRIPTION
This fixes a bug where we would sometimes not checkout the right repository for
the build.

Bug: n/a
Test: CI