### PR TITLE
Ignore output of grep when counting changed modules

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -178,7 +178,7 @@ jobs:
         id: affected-module-count
         run: |
           set -x
-          AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt`
+          AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt || true`
           echo "::set-output name=count::$AFFECTED_MODULE_COUNT"
       - name: "./gradlew buildOnServer buildTestApks"
         uses: eskatos/gradle-command-action@v1


### PR DESCRIPTION
This PR fixes a bug in affected module detection where if the
result is 0, grep will exit with 1 so the build fails.

We just want the match count, not grep exit code so this PR
updates the workflow to ignore grep exit code.

Bug: n/a
Test: local
