### PR TITLE
trigger webhooks in workflow_run actions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,9 +32,7 @@ jobs:
           path: ${{ steps.dirs.outputs.output-dir }}
   teardown:
     runs-on: ubuntu-latest
-    needs: [
-      run_integration_tests
-    ]
+    needs: [run_integration_tests]
     if: always()
     steps:
       - name: Parse workflow status
@@ -44,9 +42,9 @@ jobs:
           if [ "${{ needs.run_integration_tests.result }}" == "success" ]                  && \
             [ "${{ github.event.workflow_run.conclusion }}" == "success" ]
           then
-            echo "::set-output name=result::success"
+            echo "::set-output name=result::true"
           else
-            echo "::set-output name=result::failure"
+            echo "::set-output name=result::false"
           fi
 
       - name: Result WebHook
@@ -54,4 +52,4 @@ jobs:
         with:
           url: 'https://androidx.dev/github/androidX/presubmit/hook'
           secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
-          payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "completed", "src" : "workflow_run", "success": ${{ steps.workflow-status.outputs.result == 'success' }} }'
+          payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "completed", "success": ${{ steps.workflow-status.outputs.result }}, "src" : "workflow_run" }'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,3 +30,28 @@ jobs:
         with:
           name: outputs
           path: ${{ steps.dirs.outputs.output-dir }}
+  teardown:
+    runs-on: ubuntu-latest
+    needs: [
+      run_integration_tests
+    ]
+    if: always()
+    steps:
+      - name: Parse workflow status
+        id: workflow-status
+        run: |
+          set -x
+          if [ "${{ needs.run_integration_tests.result }}" == "success" ]                  && \
+            [ "${{ github.event.workflow_run.conclusion }}" == "success" ]
+          then
+            echo "::set-output name=result::success"
+          else
+            echo "::set-output name=result::failure"
+          fi
+
+      - name: Result WebHook
+        uses: androidx/github-workflow-webhook-action@main
+        with:
+          url: 'https://androidx.dev/github/androidX/presubmit/hook'
+          secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
+          payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "completed", "src" : "workflow_run", "success": ${{ steps.workflow-status.outputs.result == 'success' }} }'

--- a/.github/workflows/register_workflow_start.yml
+++ b/.github/workflows/register_workflow_start.yml
@@ -1,0 +1,16 @@
+name: Register Workflow Run with AndroidX
+on:
+  workflow_run:
+    workflows: ["AndroidX Presubmits"]
+    types: [requested]
+
+jobs:
+  ping_androidx_dev:
+    runs-on: ubuntu-latest
+    - name: "Start webhook"
+      uses: androidx/github-workflow-webhook-action@main
+      with:
+        url: 'https://androidx.dev/github/androidX/presubmit/hook'
+        secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
+        payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "started", "src" : "workflow_run"}'
+

--- a/.github/workflows/register_workflow_start.yml
+++ b/.github/workflows/register_workflow_start.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   ping_androidx_dev:
     runs-on: ubuntu-latest
-    - name: "Start webhook"
-      uses: androidx/github-workflow-webhook-action@main
-      with:
-        url: 'https://androidx.dev/github/androidX/presubmit/hook'
-        secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
-        payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "started", "src" : "workflow_run"}'
-
+    name: "Start webhook"
+    steps:
+      - name: "Ping AndroidX hook"
+        uses: androidx/github-workflow-webhook-action@main
+        with:
+          url: 'https://androidx.dev/github/androidX/presubmit/hook'
+          secret: ${{ secrets.ANDROIDX_PRESUBMIT_HOOK_SECRET }}
+          payload: '{ "platform": "all", "token": "${{ secrets.GITHUB_TOKEN }}", "state": "started", "src" : "workflow_run"}'


### PR DESCRIPTION
This PR creates a duplicate call to androidx.dev hooks about workflows.

It adds an additional parameter, src, so that we can distinguish it in the logs.

Bug: n/a
Test: workflow runs only trigger from main branch so i cannot test this on prod without
merging