### PR TITLE
[Navigation] Allow exact deep links to contain query parameters

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
@@ -109,7 +109,7 @@ class NavDestinationAndroidTest {
 
         destination.addDeepLink("www.example.com/users/index.html")
 
-        destination.addArgument("id", stringArgument())
+        destination.addArgument("name", stringArgument())
         destination.addDeepLink("www.example.com/users/{name}")
 
         val match = destination.matchDeepLink(
@@ -122,6 +122,31 @@ class NavDestinationAndroidTest {
         assertWithMessage("Deep link should pick the exact match")
             .that(match?.matchingArgs?.size())
             .isEqualTo(0)
+    }
+
+    @Test
+    fun matchDeepLinkBestMatchExactWithQuery() {
+        val destination = NoOpNavigator().createDestination()
+
+        destination.addArgument("tab", stringArgument())
+        destination.addDeepLink("www.example.com/users/anonymous?tab={tab}")
+
+        destination.addArgument("name", stringArgument())
+        destination.addDeepLink("www.example.com/users/{name}?tab={tab}")
+
+        val match = destination.matchDeepLink(
+            Uri.parse("https://www.example.com/users/anonymous?tab=favorite")
+        )
+
+        assertWithMessage("Deep link should match")
+            .that(match)
+            .isNotNull()
+        assertWithMessage("Deep link should pick the exact match with query")
+            .that(match?.matchingArgs?.size())
+            .isEqualTo(1)
+        assertWithMessage("Deep link should extract tab argument correctly")
+            .that(match?.matchingArgs?.getString("tab"))
+            .isEqualTo("favorite")
     }
 
     @Test

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -386,13 +386,12 @@ public class NavDeepLink internal constructor(
             if (isParameterizedQuery) {
                 var matcher = Pattern.compile("(\\?)").matcher(uriPattern)
                 if (matcher.find()) {
-                    buildPathRegex(
+                    isExactDeepLink = buildPathRegex(
                         uriPattern.substring(0, matcher.start()),
                         uriRegex,
                         fillInPattern
                     )
                 }
-                isExactDeepLink = false
                 for (paramName in parameterizedUri.queryParameterNames) {
                     val argRegex = StringBuilder()
                     val queryParam = parameterizedUri.getQueryParameter(paramName) as String


### PR DESCRIPTION
## Proposed Changes

  - Allow exact deep links to contain query parameters
  - Prefer an exact deep link with query parameters over a regular link with query parameters:
  
For example if we have two deep links:
- `myapp://example.io/messages/{userId}?message={messageId}`
- `myapp://example.io/messages/anonymous?message={messageId}`

And the link: `myapp://example.io/messages/anonymous?message=1`,  
prefer the second deep link over the first one.

## Testing

Corresponding tests added to NavDestinationAndroidTest
Test: ./gradlew test connectedCheck

## Issues Fixed

Fixes: [185527156](https://issuetracker.google.com/issues/185527156)
