### PR TITLE
[Navigation] Check that all required arguments are present in the link

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -210,10 +210,7 @@ class NavDeepLinkTest {
         val id = 211
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse(deepLinkArgument.replace("{id}", id.toString())),
-            mapOf(
-                "id" to intArgument(),
-                "myarg" to stringArgument()
-            )
+            mapOf("id" to intArgument())
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -332,7 +329,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users"),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -369,7 +366,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse(deepLinkArgument),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -442,7 +439,7 @@ class NavDeepLinkTest {
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users?id={id}".replace("{id}", id.toString())),
             mapOf(
                 "id" to intArgument(),
-                "optional" to nullableStringArgument()
+                "optional" to nullableStringArgument(null)
             )
         )
         assertWithMessage("Args should not be null")
@@ -536,7 +533,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users?id={id}&extraParam={extraParam}"),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -574,7 +571,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users"),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -627,7 +624,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users"),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -738,8 +735,8 @@ class NavDeepLinkTest {
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users"),
             mapOf(
-                "first" to nullableStringArgument(),
-                "last" to nullableStringArgument()
+                "first" to nullableStringArgument(null),
+                "last" to nullableStringArgument(null)
             )
         )
         assertWithMessage("Args should not be null")
@@ -799,7 +796,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users?productId=wildCardMatch-{myarg}"),
-            mapOf("myarg" to nullableStringArgument())
+            mapOf("myarg" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -913,7 +910,7 @@ class NavDeepLinkTest {
 
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse("$DEEP_LINK_EXACT_HTTPS/users"),
-            mapOf("path" to nullableStringArgument())
+            mapOf("path" to nullableStringArgument(null))
         )
         assertWithMessage("Args should not be null")
             .that(matchArgs)
@@ -1113,7 +1110,7 @@ class NavDeepLinkTest {
             .replace("{param}", param.toString())
         val matchArgs = deepLink.getMatchingArguments(
             Uri.parse(deepLinkUpper),
-            mapOf("param" to intArgument())
+            mapOf("param" to intArgument(0))
         )
 
         assertWithMessage("Args should not be null")

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDeepLinkTest.kt
@@ -1116,7 +1116,43 @@ class NavDeepLinkTest {
             mapOf("param" to intArgument())
         )
 
-        assertWithMessage("Args should be not be null")
+        assertWithMessage("Args should not be null")
+            .that(matchArgs)
+            .isNotNull()
+        assertWithMessage("Args bundle should be empty")
+            .that(matchArgs?.isEmpty)
+            .isTrue()
+    }
+
+    @Test
+    fun deepLinkMissingRequiredArgument() {
+        val deepLinkString = "$DEEP_LINK_EXACT_HTTPS/greeting?title={title}&text={text}"
+        val deepLink = NavDeepLink(deepLinkString)
+
+        val matchArgs = deepLink.getMatchingArguments(
+            Uri.parse("$DEEP_LINK_EXACT_HTTPS/greeting?title=No%20text"),
+            mapOf(
+                "title" to stringArgument(),
+                "text" to stringArgument()
+            )
+        )
+
+        assertWithMessage("Args should be null")
+            .that(matchArgs)
+            .isNull()
+    }
+
+    @Test
+    fun deepLinkMissingOptionalArgument() {
+        val deepLinkString = "$DEEP_LINK_EXACT_HTTPS/greeting?text={text}"
+        val deepLink = NavDeepLink(deepLinkString)
+
+        val matchArgs = deepLink.getMatchingArguments(
+            Uri.parse("$DEEP_LINK_EXACT_HTTPS/greeting"),
+            mapOf("text" to stringArgument("Default greeting"))
+        )
+
+        assertWithMessage("Args should not be null")
             .that(matchArgs)
             .isNotNull()
         assertWithMessage("Args bundle should be empty")

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
@@ -282,9 +282,8 @@ class NavDestinationAndroidTest {
         val destination = NoOpNavigator().createDestination()
         destination.addArgument("testString", stringArgument())
         destination.addDeepLink("android-app://androidx.navigation.test/{testString}")
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
-        destination.addDeepLink(deepLink.toString())
 
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
         assertWithMessage("Deep link should match")
             .that(destination.hasDeepLink(deepLink)).isTrue()
     }

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavDestinationAndroidTest.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import androidx.core.net.toUri
 import androidx.navigation.NavDestination.Companion.createRoute
 import androidx.navigation.test.intArgument
+import androidx.navigation.test.nullableStringArgument
 import androidx.navigation.test.stringArgument
 import androidx.test.filters.SmallTest
 import com.google.common.truth.Truth.assertThat
@@ -116,7 +117,7 @@ class NavDestinationAndroidTest {
 
         destination.addDeepLink("www.example.com/users/index.html")
 
-        destination.addArgument("name", stringArgument())
+        destination.addArgument("name", nullableStringArgument(null))
         destination.addDeepLink("www.example.com/users/{name}")
 
         val match = destination.matchDeepLink(
@@ -138,7 +139,7 @@ class NavDestinationAndroidTest {
         destination.addArgument("tab", stringArgument())
         destination.addDeepLink("www.example.com/users/anonymous?tab={tab}")
 
-        destination.addArgument("name", stringArgument())
+        destination.addArgument("name", nullableStringArgument(null))
         destination.addDeepLink("www.example.com/users/{name}?tab={tab}")
 
         val match = destination.matchDeepLink(
@@ -224,7 +225,7 @@ class NavDestinationAndroidTest {
     fun matchDeepLinkBestMimeType() {
         val destination = NoOpNavigator().createDestination()
 
-        destination.addArgument("deeplink1", stringArgument())
+        destination.addArgument("deeplink1", nullableStringArgument(null))
         destination.addDeepLink(
             NavDeepLink(
                 "www.example.com/users/{deeplink1}",
@@ -232,7 +233,7 @@ class NavDestinationAndroidTest {
             )
         )
 
-        destination.addArgument("deeplink2", stringArgument())
+        destination.addArgument("deeplink2", nullableStringArgument(null))
         destination.addDeepLink(
             NavDeepLink(
                 "www.example.com/users/{deeplink2}",

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavGraphAndroidTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/NavGraphAndroidTest.kt
@@ -17,6 +17,7 @@
 package androidx.navigation
 
 import android.net.Uri
+import androidx.navigation.test.nullableStringArgument
 import androidx.test.filters.SmallTest
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
@@ -70,11 +71,8 @@ class NavGraphAndroidTest {
 
         graph.addDeepLink("www.example.com/users/index.html")
 
-        val idArgument = NavArgument.Builder()
-            .setType(NavType.StringType)
-            .build()
-        graph.addArgument("id", idArgument)
-        graph.addDeepLink("www.example.com/users/{name}")
+        graph.addArgument("id", nullableStringArgument(null))
+        graph.addDeepLink("www.example.com/users/{id}")
 
         val match = graph.matchDeepLink(
             Uri.parse("https://www.example.com/users/index.html")
@@ -155,16 +153,10 @@ class NavGraphAndroidTest {
         val graph = navigatorProvider.getNavigator(NavGraphNavigator::class.java)
             .createDestination()
 
-        val codeArgument = NavArgument.Builder()
-            .setType(NavType.StringType)
-            .build()
-        graph.addArgument("code", codeArgument)
+        graph.addArgument("code", nullableStringArgument(null))
         graph.addDeepLink("www.example.com/users?code={code}")
 
-        val idArgument = NavArgument.Builder()
-            .setType(NavType.StringType)
-            .build()
-        graph.addArgument("id", idArgument)
+        graph.addArgument("id", nullableStringArgument(null))
         graph.addDeepLink("www.example.com/users?id={id}")
 
         val match = graph.matchDeepLink(

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/test/NavArgument.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/test/NavArgument.kt
@@ -77,8 +77,11 @@ fun stringArgument(
     .setDefaultValue(defaultValue)
     .build()
 
-fun nullableStringArgument() = NavArgument.Builder().setType(StringType)
+fun nullableStringArgument(
+    defaultValue: String?
+) = NavArgument.Builder().setType(StringType)
     .setIsNullable(true)
+    .setDefaultValue(defaultValue)
     .build()
 // endregion
 

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -54,6 +54,10 @@ public class NavDeepLink internal constructor(
 
     private var mimeTypePattern: Pattern? = null
 
+    /** Arguments present in the deep link, including both path and query arguments. */
+    internal val argumentsNames: List<String>
+        get() = arguments + paramArgMap.keys
+
     public var isExactDeepLink: Boolean = false
         /** @suppress */
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDeepLink.kt
@@ -192,6 +192,13 @@ public class NavDeepLink internal constructor(
                 }
             }
         }
+
+        // Check that all required arguments are present in bundle
+        for ((argName, argument) in arguments.entries) {
+            val argumentIsRequired = argument != null && !argument.isDefaultValuePresent
+            if (argumentIsRequired && !bundle.containsKey(argName)) return null
+        }
+
         return bundle
     }
 
@@ -283,7 +290,8 @@ public class NavDeepLink internal constructor(
     public class Builder {
 
         /** @suppress */
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) public constructor()
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        public constructor()
 
         private var uriPattern: String? = null
         private var action: String? = null

--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDestination.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDestination.kt
@@ -315,6 +315,14 @@ public open class NavDestination(
      * @see NavController.navigate
      */
     public fun addDeepLink(navDeepLink: NavDeepLink) {
+        val missingRequiredArguments = arguments.filterValues { !it.isDefaultValuePresent }
+            .keys
+            .filter { it !in navDeepLink.argumentsNames }
+        require(missingRequiredArguments.isEmpty()) {
+            "Deep link ${navDeepLink.uriPattern} can't be used to open destination $this.\n" +
+                "Following required arguments are missing: $missingRequiredArguments"
+        }
+
         deepLinks.add(navDeepLink)
     }
 

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerActivityTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerActivityTest.kt
@@ -75,7 +75,7 @@ class NavControllerActivityTest {
         navController.setGraph(R.navigation.nav_simple)
         navController.handleDeepLink(
             Intent().apply {
-                data = Uri.parse("android-app://androidx.navigation.test/test")
+                data = Uri.parse("android-app://androidx.navigation.test/test/arg2")
             }
         )
         assertThat(navController.currentDestination?.id)
@@ -97,7 +97,7 @@ class NavControllerActivityTest {
         val activity = activityRule.activity
 
         val intent = Intent().apply {
-            data = Uri.parse("android-app://androidx.navigation.test/test")
+            data = Uri.parse("android-app://androidx.navigation.test/test/arg2")
         }
 
         activity.intent = intent

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerRouteTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerRouteTest.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import android.os.Parcel
 import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.addCallback
+import androidx.core.os.bundleOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.testing.TestLifecycleOwner
@@ -65,14 +66,14 @@ class NavControllerRouteTest {
             test("start_test_with_default_arg") {
                 argument("defaultArg") { defaultValue = true }
             }
-            test("second_test") {
+            test("second_test/{arg2}") {
                 argument("arg2") { type = NavType.StringType }
                 argument("defaultArg") {
                     type = NavType.StringType
                     defaultValue = "defaultValue"
                 }
                 deepLink {
-                    uriPattern = "android-app://androidx.navigation.test/test"
+                    uriPattern = "android-app://androidx.navigation.test/test/{arg2}"
                     action = "test.action"
                     mimeType = "type/test"
                 }
@@ -185,7 +186,7 @@ class NavControllerRouteTest {
     fun testGetPreviousBackStackEntry() {
         val navController = createNavController()
         navController.graph = nav_simple_route_graph
-        navController.navigate("second_test")
+        navController.navigate("second_test/arg2")
         assertThat(navController.previousBackStackEntry?.destination?.route).isEqualTo("start_test")
     }
 
@@ -319,8 +320,8 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test")
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        navController.navigate("second_test/arg2")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
     }
 
@@ -330,10 +331,10 @@ class NavControllerRouteTest {
         val navController = createNavController()
         navController.graph = nav_simple_route_graph
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(deepLink)
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
         val intent = navigator.current.arguments?.getParcelable<Intent>(
             NavController.KEY_DEEP_LINK_INTENT
@@ -347,12 +348,12 @@ class NavControllerRouteTest {
         val navController = createNavController()
         navController.graph = nav_simple_route_graph
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(deepLink)
 
         val destination = navController.currentDestination
-        assertThat(destination?.route).isEqualTo("second_test")
+        assertThat(destination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
         assertThat(destination?.arguments?.get("defaultArg")?.defaultValue.toString())
             .isEqualTo("defaultValue")
@@ -367,7 +368,7 @@ class NavControllerRouteTest {
         val deepLink = NavDeepLinkRequest(Uri.parse("invalidDeepLink.com"), "test.action", null)
 
         navController.navigate(deepLink)
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
     }
 
@@ -380,7 +381,7 @@ class NavControllerRouteTest {
         val deepLink = NavDeepLinkRequest(Uri.parse("invalidDeepLink.com"), null, "type/test")
 
         navController.navigate(deepLink)
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
     }
 
@@ -447,7 +448,7 @@ class NavControllerRouteTest {
         val navController = createNavController()
         navController.graph = nav_simple_route_graph
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(
             deepLink,
@@ -455,7 +456,7 @@ class NavControllerRouteTest {
                 popUpTo("nav_root") { inclusive = true }
             }
         )
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(1)
     }
 
@@ -570,7 +571,8 @@ class NavControllerRouteTest {
                     val navigator =
                         navController.navigatorProvider.getNavigator(TestNavigator::class.java)
 
-                    assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+                    assertThat(navController.currentDestination?.route)
+                        .isEqualTo("second_test/{arg2}")
 
                     // Only the leaf destination should be on the stack.
                     assertThat(navigator.backStack.size).isEqualTo(1)
@@ -619,7 +621,7 @@ class NavControllerRouteTest {
         var navigator = SaveStateTestNavigator()
         navController.navigatorProvider.addNavigator(navigator)
         navController.graph = nav_simple_route_graph
-        navController.navigate("second_test")
+        navController.navigate("second_test/arg2")
 
         val savedState = navController.saveState()
         navController = NavController(context)
@@ -632,7 +634,7 @@ class NavControllerRouteTest {
 
         // Explicitly setting a graph then restores the state
         navController.graph = nav_simple_route_graph
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
         // Save state should be called on the navigator exactly once
         assertThat(navigator.saveStateCount).isEqualTo(1)
@@ -679,7 +681,7 @@ class NavControllerRouteTest {
         var navigator = TestNavigator()
         navController.navigatorProvider.addNavigator(navigator)
         navController.graph = nav_simple_route_graph
-        navController.navigate("second_test")
+        navController.navigate("second_test/arg2")
 
         val savedState = navController.saveState()
         navController = NavController(context)
@@ -692,7 +694,7 @@ class NavControllerRouteTest {
 
         // Explicitly setting a graph then restores the state
         navController.graph = nav_simple_route_graph
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
     }
 
@@ -926,8 +928,8 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test")
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        navController.navigate("second_test/arg2")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
 
         val popped = navController.popBackStack()
@@ -947,15 +949,15 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test")
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        navController.navigate("second_test/arg2")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
 
         val popped = navController.popBackStack(UNKNOWN_DESTINATION_ID, false)
         assertWithMessage("Popping to an invalid destination should return false")
             .that(popped)
             .isFalse()
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
     }
 
@@ -968,10 +970,10 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test") {
+        navController.navigate("second_test/arg2") {
             popUpTo("start_test") { inclusive = true }
         }
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(1)
     }
 
@@ -984,10 +986,10 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test") {
+        navController.navigate("second_test/arg2") {
             popUpTo("nav_root") { inclusive = true }
         }
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(1)
     }
 
@@ -1000,8 +1002,8 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test")
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        navController.navigate("second_test/arg2")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
 
         // This should function identically to popBackStack()
@@ -1021,8 +1023,8 @@ class NavControllerRouteTest {
         assertThat(navController.currentDestination?.route).isEqualTo("start_test")
         assertThat(navigator.backStack.size).isEqualTo(1)
 
-        navController.navigate("second_test")
-        assertThat(navController.currentDestination?.route).isEqualTo("second_test")
+        navController.navigate("second_test/arg2")
+        assertThat(navController.currentDestination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
 
         navController.navigate("start_test_with_default_arg")
@@ -1033,7 +1035,7 @@ class NavControllerRouteTest {
         val success = navController.navigateUp()
         assertThat(success).isTrue()
         val destination = navController.currentDestination
-        assertThat(destination?.route).isEqualTo("second_test")
+        assertThat(destination?.route).isEqualTo("second_test/{arg2}")
         assertThat(navigator.backStack.size).isEqualTo(2)
         assertThat(destination?.arguments?.get("defaultArg")?.defaultValue.toString())
             .isEqualTo("defaultValue")
@@ -1046,7 +1048,8 @@ class NavControllerRouteTest {
         navController.graph = nav_simple_route_graph
 
         val taskStackBuilder = navController.createDeepLink()
-            .setDestination("second_test")
+            .setDestination("second_test/{arg2}")
+            .setArguments(bundleOf("arg2" to "value"))
             .createTaskStackBuilder()
         assertThat(taskStackBuilder).isNotNull()
         assertThat(taskStackBuilder.intentCount).isEqualTo(1)
@@ -1058,10 +1061,12 @@ class NavControllerRouteTest {
         val navController = createNavController()
         navController.graph = nav_simple_route_graph
 
-        val args = Bundle()
-        args.putString("test", "test")
+        val args = bundleOf(
+            "test" to "test",
+            "arg2" to "value",
+        )
         val taskStackBuilder = navController.createDeepLink()
-            .setDestination("second_test")
+            .setDestination("second_test/{arg2}")
             .setArguments(args)
             .createTaskStackBuilder()
 
@@ -1081,7 +1086,8 @@ class NavControllerRouteTest {
         navController.graph = nav_simple_route_graph
 
         val taskStackBuilder = navController.createDeepLink()
-            .setDestination("second_test")
+            .setDestination("second_test/{arg2}")
+            .setArguments(bundleOf("arg2" to "value"))
             .createTaskStackBuilder()
 
         val intent = taskStackBuilder.editIntentAt(0)
@@ -1093,7 +1099,7 @@ class NavControllerRouteTest {
         intent!!.writeToParcel(p, 0)
 
         val destination = navController.currentDestination
-        assertThat(destination?.route).isEqualTo("second_test")
+        assertThat(destination?.route).isEqualTo("second_test/{arg2}")
         assertThat(destination?.arguments?.get("defaultArg")?.defaultValue.toString())
             .isEqualTo("defaultValue")
     }
@@ -1109,7 +1115,8 @@ class NavControllerRouteTest {
         }
 
         val taskStackBuilder = navController.createDeepLink()
-            .setDestination("second_test")
+            .setDestination("second_test/{arg2}")
+            .setArguments(bundleOf("arg2" to "value"))
             .createTaskStackBuilder()
 
         val intent = taskStackBuilder.editIntentAt(0)
@@ -1119,7 +1126,7 @@ class NavControllerRouteTest {
             .isTrue()
         // Verify that we navigated down to the deep link
         assertThat(collectedDestinationIds)
-            .containsExactly("start_test", "start_test", "second_test")
+            .containsExactly("start_test", "start_test", "second_test/{arg2}")
             .inOrder()
     }
 
@@ -1311,7 +1318,7 @@ class NavControllerRouteTest {
         navController.setOnBackPressedDispatcher(dispatcher)
 
         navController.graph = nav_simple_route_graph
-        navController.navigate("second_test")
+        navController.navigate("second_test/arg2")
         assertThat(navController.previousBackStackEntry?.destination?.route)
             .isEqualTo("start_test")
 

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerTest.kt
@@ -396,7 +396,7 @@ class NavControllerTest {
         val navController = createNavController()
         navController.setGraph(R.navigation.nav_simple)
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(deepLink)
         assertThat(navController.currentDestination?.id ?: 0).isEqualTo(R.id.second_test)
@@ -413,7 +413,7 @@ class NavControllerTest {
         val navController = createNavController()
         navController.setGraph(R.navigation.nav_simple)
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(deepLink)
 
@@ -549,7 +549,7 @@ class NavControllerTest {
         val navController = createNavController()
         navController.setGraph(R.navigation.nav_simple)
         val navigator = navController.navigatorProvider.getNavigator(TestNavigator::class.java)
-        val deepLink = Uri.parse("android-app://androidx.navigation.test/test")
+        val deepLink = Uri.parse("android-app://androidx.navigation.test/test/arg2")
 
         navController.navigate(
             deepLink,

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavDeepLinkBuilderTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavDeepLinkBuilderTest.kt
@@ -50,7 +50,7 @@ class NavDeepLinkBuilderTest {
                     defaultValue = "defaultValue"
                 }
                 deepLink {
-                    uriPattern = "android-app://androidx.navigation.test/test"
+                    uriPattern = "android-app://androidx.navigation.test/test/{arg2}"
                     action = "test.action"
                     mimeType = "type/test"
                 }

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavInflaterTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavInflaterTest.kt
@@ -86,7 +86,7 @@ class NavInflaterTest {
         assertThat(graph).isNotNull()
         val expectedUri = Uri.parse(
             "android-app://" +
-                instrumentation.targetContext.packageName + "/test"
+                instrumentation.targetContext.packageName + "/test/arg2"
         )
         val expectedDeepLinkRequest = NavDeepLinkRequest.Builder.fromUri(expectedUri).build()
         val result = graph.matchDeepLink(expectedDeepLinkRequest)

--- a/navigation/navigation-runtime/src/androidTest/res/navigation/nav_simple.xml
+++ b/navigation/navigation-runtime/src/androidTest/res/navigation/nav_simple.xml
@@ -38,7 +38,7 @@
         <action android:id="@+id/finish" app:popUpTo="@id/start_test" />
         <action android:id="@+id/finish_self" app:popUpTo="@id/second_test"
             app:popUpToInclusive="true" />
-        <deepLink app:uri="android-app://androidx.navigation.test/test"
+        <deepLink app:uri="android-app://androidx.navigation.test/test/{arg2}"
             app:action="test.action" app:mimeType="type/test"/>
         <deepLink app:uri="android-app://androidx.navigation.test/test/{arg1}/{arg2}"
             app:action="" />


### PR DESCRIPTION
## Proposed Changes

Currently, we can open a destination with a link that doesn't contain the required arguments. In this case, we will get a crash in runtime. This commit adds check that all required arguments are present in the link.

After this change, deep links will require to contain all required arguments for a destination. Links not containing all required arguments will be ignored.

## Testing

Test: ./gradlew test connectedCheck

## Issues Fixed

Fixes: [185527157](https://issuetracker.google.com/issues/185527157)
