### PR TITLE
pass github token to changed files action if it exists

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -74,6 +74,8 @@ jobs:
       - name: "Get changed files in push or pull_request"
         id: changed-files
         uses: androidx/changed-files-action@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: "Warn on missing updateApi"
         run: |


### PR DESCRIPTION
Token is optional so it is fine when we don't have access to secrets. However, having token here allows action to work for private repositories.

Bug: n/a
Test: n/a