### PR TITLE
Change JavacBasicAnnotationProcessor to wrap each step individually.

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
@@ -18,12 +18,10 @@ package androidx.room.compiler.processing.javac
 
 import androidx.room.compiler.processing.XBasicAnnotationProcessor
 import androidx.room.compiler.processing.XElement
-import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XRoundEnv
 import com.google.auto.common.BasicAnnotationProcessor
 import com.google.common.collect.ImmutableSetMultimap
-import javax.annotation.processing.ProcessingEnvironment
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.element.Element
 
@@ -46,7 +44,7 @@ abstract class JavacBasicAnnotationProcessor :
     }
 
     /** A step that initializes the state before every processing round.  */
-    private inner class InitializingStep(val delegatingSteps: Iterable<DelegatingStep>): Step {
+    private inner class InitializingStep(val delegatingSteps: Iterable<DelegatingStep>) : Step {
         override fun annotations() = delegatingSteps.flatMap { it.annotations() }.toSet()
 
         override fun process(
@@ -58,7 +56,7 @@ abstract class JavacBasicAnnotationProcessor :
     }
 
     /** A [Step] that delegates to an [XProcessingStep]. */
-    private inner class DelegatingStep(val xStep: XProcessingStep): Step {
+    private inner class DelegatingStep(val xStep: XProcessingStep) : Step {
         override fun annotations() = xStep.annotations()
 
         override fun process(

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
@@ -51,7 +51,7 @@ abstract class JavacBasicAnnotationProcessor :
             // The first step in a round initializes the cachedXEnv. Note: the "first" step can
             // change each round depending on which annotations are present in the current round and
             // which elements were deferred in the previous round.
-            val xEnv = cachedXEnv ?: JavacProcessingEnv(processingEnv)
+            val xEnv = cachedXEnv ?: JavacProcessingEnv(processingEnv).also { cachedXEnv = it }
             val xElementsByAnnotation = mutableMapOf<String, Set<XElement>>()
             xStep.annotations().forEach { annotation ->
                 xElementsByAnnotation[annotation] =

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
@@ -79,7 +79,7 @@ private fun KSAnnotated.validateExceptLocals(): Boolean {
         // skip locals
         // https://github.com/google/ksp/issues/489
         val skip = (parent as? KSDeclaration)?.isLocal() == true ||
-          (current as? KSDeclaration)?.isLocal() == true
+            (current as? KSDeclaration)?.isLocal() == true
         !skip
     }
 }


### PR DESCRIPTION
## Proposed Changes

This commit changes the behavior of JavacBasicAnnotationProcessor to wrap each XProcessingStep individually in its own Step rather than have a single Step that wraps all XProcessingSteps. The issue with wrapping all XProcessingSteps in a single Step is that the underlying BasicAnnotationProcessor triggers the Step, and thus all wrapped XProcessingSteps, when any annotation is found rather than only triggering the Step that handles the annotation.

In order to share the XProcessingEnv for all XProcessingSteps in a round, the first step to process will initialize the XProcessingEnv for other steps. In addition, the postRound call also now shares the XProcessingEnv too. At the end of each postRound I've set the XProcessingEnv to null to allow GC.

## Testing

Test: I've added a test that adds 2 XProcessingSteps to JavacBasicAnnotationProcessor that each handle a different annotation, and then verify that if only one annotation is present in the sources then only the step that handles that annotation is triggered.

## Issues Fixed

Fixes: https://issuetracker.google.com/192658371
