### PR TITLE
Add Messager#printMessage() overloads to XMessager

### DIFF
--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/DiagnosticMessage.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/DiagnosticMessage.kt
@@ -16,6 +16,8 @@
 
 package androidx.room.compiler.processing.util
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.XElement
 
 /**
@@ -23,5 +25,7 @@ import androidx.room.compiler.processing.XElement
  */
 data class DiagnosticMessage(
     val msg: String,
-    val element: XElement?
+    val element: XElement?,
+    val annotation: XAnnotation?,
+    val annotationValue: XAnnotationValue?
 )

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/RecordingXMessager.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/RecordingXMessager.kt
@@ -16,6 +16,8 @@
 
 package androidx.room.compiler.processing.util
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XMessager
 import javax.tools.Diagnostic
@@ -28,7 +30,13 @@ class RecordingXMessager : XMessager() {
 
     fun diagnostics(): Map<Diagnostic.Kind, List<DiagnosticMessage>> = diagnostics
 
-    override fun onPrintMessage(kind: Diagnostic.Kind, msg: String, element: XElement?) {
+    override fun onPrintMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement?,
+        annotation: XAnnotation?,
+        annotationValue: XAnnotationValue?
+    ) {
         diagnostics.getOrPut(
             kind
         ) {
@@ -36,7 +44,9 @@ class RecordingXMessager : XMessager() {
         }.add(
             DiagnosticMessage(
                 msg = msg,
-                element = element
+                element = element,
+                annotation = annotation,
+                annotationValue = annotationValue
             )
         )
     }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
@@ -23,24 +23,48 @@ import javax.tools.Diagnostic
  */
 abstract class XMessager {
     private val watchers = mutableListOf<XMessager>()
+
     /**
-     * Prints the given [msg] to the logs while also associating it with the given [element].
+     * Prints the given [msg] to the logs while also associating it with the given [element],
+     * [annotation], and [annotationValue].
      *
      * @param kind Kind of the message
      * @param msg The actual message to report to the compiler
      * @param element The element with whom the message should be associated with
+     * @param annotation The annotation with whom the msg should be associated with
+     * @param annotationValue The annotation value with whom the msg should be associated with
      */
-    fun printMessage(kind: Diagnostic.Kind, msg: String, element: XElement? = null) {
-        watchers.forEach {
-            it.printMessage(kind, msg, element)
+    @JvmOverloads
+    fun printMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement? = null,
+        annotation: XAnnotation? = null,
+        annotationValue: XAnnotationValue? = null
+    ) {
+        if (element == null) {
+            assert(annotation == null && annotationValue == null) {
+                "If element is null, annotation and annotationValue must also be null."
+            }
         }
-        onPrintMessage(kind, msg, element)
+        if (annotation == null) {
+            assert(annotationValue == null) {
+                "If annotation is null, annotationValue must also be null."
+            }
+        }
+
+        watchers.forEach {
+            it.printMessage(kind, msg, element, annotation, annotationValue)
+        }
+        onPrintMessage(kind, msg, element, annotation, annotationValue)
     }
 
     protected abstract fun onPrintMessage(
         kind: Diagnostic.Kind,
         msg: String,
-        element: XElement? = null
+        element: XElement? = null,
+        annotation: XAnnotation? = null,
+        annotationValue: XAnnotationValue? = null
     )
 
     fun addMessageWatcher(watcher: XMessager) {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
@@ -46,8 +46,7 @@ abstract class XMessager {
             assert(annotation == null && annotationValue == null) {
                 "If element is null, annotation and annotationValue must also be null."
             }
-        }
-        if (annotation == null) {
+        } else if (annotation == null) {
             assert(annotationValue == null) {
                 "If annotation is null, annotationValue must also be null."
             }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XMessager.kt
@@ -30,30 +30,74 @@ abstract class XMessager {
      *
      * @param kind Kind of the message
      * @param msg The actual message to report to the compiler
+     */
+    fun printMessage(kind: Diagnostic.Kind, msg: String) {
+        printMsg(kind, msg)
+    }
+
+    /**
+     * Prints the given [msg] to the logs while also associating it with the given [element],
+     * [annotation], and [annotationValue].
+     *
+     * @param kind Kind of the message
+     * @param msg The actual message to report to the compiler
+     * @param element The element with whom the message should be associated with
+     */
+    final fun printMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement,
+    ) {
+        printMsg(kind, msg, element)
+    }
+
+    /**
+     * Prints the given [msg] to the logs while also associating it with the given [element],
+     * [annotation], and [annotationValue].
+     *
+     * @param kind Kind of the message
+     * @param msg The actual message to report to the compiler
+     * @param element The element with whom the message should be associated with
+     * @param annotation The annotation with whom the msg should be associated with
+     */
+    final fun printMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement,
+        annotation: XAnnotation,
+    ) {
+        printMsg(kind, msg, element, annotation)
+    }
+
+    /**
+     * Prints the given [msg] to the logs while also associating it with the given [element],
+     * [annotation], and [annotationValue].
+     *
+     * @param kind Kind of the message
+     * @param msg The actual message to report to the compiler
      * @param element The element with whom the message should be associated with
      * @param annotation The annotation with whom the msg should be associated with
      * @param annotationValue The annotation value with whom the msg should be associated with
      */
-    @JvmOverloads
-    fun printMessage(
+    final fun printMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement,
+        annotation: XAnnotation,
+        annotationValue: XAnnotationValue
+    ) {
+        printMsg(kind, msg, element, annotation, annotationValue)
+    }
+
+    private fun printMsg(
         kind: Diagnostic.Kind,
         msg: String,
         element: XElement? = null,
         annotation: XAnnotation? = null,
         annotationValue: XAnnotationValue? = null
     ) {
-        if (element == null) {
-            assert(annotation == null && annotationValue == null) {
-                "If element is null, annotation and annotationValue must also be null."
-            }
-        } else if (annotation == null) {
-            assert(annotationValue == null) {
-                "If annotation is null, annotationValue must also be null."
-            }
-        }
-
         watchers.forEach {
-            it.printMessage(kind, msg, element, annotation, annotationValue)
+            it.printMsg(kind, msg, element, annotation, annotationValue)
         }
         onPrintMessage(kind, msg, element, annotation, annotationValue)
     }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
@@ -35,24 +35,26 @@ internal class KspMessager(
         annotation: XAnnotation?,
         annotationValue: XAnnotationValue?
     ) {
-        // In Javac, the Messager requires all preceding parameters to report an error.
-        // In KSP, the KspLogger only needs the last so ignore the preceding parameters.
-        val ksNode = if (annotationValue != null) {
-            (annotationValue as KspAnnotationValue).valueArgument
-        } else if (annotation != null) {
-            (annotation as KspAnnotation).ksAnnotated
-        } else if (element != null) {
-            (element as KspElement).declaration
-        } else {
-            null
-        }
-
         if (element == null) {
             internalPrintMessage(kind, msg)
-        } else if (ksNode == null || ksNode.location == NonExistLocation) {
-            internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
         } else {
-            internalPrintMessage(kind, msg, ksNode)
+            // In Javac, the Messager requires all preceding parameters to report an error.
+            // In KSP, the KspLogger only needs the last so ignore the preceding parameters.
+            val ksNode = if (annotationValue != null) {
+                (annotationValue as KspAnnotationValue).valueArgument
+            } else if (annotation != null) {
+                (annotation as KspAnnotation).ksAnnotated
+            } else if (element != null) {
+                (element as KspElement).declaration
+            } else {
+                null
+            }
+
+            if (ksNode == null || ksNode.location == NonExistLocation) {
+                internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
+            } else {
+                internalPrintMessage(kind, msg, ksNode)
+            }
         }
     }
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
@@ -37,24 +37,25 @@ internal class KspMessager(
     ) {
         if (element == null) {
             internalPrintMessage(kind, msg)
-        } else {
-            // In Javac, the Messager requires all preceding parameters to report an error.
-            // In KSP, the KspLogger only needs the last so ignore the preceding parameters.
-            val ksNode = if (annotationValue != null) {
-                (annotationValue as KspAnnotationValue).valueArgument
-            } else if (annotation != null) {
-                (annotation as KspAnnotation).ksAnnotated
-            } else if (element != null) {
-                (element as KspElement).declaration
-            } else {
-                null
-            }
+            return
+        }
 
-            if (ksNode == null || ksNode.location == NonExistLocation) {
-                internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
-            } else {
-                internalPrintMessage(kind, msg, ksNode)
-            }
+        // In Javac, the Messager requires all preceding parameters to report an error.
+        // In KSP, the KspLogger only needs the last so ignore the preceding parameters.
+        val ksNode = if (annotationValue != null) {
+            (annotationValue as KspAnnotationValue).valueArgument
+        } else if (annotation != null) {
+            (annotation as KspAnnotation).ksAnnotated
+        } else if (element != null) {
+            (element as KspElement).declaration
+        } else {
+            null
+        }
+
+        if (ksNode == null || ksNode.location == NonExistLocation) {
+            internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
+        } else {
+            internalPrintMessage(kind, msg, ksNode)
         }
     }
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
@@ -53,7 +53,7 @@ internal class KspMessager(
         }
 
         if (ksNode == null || ksNode.location == NonExistLocation) {
-            internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
+            internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}", ksNode)
         } else {
             internalPrintMessage(kind, msg, ksNode)
         }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
@@ -16,24 +16,47 @@
 
 package androidx.room.compiler.processing.ksp
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XMessager
 import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.NonExistLocation
 import javax.tools.Diagnostic
 
 internal class KspMessager(
     private val logger: KSPLogger
 ) : XMessager() {
-    override fun onPrintMessage(kind: Diagnostic.Kind, msg: String, element: XElement?) {
-        val ksNode = (element as? KspElement)?.declaration
-
-        @Suppress("NAME_SHADOWING") // intentional to avoid reporting without location
-        val msg = if ((ksNode == null || ksNode.location == NonExistLocation) && element != null) {
-            "$msg - ${element.fallbackLocationText}"
+    override fun onPrintMessage(
+        kind: Diagnostic.Kind,
+        msg: String,
+        element: XElement?,
+        annotation: XAnnotation?,
+        annotationValue: XAnnotationValue?
+    ) {
+        // In Javac, the Messager requires all preceding parameters to report an error.
+        // In KSP, the KspLogger only needs the last so ignore the preceding parameters.
+        val ksNode = if (annotationValue != null) {
+            (annotationValue as KspAnnotationValue).valueArgument
+        } else if (annotation != null) {
+            (annotation as KspAnnotation).ksAnnotated
+        } else if (element != null) {
+            (element as KspElement).declaration
         } else {
-            msg
+            null
         }
+
+        if (element == null) {
+            internalPrintMessage(kind, msg)
+        } else if (ksNode == null || ksNode.location == NonExistLocation) {
+            internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}")
+        } else {
+            internalPrintMessage(kind, msg, ksNode)
+        }
+    }
+
+    private fun internalPrintMessage(kind: Diagnostic.Kind, msg: String, ksNode: KSNode? = null) {
         when (kind) {
             Diagnostic.Kind.ERROR -> logger.error(msg, ksNode)
             Diagnostic.Kind.WARNING -> logger.warn(msg, ksNode)

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspMessager.kt
@@ -46,13 +46,11 @@ internal class KspMessager(
             (annotationValue as KspAnnotationValue).valueArgument
         } else if (annotation != null) {
             (annotation as KspAnnotation).ksAnnotated
-        } else if (element != null) {
-            (element as KspElement).declaration
         } else {
-            null
+            (element as KspElement).declaration
         }
 
-        if (ksNode == null || ksNode.location == NonExistLocation) {
+        if (ksNode.location == NonExistLocation) {
             internalPrintMessage(kind, "$msg - ${element.fallbackLocationText}", ksNode)
         } else {
             internalPrintMessage(kind, msg, ksNode)

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XMessagerTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XMessagerTest.kt
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.compiler.processing
+
+import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.runProcessorTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import javax.tools.Diagnostic
+
+@RunWith(JUnit4::class)
+class XMessagerTest {
+    @Test
+    fun errorLogTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "Foo.java",
+                    """
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "intentional failure"
+            )
+            it.assertCompilationResult {
+                compilationDidFail()
+                hasErrorCount(1)
+                hasWarningCount(0)
+                hasError("intentional failure")
+            }
+        }
+    }
+
+    @Test
+    fun warningLogTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "Foo.java",
+                    """
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.WARNING,
+                "intentional warning"
+            )
+            it.assertCompilationResult {
+                hasErrorCount(0)
+                hasWarningCount(1)
+                hasWarning("intentional warning")
+            }
+        }
+    }
+
+    @Test
+    fun noteLogTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "Foo.java",
+                    """
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.NOTE,
+                "intentional note"
+            )
+            it.assertCompilationResult {
+                hasErrorCount(0)
+                hasWarningCount(0)
+                hasNote("intentional note")
+            }
+        }
+    }
+
+    @Test
+    fun errorOnElementTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "Foo.java",
+                    """
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val fooElement = it.processingEnv.requireTypeElement("Foo")
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "intentional failure",
+                fooElement
+            )
+            it.assertCompilationResult {
+                compilationDidFail()
+                hasErrorCount(1)
+                hasWarningCount(0)
+                hasError("intentional failure")
+            }
+        }
+    }
+
+    @Test
+    fun errorOnAnnotationTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "test.FooAnnotation",
+                    """
+                    package test;
+                    @interface FooAnnotation {}
+                    """.trimIndent()
+                ),
+                Source.java(
+                    "test.Foo",
+                    """
+                    package test;
+                    @FooAnnotation
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
+            val fooAnnotations = fooElement.getAllAnnotations().filter {
+                it.qualifiedName == "test.FooAnnotation"
+            }
+            assertThat(fooAnnotations).hasSize(1)
+            val fooAnnotation = fooAnnotations.get(0)
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "intentional failure",
+                fooElement,
+                fooAnnotation
+            )
+            it.assertCompilationResult {
+                compilationDidFail()
+                hasErrorCount(1)
+                hasWarningCount(0)
+                hasError("intentional failure")
+            }
+        }
+    }
+
+    @Test
+    fun errorOnAnnotationValueTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "test.FooAnnotation",
+                    """
+                    package test;
+                    @interface FooAnnotation {
+                      String value();
+                    }
+                    """.trimIndent()
+                ),
+                Source.java(
+                    "test.Foo",
+                    """
+                    package test;
+                    @FooAnnotation("fooValue")
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
+            val fooAnnotations = fooElement.getAllAnnotations().filter {
+                it.qualifiedName == "test.FooAnnotation"
+            }
+            assertThat(fooAnnotations).hasSize(1)
+            val fooAnnotation = fooAnnotations.get(0)
+            val fooAnnotationValue = fooAnnotation.annotationValues.firstOrNull {
+                it.name == "value"
+            }
+            assertThat(fooAnnotationValue).isNotNull()
+            it.processingEnv.messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "intentional failure",
+                fooElement,
+                fooAnnotation,
+                fooAnnotationValue
+            )
+            it.assertCompilationResult {
+                compilationDidFail()
+                hasErrorCount(1)
+                hasWarningCount(0)
+                hasError("intentional failure")
+            }
+        }
+    }
+
+    @Test
+    fun reportingAnnotationFailsWhenElementIsNullTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "test.FooAnnotation",
+                    """
+                    package test;
+                    @interface FooAnnotation {
+                      String value();
+                    }
+                    """.trimIndent()
+                ),
+                Source.java(
+                    "test.Foo",
+                    """
+                    package test;
+                    @FooAnnotation("fooValue")
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
+            val fooAnnotations = fooElement.getAllAnnotations().filter {
+                it.qualifiedName == "test.FooAnnotation"
+            }
+            assertThat(fooAnnotations).hasSize(1)
+            val fooAnnotation = fooAnnotations.get(0)
+            assertThat(fooAnnotation).isNotNull()
+            try {
+                it.processingEnv.messager.printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "intentional failure",
+                    null,
+                    fooAnnotation,
+                )
+            } catch (e: AssertionError) {
+                assertThat(e.message).contains(
+                    "If element is null, annotation and annotationValue must also be null"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun reportingAnnotationValueFailsWhenAnnotationIsNullTest() {
+        runProcessorTest(
+            sources = listOf(
+                Source.java(
+                    "test.FooAnnotation",
+                    """
+                    package test;
+                    @interface FooAnnotation {
+                      String value();
+                    }
+                    """.trimIndent()
+                ),
+                Source.java(
+                    "test.Foo",
+                    """
+                    package test;
+                    @FooAnnotation("fooValue")
+                    class Foo {}
+                    """.trimIndent()
+                )
+            )
+        ) {
+            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
+            val fooAnnotations = fooElement.getAllAnnotations().filter {
+                it.qualifiedName == "test.FooAnnotation"
+            }
+            assertThat(fooAnnotations).hasSize(1)
+            val fooAnnotation = fooAnnotations.get(0)
+            assertThat(fooAnnotation).isNotNull()
+            val fooAnnotationValue = fooAnnotation.annotationValues.firstOrNull {
+                it.name == "value"
+            }
+            assertThat(fooAnnotationValue).isNotNull()
+            try {
+                it.processingEnv.messager.printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "intentional failure",
+                    fooElement,
+                    null,
+                    fooAnnotationValue
+                )
+            } catch (e: AssertionError) {
+                assertThat(e.message).contains(
+                    "If annotation is null, annotationValue must also be null"
+                )
+            }
+        }
+    }
+}

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XMessagerTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XMessagerTest.kt
@@ -197,7 +197,7 @@ class XMessagerTest {
             }
             assertThat(fooAnnotations).hasSize(1)
             val fooAnnotation = fooAnnotations.get(0)
-            val fooAnnotationValue = fooAnnotation.annotationValues.firstOrNull {
+            val fooAnnotationValue = fooAnnotation.annotationValues.first {
                 it.name == "value"
             }
             assertThat(fooAnnotationValue).isNotNull()
@@ -213,101 +213,6 @@ class XMessagerTest {
                 hasErrorCount(1)
                 hasWarningCount(0)
                 hasError("intentional failure")
-            }
-        }
-    }
-
-    @Test
-    fun reportingAnnotationFailsWhenElementIsNullTest() {
-        runProcessorTest(
-            sources = listOf(
-                Source.java(
-                    "test.FooAnnotation",
-                    """
-                    package test;
-                    @interface FooAnnotation {
-                      String value();
-                    }
-                    """.trimIndent()
-                ),
-                Source.java(
-                    "test.Foo",
-                    """
-                    package test;
-                    @FooAnnotation("fooValue")
-                    class Foo {}
-                    """.trimIndent()
-                )
-            )
-        ) {
-            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
-            val fooAnnotations = fooElement.getAllAnnotations().filter {
-                it.qualifiedName == "test.FooAnnotation"
-            }
-            assertThat(fooAnnotations).hasSize(1)
-            val fooAnnotation = fooAnnotations.get(0)
-            assertThat(fooAnnotation).isNotNull()
-            try {
-                it.processingEnv.messager.printMessage(
-                    Diagnostic.Kind.ERROR,
-                    "intentional failure",
-                    null,
-                    fooAnnotation,
-                )
-            } catch (e: AssertionError) {
-                assertThat(e.message).contains(
-                    "If element is null, annotation and annotationValue must also be null"
-                )
-            }
-        }
-    }
-
-    @Test
-    fun reportingAnnotationValueFailsWhenAnnotationIsNullTest() {
-        runProcessorTest(
-            sources = listOf(
-                Source.java(
-                    "test.FooAnnotation",
-                    """
-                    package test;
-                    @interface FooAnnotation {
-                      String value();
-                    }
-                    """.trimIndent()
-                ),
-                Source.java(
-                    "test.Foo",
-                    """
-                    package test;
-                    @FooAnnotation("fooValue")
-                    class Foo {}
-                    """.trimIndent()
-                )
-            )
-        ) {
-            val fooElement = it.processingEnv.requireTypeElement("test.Foo")
-            val fooAnnotations = fooElement.getAllAnnotations().filter {
-                it.qualifiedName == "test.FooAnnotation"
-            }
-            assertThat(fooAnnotations).hasSize(1)
-            val fooAnnotation = fooAnnotations.get(0)
-            assertThat(fooAnnotation).isNotNull()
-            val fooAnnotationValue = fooAnnotation.annotationValues.firstOrNull {
-                it.name == "value"
-            }
-            assertThat(fooAnnotationValue).isNotNull()
-            try {
-                it.processingEnv.messager.printMessage(
-                    Diagnostic.Kind.ERROR,
-                    "intentional failure",
-                    fooElement,
-                    null,
-                    fooAnnotationValue
-                )
-            } catch (e: AssertionError) {
-                assertThat(e.message).contains(
-                    "If annotation is null, annotationValue must also be null"
-                )
             }
         }
     }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspFilerTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/ksp/KspFilerTest.kt
@@ -16,6 +16,8 @@
 
 package androidx.room.compiler.processing.ksp
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XMessager
 import androidx.room.compiler.processing.addOriginatingElement
@@ -97,11 +99,21 @@ class KspFilerTest {
     }
 
     class TestMessager : XMessager() {
-        override fun onPrintMessage(kind: Diagnostic.Kind, msg: String, element: XElement?) {
+        override fun onPrintMessage(
+            kind: Diagnostic.Kind,
+            msg: String,
+            element: XElement?,
+            annotation: XAnnotation?,
+            annotationValue: XAnnotationValue?
+        ) {
+            var errorMsg = "${kind.name} element: $element " +
+                "annotation: $annotation " +
+                "annotationValue: $annotationValue " +
+                "msg: $msg"
             if (kind == Diagnostic.Kind.ERROR) {
-                error("Error element: $element msg: $msg")
+                error(errorMsg)
             } else {
-                println("${kind.name} element: $element msg: $msg")
+                println(errorMsg)
             }
         }
     }

--- a/room/room-compiler/src/test/kotlin/androidx/room/log/RLogTest.kt
+++ b/room/room-compiler/src/test/kotlin/androidx/room/log/RLogTest.kt
@@ -16,6 +16,8 @@
 
 package androidx.room.log
 
+import androidx.room.compiler.processing.XAnnotation
+import androidx.room.compiler.processing.XAnnotationValue
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XMessager
 import androidx.room.vo.Warning
@@ -29,8 +31,13 @@ class RLogTest {
     @Test
     fun testSafeFormat() {
         val messager = object : XMessager() {
-            override fun onPrintMessage(kind: Diagnostic.Kind, msg: String, element: XElement?) {
-            }
+            override fun onPrintMessage(
+                kind: Diagnostic.Kind,
+                msg: String,
+                element: XElement?,
+                annotation: XAnnotation?,
+                annotationValue: XAnnotationValue?
+            ) {}
         }
         val logger = RLog(messager, emptySet(), null)
 


### PR DESCRIPTION
## Proposed Changes

Adds [Messager#printMessage()](https://docs.oracle.com/javase/8/docs/api/javax/annotation/processing/Messager.html) overloads to XMessager.

For KSP, there's not a direct equivalent to these overloads since the KspLogger can accept the element/annotation/annotationValue directly without requiring all preceding information. Thus, for KspMessager, we only look at the most specific, non-null parameter given. For example, if element and annotation are given we report on the annotation.

## Testing

Test: ./gradlew :room:r-c-p:test

## Issues Fixed

Fixes: [https://issuetracker.google.com/193819242](https://issuetracker.google.com/193819242)
