### PR TITLE
Add a `xProcessingEnv` property to `XBasicAnnotatationProcessor`

### DIFF
--- a/room/room-compiler-processing-testing/build.gradle
+++ b/room/room-compiler-processing-testing/build.gradle
@@ -68,12 +68,20 @@ tasks.named("sourceJar").configure {
 tasks.named("processResources").configure {
     dependsOn(writeTestPropsTask)
 }
+
+tasks.withType(KotlinCompile).configureEach {
+    kotlinOptions {
+        freeCompilerArgs += [
+                "-Xjvm-default=all",
+        ]
+    }
+}
+
 // enable opt in only for tests so that we don't create non experimental APIs by mistake
 // in the source.
 tasks.named("compileTestKotlin", KotlinCompile.class).configure {
     it.kotlinOptions {
         freeCompilerArgs += [
-                "-Xjvm-default=all",
                 "-Xopt-in=kotlin.RequiresOptIn",
                 "-Xopt-in=androidx.room.compiler.processing.ExperimentalProcessingApi"
         ]

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -16,14 +16,11 @@
 
 package androidx.room.compiler.processing
 
-<<<<<<< HEAD
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XRoundEnv
 import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.compat.XConverters.toJavac
-=======
->>>>>>> 65af8188878 (Fixed lint issues)
 import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation
 import javax.lang.model.SourceVersion
@@ -35,27 +32,13 @@ class SyntheticJavacProcessor private constructor(
 ) : JavacBasicAnnotationProcessor(), SyntheticProcessor by impl {
     constructor(handlers: List<(XTestInvocation) -> Unit>) : this(SyntheticProcessorImpl(handlers))
 
-<<<<<<< HEAD
     override fun processingSteps(): Iterable<XProcessingStep> = impl.processingSteps()
 
-<<<<<<< HEAD
     override fun postRound(env: XProcessingEnv, round: XRoundEnv) {
         if (!round.toJavac().processingOver()) {
             impl.postRound(env, round)
         }
-=======
-    // TODO: Figure out why the compiler forces us to implement this method.
-    override fun initSteps(): Iterable<ProcessingStep> {
-        throw AssertionError("If steps() is not implemented, initSteps() must be.")
->>>>>>> 65af8188878 (Fixed lint issues)
     }
 
     override fun getSupportedSourceVersion() = SourceVersion.latest()
-=======
-    override fun getSupportedSourceVersion() = SourceVersion.latest()
-
-    override fun processingSteps() = impl.processingSteps()
-
-    override fun postRound(env: XProcessingEnv, round: XRoundEnv) = impl.postRound(env, round)
->>>>>>> 2e9f6f254cc (Move initSteps() into JavacBasicAnnotationProcessor and make final)
 }

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -16,10 +16,6 @@
 
 package androidx.room.compiler.processing
 
-import androidx.room.compiler.processing.XProcessingEnv
-import androidx.room.compiler.processing.XProcessingStep
-import androidx.room.compiler.processing.XRoundEnv
-import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.compat.XConverters.toJavac
 import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -16,18 +16,18 @@
 
 package androidx.room.compiler.processing
 
+<<<<<<< HEAD
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XRoundEnv
 import androidx.room.compiler.processing.XTypeElement
 import androidx.room.compiler.processing.compat.XConverters.toJavac
+=======
+>>>>>>> 65af8188878 (Fixed lint issues)
 import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation
-import com.google.auto.common.BasicAnnotationProcessor
-import javax.annotation.processing.AbstractProcessor
-import javax.annotation.processing.RoundEnvironment
+import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep
 import javax.lang.model.SourceVersion
-import javax.lang.model.element.TypeElement
 
 @Suppress("VisibleForTests")
 @ExperimentalProcessingApi
@@ -38,10 +38,16 @@ class SyntheticJavacProcessor private constructor(
 
     override fun processingSteps(): Iterable<XProcessingStep> = impl.processingSteps()
 
+<<<<<<< HEAD
     override fun postRound(env: XProcessingEnv, round: XRoundEnv) {
         if (!round.toJavac().processingOver()) {
             impl.postRound(env, round)
         }
+=======
+    // TODO: Figure out why the compiler forces us to implement this method.
+    override fun initSteps(): Iterable<ProcessingStep> {
+        throw AssertionError("If steps() is not implemented, initSteps() must be.")
+>>>>>>> 65af8188878 (Fixed lint issues)
     }
 
     override fun getSupportedSourceVersion() = SourceVersion.latest()

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -36,6 +36,7 @@ class SyntheticJavacProcessor private constructor(
 ) : JavacBasicAnnotationProcessor(), SyntheticProcessor by impl {
     constructor(handlers: List<(XTestInvocation) -> Unit>) : this(SyntheticProcessorImpl(handlers))
 
+<<<<<<< HEAD
     override fun processingSteps(): Iterable<XProcessingStep> = impl.processingSteps()
 
 <<<<<<< HEAD
@@ -51,4 +52,11 @@ class SyntheticJavacProcessor private constructor(
     }
 
     override fun getSupportedSourceVersion() = SourceVersion.latest()
+=======
+    override fun getSupportedSourceVersion() = SourceVersion.latest()
+
+    override fun processingSteps() = impl.processingSteps()
+
+    override fun postRound(env: XProcessingEnv, round: XRoundEnv) = impl.postRound(env, round)
+>>>>>>> 2e9f6f254cc (Move initSteps() into JavacBasicAnnotationProcessor and make final)
 }

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -16,7 +16,14 @@
 
 package androidx.room.compiler.processing
 
+import androidx.room.compiler.processing.XProcessingEnv
+import androidx.room.compiler.processing.XProcessingStep
+import androidx.room.compiler.processing.XRoundEnv
+import androidx.room.compiler.processing.XTypeElement
+import androidx.room.compiler.processing.compat.XConverters.toJavac
+import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation
+import com.google.auto.common.BasicAnnotationProcessor
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.RoundEnvironment
 import javax.lang.model.SourceVersion
@@ -26,34 +33,16 @@ import javax.lang.model.element.TypeElement
 @ExperimentalProcessingApi
 class SyntheticJavacProcessor private constructor(
     private val impl: SyntheticProcessorImpl
-) : AbstractProcessor(), SyntheticProcessor by impl {
-    constructor(handlers: List<(XTestInvocation) -> Unit>) : this(
-        SyntheticProcessorImpl(handlers)
-    )
+) : JavacBasicAnnotationProcessor(), SyntheticProcessor by impl {
+    constructor(handlers: List<(XTestInvocation) -> Unit>) : this(SyntheticProcessorImpl(handlers))
 
-    override fun process(
-        annotations: MutableSet<out TypeElement>,
-        roundEnv: RoundEnvironment
-    ): Boolean {
-        if (roundEnv.processingOver()) {
-            return true
+    override fun processingSteps(): Iterable<XProcessingStep> = impl.processingSteps()
+
+    override fun postRound(env: XProcessingEnv, round: XRoundEnv) {
+        if (!round.toJavac().processingOver()) {
+            impl.postRound(env, round)
         }
-        if (!impl.canRunAnotherRound()) {
-            return true
-        }
-        val xEnv = XProcessingEnv.create(processingEnv)
-        val xRoundEnv = XRoundEnv.create(xEnv, roundEnv)
-        val testInvocation = XTestInvocation(
-            processingEnv = xEnv,
-            roundEnv = xRoundEnv
-        )
-        impl.runNextRound(testInvocation)
-        return impl.expectsAnotherRound()
     }
 
-    override fun getSupportedSourceVersion(): SourceVersion {
-        return SourceVersion.latest()
-    }
-
-    override fun getSupportedAnnotationTypes() = setOf("*")
+    override fun getSupportedSourceVersion() = SourceVersion.latest()
 }

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticJavacProcessor.kt
@@ -26,7 +26,6 @@ import androidx.room.compiler.processing.compat.XConverters.toJavac
 >>>>>>> 65af8188878 (Fixed lint issues)
 import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation
-import com.google.auto.common.BasicAnnotationProcessor.ProcessingStep
 import javax.lang.model.SourceVersion
 
 @Suppress("VisibleForTests")

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticKspProcessor.kt
@@ -17,13 +17,7 @@ package androidx.room.compiler.processing
 
 import androidx.room.compiler.processing.ksp.KspBasicAnnotationProcessor
 import androidx.room.compiler.processing.util.XTestInvocation
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
-import com.google.devtools.ksp.processing.SymbolProcessorProvider
-import com.google.devtools.ksp.symbol.KSAnnotated
 
 @ExperimentalProcessingApi
 class SyntheticKspProcessor private constructor(

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
@@ -15,7 +15,6 @@
  */
 package androidx.room.compiler.processing
 
-import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.util.RecordingXMessager
 import androidx.room.compiler.processing.util.XTestInvocation
 
@@ -66,7 +65,7 @@ internal class SyntheticProcessorImpl(
 
     internal fun processingSteps() = listOf<XProcessingStep>(
         // A processing step that just ensures we're run every round.
-        object: XProcessingStep {
+        object : XProcessingStep {
             override fun annotations(): Set<String> = setOf("*")
             override fun process(
                 env: XProcessingEnv,

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
@@ -63,6 +63,23 @@ internal class SyntheticProcessorImpl(
     private val nextRunHandlers = handlers.toMutableList()
     override val messageWatcher = RecordingXMessager()
 
+    internal fun processingSteps() = listOf<XProcessingStep>(
+        // A processing step that just ensures we're run every round.
+        object : XProcessingStep {
+            override fun annotations(): Set<String> = setOf("*")
+            override fun process(
+                env: XProcessingEnv,
+                elementsByAnnotation: Map<String, Set<XElement>>
+            ): Set<XTypeElement> = emptySet()
+        }
+    )
+
+    internal fun postRound(env: XProcessingEnv, round: XRoundEnv) {
+        if (canRunAnotherRound()) {
+            runNextRound(XTestInvocation(env, round))
+        }
+    }
+
     override fun expectsAnotherRound(): Boolean {
         return nextRunHandlers.isNotEmpty()
     }

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
@@ -15,6 +15,7 @@
  */
 package androidx.room.compiler.processing
 
+import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.util.RecordingXMessager
 import androidx.room.compiler.processing.util.XTestInvocation
 
@@ -48,6 +49,20 @@ internal interface SyntheticProcessor {
      * Returns true if the processor expected to run another round.
      */
     fun expectsAnotherRound(): Boolean
+}
+
+@ExperimentalProcessingApi
+internal interface SyntheticXProcessingStep: XProcessingStep {
+//        override fun process(
+//            env: XProcessingEnv,
+//            elementsByAnnotation: Map<String, Set<XElement>>
+//        ): Set<XTypeElement> {
+//            return emptySet()
+//        }
+
+//        override fun annotations(): Set<String> {
+//            return emptySet()
+//        }
 }
 
 /**

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
@@ -49,10 +49,6 @@ internal interface SyntheticProcessor {
      * Returns true if the processor expected to run another round.
      */
     fun expectsAnotherRound(): Boolean
-
-    fun processingSteps(): Iterable<XProcessingStep>
-
-    fun postRound(xProcessingEnv: XProcessingEnv, xRoundEnv: XRoundEnv)
 }
 
 /**
@@ -68,7 +64,7 @@ internal class SyntheticProcessorImpl(
     private val nextRunHandlers = handlers.toMutableList()
     override val messageWatcher = RecordingXMessager()
 
-    override fun processingSteps() = listOf<XProcessingStep>(
+    internal fun processingSteps() = listOf<XProcessingStep>(
         // A processing step that just ensures we're run every round.
         object: XProcessingStep {
             override fun annotations(): Set<String> = setOf("*")
@@ -79,9 +75,9 @@ internal class SyntheticProcessorImpl(
         }
     )
 
-    override fun postRound(xProcessingEnv: XProcessingEnv, xRoundEnv: XRoundEnv) {
-        if (!canRunAnotherRound()) {
-            return
+    internal fun postRound(env: XProcessingEnv, round: XRoundEnv) {
+        if (canRunAnotherRound()) {
+            runNextRound(XTestInvocation(env, round))
         }
     }
 

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/SyntheticProcessor.kt
@@ -49,20 +49,10 @@ internal interface SyntheticProcessor {
      * Returns true if the processor expected to run another round.
      */
     fun expectsAnotherRound(): Boolean
-}
 
-@ExperimentalProcessingApi
-internal interface SyntheticXProcessingStep: XProcessingStep {
-//        override fun process(
-//            env: XProcessingEnv,
-//            elementsByAnnotation: Map<String, Set<XElement>>
-//        ): Set<XTypeElement> {
-//            return emptySet()
-//        }
+    fun processingSteps(): Iterable<XProcessingStep>
 
-//        override fun annotations(): Set<String> {
-//            return emptySet()
-//        }
+    fun postRound(xProcessingEnv: XProcessingEnv, xRoundEnv: XRoundEnv)
 }
 
 /**
@@ -78,9 +68,9 @@ internal class SyntheticProcessorImpl(
     private val nextRunHandlers = handlers.toMutableList()
     override val messageWatcher = RecordingXMessager()
 
-    internal fun processingSteps() = listOf<XProcessingStep>(
+    override fun processingSteps() = listOf<XProcessingStep>(
         // A processing step that just ensures we're run every round.
-        object : XProcessingStep {
+        object: XProcessingStep {
             override fun annotations(): Set<String> = setOf("*")
             override fun process(
                 env: XProcessingEnv,
@@ -89,9 +79,9 @@ internal class SyntheticProcessorImpl(
         }
     )
 
-    internal fun postRound(env: XProcessingEnv, round: XRoundEnv) {
-        if (canRunAnotherRound()) {
-            runNextRound(XTestInvocation(env, round))
+    override fun postRound(xProcessingEnv: XProcessingEnv, xRoundEnv: XRoundEnv) {
+        if (!canRunAnotherRound()) {
+            return
         }
     }
 

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
@@ -23,7 +23,6 @@ import androidx.room.compiler.processing.util.KotlinCompilationUtil
 import androidx.room.compiler.processing.util.KotlinCompileTestingCompilationResult
 import androidx.room.compiler.processing.util.CompilationTestCapabilities
 import androidx.room.compiler.processing.util.Source
-import androidx.room.compiler.processing.util.XTestInvocation
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider

--- a/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
+++ b/room/room-compiler-processing-testing/src/main/java/androidx/room/compiler/processing/util/runner/KspCompilationTestRunner.kt
@@ -23,6 +23,10 @@ import androidx.room.compiler.processing.util.KotlinCompilationUtil
 import androidx.room.compiler.processing.util.KotlinCompileTestingCompilationResult
 import androidx.room.compiler.processing.util.CompilationTestCapabilities
 import androidx.room.compiler.processing.util.Source
+import androidx.room.compiler.processing.util.XTestInvocation
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.kspArgs
@@ -50,7 +54,14 @@ internal object KspCompilationTestRunner : CompilationTestRunner {
         } else {
             params.sources
         }
-        val syntheticKspProcessor = SyntheticKspProcessor(params.handlers)
+
+        val processorProvider = object : SymbolProcessorProvider {
+            lateinit var processor: SyntheticKspProcessor
+
+            override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+                return SyntheticKspProcessor(environment, params.handlers).also { processor = it }
+            }
+        }
 
         val combinedOutputStream = ByteArrayOutputStream()
         val kspCompilation = KotlinCompilationUtil.prepareCompilation(
@@ -59,7 +70,7 @@ internal object KspCompilationTestRunner : CompilationTestRunner {
             classpaths = params.classpath
         )
         kspCompilation.kspArgs.putAll(params.options)
-        kspCompilation.symbolProcessorProviders = listOf(syntheticKspProcessor.asProvider())
+        kspCompilation.symbolProcessorProviders = listOf(processorProvider)
         kspCompilation.compile()
         // ignore KSP result for now because KSP stops compilation, which might create false
         // negatives when java code accesses kotlin code.
@@ -76,6 +87,7 @@ internal object KspCompilationTestRunner : CompilationTestRunner {
         finalCompilation.sources += kspCompilation.kspJavaSourceDir.collectSourceFiles() +
             kspCompilation.kspKotlinSourceDir.collectSourceFiles()
         val result = finalCompilation.compile()
+        val syntheticKspProcessor = processorProvider.processor
         // workaround for: https://github.com/google/ksp/issues/122
         // KSP does not fail compilation for error diagnostics hence we do it here.
         val hasErrorDiagnostics = syntheticKspProcessor.messageWatcher

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XBasicAnnotationProcessor.kt
@@ -26,6 +26,11 @@ package androidx.room.compiler.processing
 interface XBasicAnnotationProcessor {
 
     /**
+     * Returns the [XProcessingEnv].
+     */
+    val xProcessingEnv: XProcessingEnv
+
+    /**
      * The list of processing steps to execute.
      */
     fun processingSteps(): Iterable<XProcessingStep>

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -148,8 +148,7 @@ interface XProcessingEnv {
             options = options,
             codeGenerator = codeGenerator,
             logger = logger,
-            resolver = resolver
-        )
+        ).also { it.resolver = resolver }
     }
 
     /**

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
@@ -20,7 +20,6 @@ import androidx.room.compiler.processing.XBasicAnnotationProcessor
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
-import androidx.room.compiler.processing.XRoundEnv
 import com.google.auto.common.BasicAnnotationProcessor
 import com.google.common.collect.ImmutableSetMultimap
 import javax.annotation.processing.RoundEnvironment

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacBasicAnnotationProcessor.kt
@@ -18,6 +18,7 @@ package androidx.room.compiler.processing.javac
 
 import androidx.room.compiler.processing.XBasicAnnotationProcessor
 import androidx.room.compiler.processing.XElement
+import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.XProcessingStep
 import androidx.room.compiler.processing.XRoundEnv
 import com.google.auto.common.BasicAnnotationProcessor
@@ -32,14 +33,16 @@ import javax.lang.model.element.Element
 abstract class JavacBasicAnnotationProcessor :
     BasicAnnotationProcessor(), XBasicAnnotationProcessor {
 
-    // This state is cached here so that it can be shared by all steps in a given processing round.
-    // The state is initialized at beginning of each round using the InitializingStep, and
-    // the state is cleared at the end of each round in BasicAnnotationProcessor#postRound()
-    private var cachedXEnv: JavacProcessingEnv? = null
+    private val xEnv: JavacProcessingEnv by lazy { JavacProcessingEnv(processingEnv) }
+
+    final override val xProcessingEnv: XProcessingEnv get() = xEnv
 
     final override fun steps(): Iterable<Step> {
         return processingSteps().map { DelegatingStep(it) }
     }
+
+    @Suppress("DEPRECATION") // Override initSteps to make it final.
+    final override fun initSteps() = super.initSteps()
 
     /** A [Step] that delegates to an [XProcessingStep]. */
     private inner class DelegatingStep(val xStep: XProcessingStep) : Step {
@@ -51,7 +54,6 @@ abstract class JavacBasicAnnotationProcessor :
             // The first step in a round initializes the cachedXEnv. Note: the "first" step can
             // change each round depending on which annotations are present in the current round and
             // which elements were deferred in the previous round.
-            val xEnv = cachedXEnv ?: JavacProcessingEnv(processingEnv).also { cachedXEnv = it }
             val xElementsByAnnotation = mutableMapOf<String, Set<XElement>>()
             xStep.annotations().forEach { annotation ->
                 xElementsByAnnotation[annotation] =
@@ -66,11 +68,7 @@ abstract class JavacBasicAnnotationProcessor :
     }
 
     final override fun postRound(roundEnv: RoundEnvironment) {
-        // The cachedXEnv can be null if none of the steps were processed in the round.
-        // In this case, we just create a new one since there is no cached one to share.
-        val xEnv = cachedXEnv ?: JavacProcessingEnv(processingEnv)
-        val xRound = XRoundEnv.create(xEnv, roundEnv)
-        postRound(xEnv, xRound)
-        cachedXEnv = null // Reset after every round to allow GC
+        postRound(xEnv, JavacRoundEnv(xEnv, roundEnv))
+        xEnv.clearCache() // Reset cache after every round to avoid leaking elements across rounds
     }
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -260,6 +260,10 @@ internal class JavacProcessingEnv(
         }
     }
 
+    internal fun clearCache() {
+        typeElementStore.clear()
+    }
+
     companion object {
         val PRIMITIVE_TYPES = TypeKind.values().filter {
             it.isPrimitive

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/XTypeElementStore.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/XTypeElementStore.kt
@@ -59,4 +59,8 @@ internal class XTypeElementStore<BackingType, T : XTypeElement>(
         typeCache[qName] = WeakReference(element)
         return element
     }
+
+    internal fun clear() {
+        typeCache.clear()
+    }
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
@@ -19,7 +19,6 @@ package androidx.room.compiler.processing.ksp
 import androidx.room.compiler.processing.XBasicAnnotationProcessor
 import androidx.room.compiler.processing.XElement
 import androidx.room.compiler.processing.XProcessingEnv
-import androidx.room.compiler.processing.XRoundEnv
 import com.google.devtools.ksp.isLocal
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspBasicAnnotationProcessor.kt
@@ -35,45 +35,45 @@ abstract class KspBasicAnnotationProcessor(
     val symbolProcessorEnvironment: SymbolProcessorEnvironment
 ) : SymbolProcessor, XBasicAnnotationProcessor {
 
-  private val xEnv = KspProcessingEnv(
-    symbolProcessorEnvironment.options,
-    symbolProcessorEnvironment.codeGenerator,
-    symbolProcessorEnvironment.logger
-  )
+    private val xEnv = KspProcessingEnv(
+        symbolProcessorEnvironment.options,
+        symbolProcessorEnvironment.codeGenerator,
+        symbolProcessorEnvironment.logger
+    )
 
-  final override val xProcessingEnv: XProcessingEnv get() = xEnv
+    final override val xProcessingEnv: XProcessingEnv get() = xEnv
 
-  // Cache and lazily get steps during the initial process() so steps initialization is done once.
-  private val steps by lazy { processingSteps() }
+    // Cache and lazily get steps during the initial process() so steps initialization is done once.
+    private val steps by lazy { processingSteps() }
 
-  final override fun process(resolver: Resolver): List<KSAnnotated> {
-    xEnv.resolver = resolver // Set the resolver at the beginning of each round
-    val xRoundEnv = KspRoundEnv(xEnv)
-    val deferredElements = steps.flatMap { step ->
-      val invalidElements = mutableSetOf<XElement>()
-      val elementsByAnnotation = step.annotations().mapNotNull { annotation ->
-        val annotatedElements = xRoundEnv.getElementsAnnotatedWith(annotation)
-        val validElements = annotatedElements
-          .filter { (it as KspElement).declaration.validateExceptLocals() }
-          .toSet()
-        invalidElements.addAll(annotatedElements - validElements)
-        if (validElements.isNotEmpty()) {
-          annotation to validElements
-        } else {
-          null
+    final override fun process(resolver: Resolver): List<KSAnnotated> {
+        xEnv.resolver = resolver // Set the resolver at the beginning of each round
+        val xRoundEnv = KspRoundEnv(xEnv)
+        val deferredElements = steps.flatMap { step ->
+            val invalidElements = mutableSetOf<XElement>()
+            val elementsByAnnotation = step.annotations().mapNotNull { annotation ->
+                val annotatedElements = xRoundEnv.getElementsAnnotatedWith(annotation)
+                val validElements = annotatedElements
+                    .filter { (it as KspElement).declaration.validateExceptLocals() }
+                    .toSet()
+                invalidElements.addAll(annotatedElements - validElements)
+                if (validElements.isNotEmpty()) {
+                    annotation to validElements
+                } else {
+                    null
+                }
+            }.toMap()
+            // Only process the step if there are annotated elements found for this step.
+            if (elementsByAnnotation.isNotEmpty()) {
+                invalidElements + step.process(xEnv, elementsByAnnotation)
+            } else {
+                invalidElements
+            }
         }
-      }.toMap()
-      // Only process the step if there are annotated elements found for this step.
-      if (elementsByAnnotation.isNotEmpty()) {
-        invalidElements + step.process(xEnv, elementsByAnnotation)
-      } else {
-        invalidElements
-      }
+        postRound(xEnv, xRoundEnv)
+        xEnv.clearCache() // Reset cache after every round to avoid leaking elements across rounds
+        return deferredElements.map { (it as KspElement).declaration }
     }
-    postRound(xEnv, xRoundEnv)
-    xEnv.clearCache() // Reset cache after every round to avoid leaking elements across rounds
-    return deferredElements.map { (it as KspElement).declaration }
-  }
 }
 
 /**

--- a/room/room-compiler/src/main/kotlin/androidx/room/RoomProcessor.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/RoomProcessor.kt
@@ -16,7 +16,6 @@
 
 package androidx.room
 
-import androidx.room.compiler.processing.XProcessingEnv
 import androidx.room.compiler.processing.javac.JavacBasicAnnotationProcessor
 import androidx.room.processor.Context
 import androidx.room.processor.ProcessorErrors

--- a/room/room-compiler/src/main/kotlin/androidx/room/RoomProcessor.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/RoomProcessor.kt
@@ -44,15 +44,13 @@ class RoomProcessor : JavacBasicAnnotationProcessor() {
 
     override fun getSupportedOptions(): MutableSet<String> {
         val supportedOptions = Context.ARG_OPTIONS.toMutableSet()
-        // XProcessingEnv is a cheap wrapper so it is fine to re-create.
-        val xProcessing = XProcessingEnv.create(processingEnv)
-        if (Context.BooleanProcessorOptions.INCREMENTAL.getValue(xProcessing)) {
+        if (Context.BooleanProcessorOptions.INCREMENTAL.getValue(xProcessingEnv)) {
             if (methodParametersVisibleInClassFiles()) {
                 // Room can be incremental
                 supportedOptions.add(ISOLATING_ANNOTATION_PROCESSORS_INDICATOR)
             } else {
                 if (!jdkVersionHasBugReported) {
-                    Context(xProcessing).logger.w(
+                    Context(xProcessingEnv).logger.w(
                         Warning.JDK_VERSION_HAS_BUG, ProcessorErrors.JDK_VERSION_HAS_BUG
                     )
                     jdkVersionHasBugReported = true


### PR DESCRIPTION
## Proposed Changes

  - Added a `xProcessingEnv` property to `XBasicAnnotatationProcessor`. 
    This is meant to make it easier to migrate from `BasicAnnotationProcessor` which has access to `processingEnv` field.
  - Updated `JavacBasicAnnotationProcessor` and `JavacProcessingEnv` to clear the `typeElementCache` each round
  - Updated `KspBasicAnnotationProcessor` and `KspProcessingEnv` to clear the `typeElementCache` and
    `Resolver` each round.
  - Updated the synthetic processors to extend `JavacBasicAnnotationProcessor` and `KspBasicAnnotationProcessor`.
  - Added tests for both javac and ksp

## Testing

Test:  `./gradlew -Pandroidx.allWarningsAsErrors :room:r-compiler:test :room:r-c-p:test`

## Issues Fixed

Fixes: [b/194858327](https://issuetracker.google.com/194858327)
