### PR TITLE
Make libs.versions.toml visible from root playground projects

### DIFF
--- a/playground-common/gradle/libs.versions.toml
+++ b/playground-common/gradle/libs.versions.toml
@@ -1,0 +1,1 @@
+../gradle/libs.versions.toml


### PR DESCRIPTION
An attempt to fix the warning about AGP version detection - it should be
provided by classpath declarations in buildScript which are dependent on
the toml file. According to
https://docs.gradle.org/current/userguide/platforms.html#sub:conventional-dependencies-toml
it should be visible from the root project.

Test: cd activity && ./gradlew bOS