### PR TITLE
[Room][XProcessing] Fix NPE in getTypeElementsFromPackage

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XProcessingEnv.kt
@@ -157,7 +157,8 @@ interface XProcessingEnv {
      * @param packageName the package name to look up.
      *
      * @return A list of [XTypeElement] with matching package name. This will return declarations
-     * from both dependencies and source.
+     * from both dependencies and source. If the package is not found an empty list will be
+     * returned.
      */
     fun getTypeElementsFromPackage(packageName: String): List<XTypeElement>
 

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacProcessingEnv.kt
@@ -77,6 +77,7 @@ internal class JavacProcessingEnv(
         // Note, to support Java Modules we would need to use "getAllPackageElements",
         // but that is only available in Java 9+.
         val packageElement = delegate.elementUtils.getPackageElement(packageName)
+            ?: return emptyList()
 
         return packageElement.enclosedElements
             .filterIsInstance<TypeElement>()

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XRoundEnvTest.kt
@@ -254,6 +254,17 @@ class XRoundEnvTest {
         }
     }
 
+    @Test
+    fun getElementsFromPackageReturnsEmptyListForUnknownPackage() {
+        runProcessorTest { testInvocation ->
+            val kspElements = testInvocation.processingEnv.getTypeElementsFromPackage(
+                "com.example.unknown.package"
+            )
+
+            assertThat(kspElements).isEmpty()
+        }
+    }
+
     annotation class TopLevelAnnotation
 
     @Suppress("unused") // used in tests


### PR DESCRIPTION
## Proposed Changes
The javac implementation of XProcessingEnv.getTypeElementsFromPackage contains a bug, where an NPE is thrown if the requested package is not found. This is because `elementUtils.getPackageElement` returns null for an unknown package, and this was not previously handled in the code because it is a platform type and this case was overlooked (by me, when I originally contributed it).

## Testing

Test: Added the unit test getElementsFromPackageReturnsEmptyListForUnknownPackage

## Issues Fixed

Fixes: N/A
