### PR TITLE
allow public repos when launching studio

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/studio/StudioTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/studio/StudioTask.kt
@@ -198,7 +198,8 @@ abstract class StudioTask : DefaultTask() {
                 // This environment variable is read by AndroidXRootPlugin to ensure that
                 // Studio-initiated Gradle tasks are run against the same version of AGP that was
                 // used to start Studio, which prevents version mismatch after repo sync.
-                "EXPECTED_AGP_VERSION" to ANDROID_GRADLE_PLUGIN_VERSION
+                "EXPECTED_AGP_VERSION" to ANDROID_GRADLE_PLUGIN_VERSION,
+                "ALLOW_PUBLIC_REPOS" to "true"
             )
 
             // Append to the existing environment variables set by gradlew and the user.


### PR DESCRIPTION
Playground projects stopped loading in studio after the
buildSrc change because, for some reason, Studio's gradle
init script does not respect environment value changes.

I made sure playground environment setting code runs before
the buildSrc repos.gradle but it is still broken.

For now, passing the environment variable in the studio task
fixes the issue. We should eventually make this more resillient,
maybe by setting that value to true by checking some other
project flag.

Bug: n/a
Test: open room project in a github checkout