### PR TITLE
Pass allow public repos to studio

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/studio/StudioTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/studio/StudioTask.kt
@@ -128,6 +128,12 @@ abstract class StudioTask : DefaultTask() {
     @get:Internal
     protected abstract val studioArchiveCreator: StudioArchiveCreator
 
+    /**
+     * List of additional environment variables to pass into the Studio application.
+     */
+    @get:Internal
+    open val additionalEnvironmentProperties: Map<String, String> = emptyMap()
+
     private val licenseAcceptedFile: File by lazy {
         File("$studioInstallationDir/STUDIOW_LICENSE_ACCEPTED")
     }
@@ -199,7 +205,7 @@ abstract class StudioTask : DefaultTask() {
                 // Studio-initiated Gradle tasks are run against the same version of AGP that was
                 // used to start Studio, which prevents version mismatch after repo sync.
                 "EXPECTED_AGP_VERSION" to ANDROID_GRADLE_PLUGIN_VERSION
-            )
+            ) + additionalEnvironmentProperties
 
             // Append to the existing environment variables set by gradlew and the user.
             environment().putAll(additionalStudioEnvironmentProperties)
@@ -268,6 +274,8 @@ open class PlaygroundStudioTask : RootStudioTask() {
      */
     override val requiresProjectList get() = false
     override val installParentDir get() = supportRootFolder
+    override val additionalEnvironmentProperties: Map<String, String>
+        get() = mapOf("ALLOW_PUBLIC_REPOS" to "true")
     override val ideaProperties
         get() = supportRootFolder.resolve("../playground-common/idea.properties")
     override val vmOptions


### PR DESCRIPTION
After the buildSrc change, studio failed to load playground projects
because it tries to configure buildSrc without running the original
settings file, hence it does not have the right repositories.

This CL fixes it by passing the environment variable into studio,
which later passes it down while invoking gradle to configure buildSrc.

Bug: n/a
Test: gw studio in unbundled checkout works
