### PR TITLE
Workaround for projectDir conflicts

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -26,3 +26,8 @@ selectProjectsFromAndroidX({ name ->
     return false
 })
 
+// Workaround for b/197253160; sets the projectDir for automatically generated
+// parent project to non-existent folder as it would normally conflict with the
+// root project with adverse affects.
+project(":activity").projectDir = new File("." + rootProject.name)
+

--- a/biometric/settings.gradle
+++ b/biometric/settings.gradle
@@ -24,3 +24,8 @@ selectProjectsFromAndroidX({ name ->
     return false
 })
 
+// Workaround for b/197253160; sets the projectDir for automatically generated
+// parent project to non-existent folder as it would normally conflict with the
+// root project with adverse affects.
+project(":biometric").projectDir = new File("." + rootProject.name)
+

--- a/buildSrc/plugins/src/main/kotlin/androidx/build/AndroidXPlugin.kt
+++ b/buildSrc/plugins/src/main/kotlin/androidx/build/AndroidXPlugin.kt
@@ -881,13 +881,6 @@ private const val GROUP_PREFIX = "androidx."
  * Validates the project structure against Jetpack guidelines.
  */
 fun Project.validateProjectStructure(groupId: String) {
-    // TODO(b/197253160): Re-enable this check for playground. For unknown reasons in playground
-    //  builds, automatically generated parent projects such as :activity are incorrectly
-    //  inheriting their children's build file which causes the AndroidXPlugin to get applied.
-    if (studioType() == StudioType.PLAYGROUND) {
-        return
-    }
-
     val shortGroupId = if (groupId.startsWith(GROUP_PREFIX)) {
         groupId.substring(GROUP_PREFIX.length)
     } else {

--- a/datastore/settings.gradle
+++ b/datastore/settings.gradle
@@ -25,3 +25,8 @@ selectProjectsFromAndroidX({ name ->
     return false
 })
 
+// Workaround for b/197253160; sets the projectDir for automatically generated
+// parent project to non-existent folder as it would normally conflict with the
+// root project with adverse affects.
+project(":datastore").projectDir = new File("." + rootProject.name)
+

--- a/fragment/settings.gradle
+++ b/fragment/settings.gradle
@@ -24,3 +24,9 @@ selectProjectsFromAndroidX({ name ->
     if (name == ":internal-testutils-truth") return true
     return false
 })
+
+// Workaround for b/197253160; sets the projectDir for automatically generated
+// parent project to non-existent folder as it would normally conflict with the
+// root project with adverse affects.
+project(":fragment").projectDir = new File("." + rootProject.name)
+

--- a/paging/settings.gradle
+++ b/paging/settings.gradle
@@ -28,3 +28,8 @@ selectProjectsFromAndroidX({ name ->
     return false
 })
 
+// Workaround for b/197253160; sets the projectDir for automatically generated
+// parent project to non-existent folder as it would normally conflict with the
+// root project with adverse affects.
+project(":paging").projectDir = new File("." + rootProject.name)
+


### PR DESCRIPTION
Points the automatically generated parent project's projectDir to a
non-existent file to workaround Gradle limitations around conflict
project roots. Normally, the automatically generated parent project
would default to its relative dir, but since it conflicts with the root
project in Playground builds, it reverts to
`frameworks/support/parent/parent`, which conflicts with a real project
in some playgrounds. This causes the AndroidXPlugin to get applied to
the parent project incorrectly, but also causes adverse affects in
studio's code completion and conflicts with the child project if it
exists.

Fixes: 197253160
Test: cd activity && ./gradlew tasks