### PR TITLE
Support playground during CHECKOUT_ROOT detection

### DIFF
--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -26,7 +26,18 @@ def chooseOutDir(subdir = "") {
         def checkoutRoot = System.getProperty("CHECKOUT_ROOT")
         if (checkoutRoot == null) {
             def workingDir = new File(buildscript.sourceFile.parent)
-            checkoutRoot = new File("git rev-parse --show-toplevel".execute([], workingDir).text)
+            // Note: Using String.execute() causes exit code 148, so we use ProcessBuilder instead.
+            def repoProcess = new ProcessBuilder()
+                .command("repo", "help")
+                .directory(workingDir)
+                .start()
+            def isRepoCheckout = repoProcess.waitFor() == 0
+            if (isRepoCheckout) {
+                checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
+            } else {
+                checkoutRoot = new File("git rev-parse --show-toplevel".execute([], workingDir).text)
+            }
+
         }
         outDir = new File("${checkoutRoot}/out${subdir}")
         project.ext.buildSrcOut = new File("${checkoutRoot}/out/buildSrc")

--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -25,7 +25,8 @@ def chooseOutDir(subdir = "") {
     if (outDir == null) {
         def checkoutRoot = System.getProperty("CHECKOUT_ROOT")
         if (checkoutRoot == null) {
-            checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
+            def workingDir = new File(buildscript.sourceFile.parent)
+            checkoutRoot = new File("git rev-parse --show-toplevel".execute([], workingDir).text)
         }
         outDir = new File("${checkoutRoot}/out${subdir}")
         project.ext.buildSrcOut = new File("${checkoutRoot}/out/buildSrc")

--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -26,18 +26,22 @@ def chooseOutDir(subdir = "") {
         def checkoutRoot = System.getProperty("CHECKOUT_ROOT")
         if (checkoutRoot == null) {
             def workingDir = new File(buildscript.sourceFile.parent)
-            // Note: Using String.execute() causes exit code 148, so we use ProcessBuilder instead.
-            def repoProcess = new ProcessBuilder()
-                .command("repo", "help")
-                .directory(workingDir)
-                .start()
-            def isRepoCheckout = repoProcess.waitFor() == 0
-            if (isRepoCheckout) {
-                checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
-            } else {
+            try {
+                // Note: Using String.execute() causes exit code 148, so we use ProcessBuilder instead.
+                def repoProcess = new ProcessBuilder()
+                    .command("repo", "help")
+                    .directory(workingDir)
+                    .start()
+                def isRepoCheckout = repoProcess.waitFor() == 0
+                if (isRepoCheckout) {
+                    checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
+                } else {
+                    checkoutRoot = new File("git rev-parse --show-toplevel".execute([], workingDir).text)
+                }
+            // Thrown if repo is not available from PATH
+            } catch (IOException ioException) {
                 checkoutRoot = new File("git rev-parse --show-toplevel".execute([], workingDir).text)
             }
-
         }
         outDir = new File("${checkoutRoot}/out${subdir}")
         project.ext.buildSrcOut = new File("${checkoutRoot}/out/buildSrc")

--- a/cleanBuild.sh
+++ b/cleanBuild.sh
@@ -47,7 +47,7 @@ function confirm() {
 confirm
 
 scriptDir="$(cd $(dirname $0) && pwd)"
-checkoutDir="$(cd $scriptDir/../.. && pwd)"
+checkoutDir="$(cd $(git rev-parse --show-toplevel) && pwd)"
 export OUT_DIR="$checkoutDir/out"
 
 ./gradlew --clean $goals

--- a/playground-common/playground-include-settings.gradle
+++ b/playground-common/playground-include-settings.gradle
@@ -138,6 +138,3 @@ if (jvmVersion != "11") {
 
 // allow public repositories
 System.setProperty("ALLOW_PUBLIC_REPOS", "true")
-
-// specify out dir location
-System.setProperty("CHECKOUT_ROOT", "${buildscript.sourceFile.parent}/..")


### PR DESCRIPTION
Currently, we hard-code "../.." to get to the root of git checkout for
declaring a location for build outputs, however this causes issues in
Github checkouts which live directly in ./androidx as opposed
to ./frameworks/support.

This changes the hard-coded "../.." to instead use git to parse the root
checkout directory.

Test: Manually - Gradle sync within Studio from github checkout
