### PR TITLE
chooseOutDir removing subdir param

### DIFF
--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -17,7 +17,7 @@
 def init = new Properties()
 ext.init = init
 
-def chooseOutDir(subdir = "") {
+def chooseOutDir() {
     /*
      * The OUT_DIR is a temporary directory you can use to put things during the build.
      */
@@ -27,7 +27,7 @@ def chooseOutDir(subdir = "") {
         if (checkoutRoot == null) {
             checkoutRoot = new File("${buildscript.sourceFile.parent}/../../..")
         }
-        outDir = new File("${checkoutRoot}/out${subdir}")
+        outDir = new File("${checkoutRoot}/out")
     } else {
         outDir = new File(outDir)
     }

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -67,7 +67,7 @@ buildscript {
 
 apply from: "$supportRootFolder/buildSrc/dependencies.gradle"
 apply from: "$supportRootFolder/buildSrc/out.gradle"
-init.chooseOutDir("/${rootProject.name}")
+init.chooseOutDir()
 
 apply plugin: AndroidXRootPlugin
 apply plugin: AndroidXPlaygroundRootPlugin


### PR DESCRIPTION
This makes the out directories be the same for all of the playground projects and makes it more convenient to find where buildSrc puts its artifacts

Bug: 140265324
Test: cd paging && ./gradlew checkApi
Test: cd activity && ./gradlew compileKotlin