### PR TITLE
Allow null result from switchMap extension transform

### DIFF
--- a/lifecycle/lifecycle-livedata-ktx/src/main/java/androidx/lifecycle/Transformations.kt
+++ b/lifecycle/lifecycle-livedata-ktx/src/main/java/androidx/lifecycle/Transformations.kt
@@ -75,7 +75,7 @@ public inline fun <X, Y> LiveData<X>.map(crossinline transform: (X) -> Y): LiveD
  * ```
  */
 public inline fun <X, Y> LiveData<X>.switchMap(
-    crossinline transform: (X) -> LiveData<Y>
+    crossinline transform: (X) -> LiveData<Y>?
 ): LiveData<Y> = Transformations.switchMap(this) { transform(it) }
 
 /**


### PR DESCRIPTION
The existing extension method breaks one of the features of the underlying method - that you aren't forced to return a LiveData on every invocation of the transform.

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
