### PR TITLE
Declare AndroidXPlaygroundRootPlugin in buildSrc

### DIFF
--- a/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/AndroidXPlaygroundRootPlugin.properties
+++ b/buildSrc/plugins/src/main/resources/META-INF/gradle-plugins/AndroidXPlaygroundRootPlugin.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=androidx.build.AndroidXPlaygroundRootPlugin

--- a/buildSrc/private/src/main/resources/META-INF/gradle-plugins/impls/AndroidXPlaygroundRootImplPlugin.properties
+++ b/buildSrc/private/src/main/resources/META-INF/gradle-plugins/impls/AndroidXPlaygroundRootImplPlugin.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2021 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=androidx.build.AndroidXPlaygroundRootImplPlugin

--- a/buildSrc/public/src/main/kotlin/androidx/build/SdkHelper.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SdkHelper.kt
@@ -54,7 +54,7 @@ fun Project.writeSdkPathToLocalPropertiesFile() {
  * Returns the root project's platform-specific SDK path as a file.
  */
 fun Project.getSdkPath(): File {
-    if (rootProject.plugins.hasPlugin("androix.build.AndroidXPlaygroundRootImplPlugin") ||
+    if (rootProject.plugins.hasPlugin("AndroidXPlaygroundRootPlugin") ||
         System.getenv("COMPOSE_DESKTOP_GITHUB_BUILD") != null
     ) {
         // This is not full checkout, use local settings instead.


### PR DESCRIPTION
This PR fixes a bug in playground build where it fails to find
SDK location because it fails to detect the playground plugin.

When a plugin is not declared in the metadata, it does not get
and ID, hence the  check fails. I've added the metadata
and also changed the ID key that we use to search.

Bug: n/a
Test: gw :datastore:datastore-core:generateApi