### PR TITLE
Ensure the coroutine cannot be garbage collected

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.android.kt
@@ -37,11 +37,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 internal object GlobalSnapshotManager {
     private val started = AtomicBoolean(false)
+    private val uiScope = CoroutineScope(AndroidUiDispatcher.Main)
 
     fun ensureStarted() {
         if (started.compareAndSet(false, true)) {
             val channel = Channel<Unit>(Channel.CONFLATED)
-            CoroutineScope(AndroidUiDispatcher.Main).launch {
+            uiScope.launch {
                 channel.consumeEach {
                     Snapshot.sendApplyNotifications()
                 }

--- a/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
+++ b/compose/ui/ui/src/desktopMain/kotlin/androidx/compose/ui/platform/GlobalSnapshotManager.desktop.kt
@@ -39,11 +39,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 internal object GlobalSnapshotManager {
     private val started = AtomicBoolean(false)
+    private val uiScope = CoroutineScope(Dispatchers.Swing)
 
     fun ensureStarted() {
         if (started.compareAndSet(false, true)) {
             val channel = Channel<Unit>(Channel.CONFLATED)
-            CoroutineScope(Dispatchers.Swing).launch {
+            uiScope.launch {
                 channel.consumeEach {
                     Snapshot.sendApplyNotifications()
                 }


### PR DESCRIPTION
## Proposed Changes

Before this change, the coroutine not being garbage collected relies on the fact that `consumeEach` indirectly injects a strong reference to the `Continuation` inside the `Channel` while the iteration is suspended. This is brittle, because if an API that used `WeakReference`s under the hood was to be called in that coroutine, it could then be garbage collected, creating very subtle bugs that don't always happen since the Garbage Collector doesn't run at predictable times.

These changes keep a strong reference to the `CoroutineScope` which keeps a strong reference to its underlying `Job` instance, which keeps a reference to the coroutines launched in it, regardless of the implementation details of the suspending functions being called.

## Testing

Test: This code is already tested, it should not change the behavior in the current form.