### PR TITLE
Fix paging compose build for playground

### DIFF
--- a/paging/paging-compose/build.gradle
+++ b/paging/paging-compose/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation(libs.kotlinStdlib)
     api("androidx.compose.foundation:foundation:1.0.1")
     api(project(":paging:paging-common"))
-    api(project(":compose:runtime:runtime"))
+    api(projectOrArtifact(":compose:runtime:runtime"))
 
     androidTestImplementation(projectOrArtifact(":compose:ui:ui-test-junit4"))
     androidTestImplementation(project(":compose:test-utils"))


### PR DESCRIPTION
It was depending on compose which does not exist in the
playground setup.

Bug: n/a
Test: cd paging && ./gradlew buildTestApks