### PR TITLE
Fix misspelling in LazyList contentPadding documentation

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyList.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/lazy/LazyList.kt
@@ -50,7 +50,7 @@ internal fun LazyList(
     modifier: Modifier,
     /** State controlling the scroll position */
     state: LazyListState,
-    /** The inner padding to be added for the whole content(nor for each individual item) */
+    /** The inner padding to be added for the whole content(not for each individual item) */
     contentPadding: PaddingValues,
     /** reverse the direction of scrolling and layout */
     reverseLayout: Boolean,


### PR DESCRIPTION
## Proposed Changes

  - Fixes a misspell of "nor" to "not" since "nor" can be misinterpreted in this context and confuse the reader.

Test: N/A doc change