### PR TITLE
[XProcessor] Support Synthetic elements as an aggregating elements

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
@@ -19,6 +19,9 @@ package androidx.room.compiler.processing
 import androidx.room.compiler.processing.javac.JavacElement
 import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
 import androidx.room.compiler.processing.ksp.KspElement
+import androidx.room.compiler.processing.ksp.KspMemberContainer
+import androidx.room.compiler.processing.ksp.containingFileAsOriginatingElement
+import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import javax.lang.model.element.Element
 import kotlin.contracts.contract
 
@@ -35,6 +38,7 @@ interface XElement : XAnnotated {
      * Returns the string representation of the Element's kind.
      */
     fun kindName(): String
+
     /**
      * When the location of an element is unknown, this String is appended to the diagnostic
      * message. Without this information, developer gets no clue on where the error is.
@@ -96,7 +100,15 @@ fun XElement.isConstructor(): Boolean {
 internal fun XElement.originatingElementForPoet(): Element? {
     return when (this) {
         is JavacElement -> element
-        is KspElement -> containingFileAsOriginatingElement()
+        is KspElement -> {
+            declaration.containingFileAsOriginatingElement()
+        }
+        is KspSyntheticPropertyMethodElement -> {
+            field.declaration.containingFileAsOriginatingElement()
+        }
+        is KspMemberContainer -> {
+            declaration?.containingFileAsOriginatingElement()
+        }
         else -> error("Originating element is not implemented for ${this.javaClass}")
     }
 }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSAnnotatedExt.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSAnnotatedExt.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing.ksp
 
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSDeclaration
 
 private fun KSAnnotated.hasAnnotationWithQName(qName: String) = annotations.any {
     it.annotationType.resolve().declaration.qualifiedName?.asString() == qName
@@ -30,3 +31,13 @@ internal fun KSAnnotated.hasJvmTransientAnnotation() =
 internal fun KSAnnotated.hasJvmFieldAnnotation() = hasAnnotationWithQName("kotlin.jvm.JvmField")
 
 internal fun KSAnnotated.hasJvmDefaultAnnotation() = hasAnnotationWithQName("kotlin.jvm.JvmDefault")
+
+/**
+ * Return a reference to the containing file that implements the
+ * [javax.lang.model.element.Element] API so that we can report it to JavaPoet.
+ */
+internal fun KSAnnotated.containingFileAsOriginatingElement(): KSFileAsOriginatingElement? {
+    return (this as? KSDeclaration)?.containingFile?.let {
+        KSFileAsOriginatingElement(it)
+    }
+}

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspElement.kt
@@ -52,16 +52,6 @@ internal abstract class KspElement(
         return declaration.toString()
     }
 
-    /**
-     * Return a reference to the containing file that implements the
-     * [javax.lang.model.element.Element] API so that we can report it to JavaPoet.
-     */
-    fun containingFileAsOriginatingElement(): KSFileAsOriginatingElement? {
-        return (declaration as? KSDeclaration)?.containingFile?.let {
-            KSFileAsOriginatingElement(it)
-        }
-    }
-
     override val docComment: String? by lazy {
         (declaration as? KSDeclaration)?.docString
     }


### PR DESCRIPTION
## Proposed Changes
I ran into a crash using XProcessing because I pass a KspSyntheticPropertyMethodElement as an aggregating element, which wasn't supported. It's possible to work around this and manage elements in my processor differently, but it is fairly simple to support by expanding the when statement to map XElement to originating element.

## Testing

Test: Added cases to OriginatingElementsTest

## Issues Fixed

Fixes: N/A
