### PR TITLE
[XProcessing] Support all primitive types in XAnnotationBox

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationBox.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationBox.kt
@@ -77,6 +77,13 @@ internal fun <T : Annotation> AnnotationMirror.box(
             returnType == Array<String>::class.java -> value.getAsStringList().toTypedArray()
             returnType == emptyArray<Class<*>>()::class.java -> value.toListOfClassTypes(env)
             returnType == IntArray::class.java -> value.getAsIntList().toIntArray()
+            returnType == DoubleArray::class.java -> value.getAsDoubleList().toDoubleArray()
+            returnType == FloatArray::class.java -> value.getAsFloatList().toFloatArray()
+            returnType == CharArray::class.java -> value.getAsCharList().toCharArray()
+            returnType == ByteArray::class.java -> value.getAsByteList().toByteArray()
+            returnType == ShortArray::class.java -> value.getAsShortList().toShortArray()
+            returnType == LongArray::class.java -> value.getAsLongList().toLongArray()
+            returnType == BooleanArray::class.java -> value.getAsBooleanList().toBooleanArray()
             returnType == Class::class.java -> {
                 try {
                     value.toClassType(env)
@@ -132,6 +139,54 @@ private val ANNOTATION_VALUE_TO_INT_VISITOR = object : SimpleAnnotationValueVisi
 }
 
 @Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_DOUBLE_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Double?, Void>() {
+        override fun visitDouble(i: Double, p: Void?): Double? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_FLOAT_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Float?, Void>() {
+        override fun visitFloat(i: Float, p: Void?): Float? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_CHAR_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Char?, Void>() {
+        override fun visitChar(i: Char, p: Void?): Char? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_BYTE_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Byte?, Void>() {
+        override fun visitByte(i: Byte, p: Void?): Byte? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_SHORT_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Short?, Void>() {
+        override fun visitShort(i: Short, p: Void?): Short? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_TO_LONG_VISITOR =
+    object : SimpleAnnotationValueVisitor6<Long?, Void>() {
+        override fun visitLong(i: Long, p: Void?): Long? {
+            return i
+        }
+    }
+
+@Suppress("DEPRECATION")
 private val ANNOTATION_VALUE_TO_BOOLEAN_VISITOR = object :
     SimpleAnnotationValueVisitor6<Boolean?, Void>() {
     override fun visitBoolean(b: Boolean, p: Void?): Boolean? {
@@ -167,12 +222,110 @@ private val ANNOTATION_VALUE_INT_ARR_VISITOR = object :
     }
 }
 
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_DOUBLE_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Double>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Double> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_DOUBLE_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_FLOAT_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Float>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Float> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_FLOAT_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_CHAR_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Char>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Char> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_CHAR_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_BYTE_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Byte>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Byte> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_BYTE_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_SHORT_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Short>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Short> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_SHORT_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_LONG_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Long>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Long> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_LONG_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
+@Suppress("DEPRECATION")
+private val ANNOTATION_VALUE_BOOLEAN_ARR_VISITOR = object :
+    SimpleAnnotationValueVisitor6<List<Boolean>, Void>() {
+    override fun visitArray(vals: MutableList<out AnnotationValue>?, p: Void?): List<Boolean> {
+        return vals?.mapNotNull {
+            ANNOTATION_VALUE_TO_BOOLEAN_VISITOR.visit(it)
+        } ?: emptyList()
+    }
+}
+
 private fun AnnotationValue.getAsInt(def: Int? = null): Int? {
     return ANNOTATION_VALUE_TO_INT_VISITOR.visit(this) ?: def
 }
 
 private fun AnnotationValue.getAsIntList(): List<Int> {
     return ANNOTATION_VALUE_INT_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsDoubleList(): List<Double> {
+    return ANNOTATION_VALUE_DOUBLE_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsFloatList(): List<Float> {
+    return ANNOTATION_VALUE_FLOAT_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsCharList(): List<Char> {
+    return ANNOTATION_VALUE_CHAR_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsByteList(): List<Byte> {
+    return ANNOTATION_VALUE_BYTE_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsShortList(): List<Short> {
+    return ANNOTATION_VALUE_SHORT_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsLongList(): List<Long> {
+    return ANNOTATION_VALUE_LONG_ARR_VISITOR.visit(this)
+}
+
+private fun AnnotationValue.getAsBooleanList(): List<Boolean> {
+    return ANNOTATION_VALUE_BOOLEAN_ARR_VISITOR.visit(this)
 }
 
 private fun AnnotationValue.getAsString(def: String? = null): String? {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationBox.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/javac/JavacAnnotationBox.kt
@@ -72,6 +72,13 @@ internal fun <T : Annotation> AnnotationMirror.box(
         val returnType = method.returnType
         val defaultValue = method.defaultValue
         val result: Any? = when {
+            returnType == Int::class.java -> value.getAsInt(defaultValue as Int?)
+            returnType == Double::class.java -> value.getAsDouble(defaultValue as Double?)
+            returnType == Float::class.java -> value.getAsFloat(defaultValue as Float?)
+            returnType == Char::class.java -> value.getAsChar(defaultValue as Char?)
+            returnType == Byte::class.java -> value.getAsByte(defaultValue as Byte?)
+            returnType == Short::class.java -> value.getAsShort(defaultValue as Short?)
+            returnType == Long::class.java -> value.getAsLong(defaultValue as Long?)
             returnType == Boolean::class.java -> value.getAsBoolean(defaultValue as Boolean)
             returnType == String::class.java -> value.getAsString(defaultValue as String?)
             returnType == Array<String>::class.java -> value.getAsStringList().toTypedArray()
@@ -91,7 +98,6 @@ internal fun <T : Annotation> AnnotationMirror.box(
                     null
                 }
             }
-            returnType == Int::class.java -> value.getAsInt(defaultValue as Int?)
             returnType.isAnnotation -> {
                 @Suppress("UNCHECKED_CAST")
                 AnnotationClassVisitor(env, returnType as Class<out Annotation>).visit(value)
@@ -294,6 +300,30 @@ private val ANNOTATION_VALUE_BOOLEAN_ARR_VISITOR = object :
 
 private fun AnnotationValue.getAsInt(def: Int? = null): Int? {
     return ANNOTATION_VALUE_TO_INT_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsDouble(def: Double? = null): Double? {
+    return ANNOTATION_VALUE_TO_DOUBLE_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsFloat(def: Float? = null): Float? {
+    return ANNOTATION_VALUE_TO_FLOAT_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsChar(def: Char? = null): Char? {
+    return ANNOTATION_VALUE_TO_CHAR_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsByte(def: Byte? = null): Byte? {
+    return ANNOTATION_VALUE_TO_BYTE_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsShort(def: Short? = null): Short? {
+    return ANNOTATION_VALUE_TO_SHORT_VISITOR.visit(this) ?: def
+}
+
+private fun AnnotationValue.getAsLong(def: Long? = null): Long? {
+    return ANNOTATION_VALUE_TO_LONG_VISITOR.visit(this) ?: def
 }
 
 private fun AnnotationValue.getAsIntList(): List<Int> {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationBox.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationBox.kt
@@ -141,13 +141,32 @@ private fun <R> Any.readAs(returnType: Class<R>): R? {
             }
             if (returnType.componentType.isPrimitive) {
                 when (returnType) {
-                    IntArray::class.java ->
+                    IntArray::class.java -> {
                         (values as Collection<Int>).toIntArray()
+                    }
+                    DoubleArray::class.java -> {
+                        (values as Collection<Double>).toDoubleArray()
+                    }
+                    FloatArray::class.java -> {
+                        (values as Collection<Float>).toFloatArray()
+                    }
+                    CharArray::class.java -> {
+                        (values as Collection<Char>).toCharArray()
+                    }
+                    ByteArray::class.java -> {
+                        (values as Collection<Byte>).toByteArray()
+                    }
+                    ShortArray::class.java -> {
+                        (values as Collection<Short>).toShortArray()
+                    }
+                    LongArray::class.java -> {
+                        (values as Collection<Long>).toLongArray()
+                    }
+                    BooleanArray::class.java -> {
+                        (values as Collection<Boolean>).toBooleanArray()
+                    }
                     else -> {
-                        // We don't have the use case for these yet but could be implemented in
-                        // the future. Also need to implement them in JavacAnnotationBox
-                        // b/179081610
-                        error("Unsupported primitive array type: $returnType")
+                       error("Unsupported primitive array type: $returnType")
                     }
                 }
             } else {

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationBox.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KspAnnotationBox.kt
@@ -166,7 +166,7 @@ private fun <R> Any.readAs(returnType: Class<R>): R? {
                         (values as Collection<Boolean>).toBooleanArray()
                     }
                     else -> {
-                       error("Unsupported primitive array type: $returnType")
+                        error("Unsupported primitive array type: $returnType")
                     }
                 }
             } else {

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationBoxTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationBoxTest.kt
@@ -469,13 +469,21 @@ class XAnnotationBoxTest(
 
     @Test
     fun javaPrimitiveArray() {
-        // TODO: expand this test for other primitive types: 179081610
         val javaSrc = Source.java(
             "JavaSubject.java",
             """
             import androidx.room.compiler.processing.testcode.*;
             class JavaSubject {
-                @JavaAnnotationWithPrimitiveArray(intArray = {1, 2, 3})
+                @JavaAnnotationWithPrimitiveArray(
+                    intArray = {1, 2, 3},
+                    doubleArray = {1.0,2.0,3.0},
+                    floatArray = {1f,2f,3f},
+                    charArray = {'1','2','3'},
+                    byteArray = {1,2,3},
+                    shortArray = {1,2,3},
+                    longArray = {1,2,3},
+                    booleanArray = {true, false}
+                )
                 Object annotated1;
             }
             """.trimIndent()
@@ -485,7 +493,16 @@ class XAnnotationBoxTest(
             """
             import androidx.room.compiler.processing.testcode.*;
             class KotlinSubject {
-                @JavaAnnotationWithPrimitiveArray(intArray = [1, 2, 3])
+                @JavaAnnotationWithPrimitiveArray(
+                    intArray = [1, 2, 3],
+                    doubleArray = [1.0,2.0,3.0],
+                    floatArray = [1f,2f,3f],
+                    charArray = ['1','2','3'],
+                    byteArray = [1,2,3],
+                    shortArray = [1,2,3],
+                    longArray = [1,2,3],
+                    booleanArray = [true, false],
+                )
                 val annotated1:Any = TODO()
             }
             """.trimIndent()
@@ -503,6 +520,41 @@ class XAnnotationBoxTest(
                     annotation?.value?.intArray
                 ).isEqualTo(
                     intArrayOf(1, 2, 3)
+                )
+                assertThat(
+                    annotation?.value?.doubleArray
+                ).isEqualTo(
+                    doubleArrayOf(1.0, 2.0, 3.0)
+                )
+                assertThat(
+                    annotation?.value?.floatArray
+                ).isEqualTo(
+                    floatArrayOf(1f, 2f, 3f)
+                )
+                assertThat(
+                    annotation?.value?.charArray
+                ).isEqualTo(
+                    charArrayOf('1', '2', '3')
+                )
+                assertThat(
+                    annotation?.value?.byteArray
+                ).isEqualTo(
+                    byteArrayOf(1, 2, 3)
+                )
+                assertThat(
+                    annotation?.value?.shortArray
+                ).isEqualTo(
+                    shortArrayOf(1, 2, 3)
+                )
+                assertThat(
+                    annotation?.value?.longArray
+                ).isEqualTo(
+                    longArrayOf(1, 2, 3)
+                )
+                assertThat(
+                    annotation?.value?.booleanArray
+                ).isEqualTo(
+                    booleanArrayOf(true, false)
                 )
             }
         }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationBoxTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationBoxTest.kt
@@ -119,6 +119,13 @@ class XAnnotationBoxTest(
                 typeList = {String.class, Integer.class},
                 singleType = Long.class,
                 intMethod = 3,
+                doubleMethodWithDefault = 3.0,
+                floatMethodWithDefault = 3f,
+                charMethodWithDefault = '3',
+                byteMethodWithDefault = 3,
+                shortMethodWithDefault = 3,
+                longMethodWithDefault = 3L,
+                boolMethodWithDefault = false,
                 otherAnnotationArray = {
                     @OtherAnnotation(
                         value = "other list 1"
@@ -150,6 +157,13 @@ class XAnnotationBoxTest(
                 )
 
                 assertThat(annotation.value.intMethod).isEqualTo(3)
+                assertThat(annotation.value.doubleMethodWithDefault).isEqualTo(3.0)
+                assertThat(annotation.value.floatMethodWithDefault).isEqualTo(3f)
+                assertThat(annotation.value.charMethodWithDefault).isEqualTo('3')
+                assertThat(annotation.value.byteMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.shortMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.longMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.boolMethodWithDefault).isEqualTo(false)
                 annotation.getAsAnnotationBox<OtherAnnotation>("singleOtherAnnotation")
                     .let { other ->
                         assertThat(other.value.value).isEqualTo("other single")
@@ -201,6 +215,13 @@ class XAnnotationBoxTest(
                 typeList = [String::class, Int::class],
                 singleType = Long::class,
                 intMethod = 3,
+                doubleMethodWithDefault = 3.0,
+                floatMethodWithDefault = 3f,
+                charMethodWithDefault = '3',
+                byteMethodWithDefault = 3,
+                shortMethodWithDefault = 3,
+                longMethodWithDefault = 3L,
+                boolMethodWithDefault = false,
                 otherAnnotationArray = [
                     OtherAnnotation(
                         value = "other list 1"
@@ -235,6 +256,13 @@ class XAnnotationBoxTest(
                 )
 
                 assertThat(annotation.value.intMethod).isEqualTo(3)
+                assertThat(annotation.value.doubleMethodWithDefault).isEqualTo(3.0)
+                assertThat(annotation.value.floatMethodWithDefault).isEqualTo(3f)
+                assertThat(annotation.value.charMethodWithDefault).isEqualTo('3')
+                assertThat(annotation.value.byteMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.shortMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.longMethodWithDefault).isEqualTo(3)
+                assertThat(annotation.value.boolMethodWithDefault).isEqualTo(false)
                 annotation.getAsAnnotationBox<OtherAnnotation>("singleOtherAnnotation")
                     .let { other ->
                         assertThat(other.value.value).isEqualTo("other single")

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/JavaAnnotationWithPrimitiveArray.java
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/JavaAnnotationWithPrimitiveArray.java
@@ -22,4 +22,18 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface JavaAnnotationWithPrimitiveArray {
     int[] intArray() default {};
+
+    double[] doubleArray() default {};
+
+    float[] floatArray() default {};
+
+    char[] charArray() default {};
+
+    byte[] byteArray() default {};
+
+    short[] shortArray() default {};
+
+    long[] longArray() default {};
+
+    boolean[] booleanArray() default {};
 }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/MainAnnotation.java
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/MainAnnotation.java
@@ -34,6 +34,18 @@ public @interface MainAnnotation {
 
     int intMethod();
 
+    double doubleMethodWithDefault() default 0;
+
+    float floatMethodWithDefault() default 0;
+
+    char charMethodWithDefault() default 0;
+
+    byte byteMethodWithDefault() default 0;
+
+    short shortMethodWithDefault() default 0;
+
+    long longMethodWithDefault() default 0;
+
     boolean boolMethodWithDefault() default true;
 
     OtherAnnotation[] otherAnnotationArray() default {};


### PR DESCRIPTION
## Proposed Changes
It had been left as a TODO to support most primitive types and primitive type arrays (besides Int) in the annotation box, and would result in a runtime crash if they were used. This implements them following the same pattern as the Int implementation.

## Testing

Test: Added tests to XAnnotationBoxTest for all primitive types and type arrays for both kotlin and java sources.

## Issues Fixed

Fixes: b/179081610
