### PR TITLE
Update gradle caching

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -121,10 +121,10 @@ jobs:
           arguments: -q :ktlintCheckFile ${{ steps.ktlint-file-args.outputs.ktlint-file-args }} ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: activity
           configuration-cache-enabled: false
-          dependencies-cache-enabled: true
+          dependencies-cache-enabled: false
           gradle-executable: activity/gradlew
           wrapper-directory: activity/gradle/wrapper
-          distributions-cache-enabled: true
+          distributions-cache-enabled: false
   build-modules:
     strategy:
       fail-fast: false

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -15,9 +15,9 @@ jobs:
         id: global-constants
         run: |
           set -x
-          GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=300000 \
-            -Dorg.gradle.internal.http.socketTimeout=300000                  \
-            -Dorg.gradle.internal.repository.max.retries=10                  \
+          GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=60000 \
+            -Dorg.gradle.internal.http.socketTimeout=60000                   \
+            -Dorg.gradle.internal.repository.max.retries=20                  \
             -Dorg.gradle.internal.repository.initial.backoff=500             \
             -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=512m"                 \
             --stacktrace"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -96,6 +96,23 @@ jobs:
           set -x
           AFFECTED_FILES=`echo "${{ steps.changed-files.outputs.files_including_removals }}" | sed 's|\([^ ]\+\)|--changedFilePath=\1|g'`
           echo "::set-output name=files::$AFFECTED_FILES"
+      - name: "warm up gradle"
+        id: warm-up-gradle-cache
+        uses: gradle/gradle-command-action@v1
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+          JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
+        with:
+          arguments: tasks -PandroidXUnusedParameter=activity # add project name to cache key
+          build-root-directory: activity
+          configuration-cache-enabled: true
+          dependencies-cache-enabled: true
+          dependencies-cache-key: |
+            **/libs.versions.toml
+          dependencies-cache-exact: false
+          gradle-executable: activity/gradlew
+          wrapper-directory: activity/gradle/wrapper
+          distributions-cache-enabled: true
       - name: "ktlint"
         uses: gradle/gradle-command-action@v1
         env:
@@ -103,7 +120,7 @@ jobs:
         with:
           arguments: -q :ktlintCheckFile ${{ steps.ktlint-file-args.outputs.ktlint-file-args }} ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: activity
-          configuration-cache-enabled: true
+          configuration-cache-enabled: false
           dependencies-cache-enabled: true
           gradle-executable: activity/gradlew
           wrapper-directory: activity/gradle/wrapper
@@ -164,7 +181,7 @@ jobs:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
           JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
         with:
-          arguments: tasks -PandroidUnusedParameter=${{ env.project-root }} # add project name to cache key
+          arguments: tasks -PandroidXUnusedParameter=${{ env.project-root }} # add project name to cache key
           build-root-directory: ${{ env.project-root }}
           configuration-cache-enabled: true
           dependencies-cache-enabled: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -97,7 +97,7 @@ jobs:
           AFFECTED_FILES=`echo "${{ steps.changed-files.outputs.files_including_removals }}" | sed 's|\([^ ]\+\)|--changedFilePath=\1|g'`
           echo "::set-output name=files::$AFFECTED_FILES"
       - name: "ktlint"
-        uses: gradle/gradle-command-action@v1.4.1
+        uses: gradle/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         with:
@@ -107,7 +107,7 @@ jobs:
           dependencies-cache-enabled: true
           gradle-executable: activity/gradlew
           wrapper-directory: activity/gradle/wrapper
-          wrapper-cache-enabled: true
+          distributions-cache-enabled: true
   build-modules:
     strategy:
       fail-fast: false
@@ -154,21 +154,41 @@ jobs:
           set -x
           echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
+      # gradle action loads the dependencies cache only on the first run based on arguments.
+      # to control it, we explicitly invoke it once which makes it load the dependencies cache with the parameters
+      # we control
+      - name: "warm up gradle"
+        id: warm-up-gradle-cache
+        uses: gradle/gradle-command-action@v1
+        env:
+          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
+          JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
+        with:
+          arguments: tasks -PandroidUnusedParameter=${{ env.project-root }} # add project name to cache key
+          build-root-directory: ${{ env.project-root }}
+          configuration-cache-enabled: true
+          dependencies-cache-enabled: true
+          dependencies-cache-key: |
+            **/libs.versions.toml
+          dependencies-cache-exact: false
+          gradle-executable: ${{ env.project-root }}/gradlew
+          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
+          distributions-cache-enabled: true
       - name: "./gradlew findAffectedModules"
         id: find-affected-modules
         if: ${{ needs.lint.outputs.affectedFileArgs != '' }}
-        uses: gradle/gradle-command-action@v1.4.1
+        uses: gradle/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
           JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
         with:
           arguments: findAffectedModules ${{ needs.lint.outputs.affectedFileArgs }} ${{ needs.setup.outputs.gradlew_flags }} --outputFilePath=${{ github.workspace }}/affected.txt
           build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
+          configuration-cache-enabled: false
+          dependencies-cache-enabled: false
+          distributions-cache-enabled: false
           gradle-executable: ${{ env.project-root }}/gradlew
           wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
       - name: "Parse the output of find affected modules step to see if we should build"
         id: affected-module-count
         run: |
@@ -176,7 +196,7 @@ jobs:
           AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt || true`
           echo "::set-output name=count::$AFFECTED_MODULE_COUNT"
       - name: "./gradlew buildOnServer buildTestApks"
-        uses: gradle/gradle-command-action@v1.4.1
+        uses: gradle/gradle-command-action@v1
         if: ${{ steps.affected-module-count.outputs.count > 0 }}
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
@@ -184,11 +204,11 @@ jobs:
         with:
           arguments: buildOnServer buildTestApks ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
-          dependencies-cache-enabled: true
+          configuration-cache-enabled: false
+          dependencies-cache-enabled: false
+          distributions-cache-enabled: false
           gradle-executable: ${{ env.project-root }}/gradlew
           wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          wrapper-cache-enabled: true
 
       - name: "Upload build artifacts"
         continue-on-error: true


### PR DESCRIPTION
gradle-command-action action uses the arguments as the cache key and restores dependency cache only in the first run.
This means, it uses the "changed files" as the cache key, which is the same for all projects, making it useless as they'll override each-other.

This PR adds a first invocation to the action and passes the project name as an argument + the toml file.
This should allow each sub project to have its own cache. 

There is a certain risk that this might hit the 5GB cache limit as projects won't share cache, causing them to evict each-other (instead of overriding each-other). We don't force exact so it should at least recover from prefix cache key.

Whether this change would help or not is questionable but if we don't get into a cache-eviction race, it might work well.

To be explicit, i disabled the cache for subsequent calls to gradle-command-action and also updated it back to @v1  as the previous issue we hit is fixed.
https://github.com/gradle/gradle-build-action/issues/70

Bug: n/a
Test: CI
