### PR TITLE
[XProcessing] Fix getAllAnnotations returning empty list

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/InternalXAnnotation.kt
@@ -38,7 +38,7 @@ internal fun XAnnotation.unwrapRepeatedAnnotationsFromContainer(): List<XAnnotat
         // the value of Repeatable is not present so the best we can do is check that all the nested
         // members are annotated with repeatable.
         // https://github.com/google/ksp/issues/358
-        val isRepeatable = nestedAnnotations.all {
+        val isRepeatable = nestedAnnotations.isNotEmpty() && nestedAnnotations.all {
             // The java and kotlin versions of Repeatable are not interchangeable.
             // https://github.com/google/ksp/issues/459 asks whether the built in type mapper
             // should convert them, but it may not be possible because there are differences

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/XAnnotationTest.kt
@@ -696,6 +696,44 @@ class XAnnotationTest(
     }
 
     @Test
+    fun javaEnumArrayWithDefaultNameAndValue() {
+        val annotationSource = Source.java(
+            "foo.bar.MyAnnotation",
+            """
+            package foo.bar;
+            public @interface MyAnnotation {
+                MyEnum[] value() default {};
+            }
+            """.trimIndent()
+        )
+        val enumSource = Source.java(
+            "foo.bar.MyEnum",
+            """
+            package foo.bar;
+            enum MyEnum {
+                 Bar
+            }
+            """.trimIndent()
+        )
+        val classSource = Source.java(
+            "foo.bar.Subject",
+            """
+            package foo.bar;
+            @MyAnnotation
+            class Subject {}
+            """.trimIndent()
+        )
+        runTest(
+            sources = listOf(annotationSource, enumSource, classSource)
+        ) { invocation ->
+            val subject = invocation.processingEnv.requireTypeElement("foo.bar.Subject")
+
+            val annotations = subject.getAllAnnotations().filter { it.name == "MyAnnotation" }
+            assertThat(annotations).hasSize(1)
+        }
+    }
+
+    @Test
     fun javaRepeatableAnnotation() {
         val javaSrc = Source.java(
             "JavaSubject",


### PR DESCRIPTION
## Proposed Changes
There is a bug in `XAnnotated.getAllAnnotations` where it returns empty if the annotation contains a value named `value` and is an array type. This is due to a bug in `unwrapRepeatedAnnotationsFromContainer` where if the array it tries to unwrap is empty it is incorrectly believed to be a repeated annotations array.

The fix is simple, in `unwrapRepeatedAnnotationsFromContainer` we need to check that the array is not empty in addition to the existing `all` check we do.

## Testing

Test: Added a test to XAnnotationTest that reproduces the issue and passes with the fix applied.

## Issues Fixed

Fixes: N/A
