### PR TITLE
Upload test apk's as a separate artifact

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -16,10 +16,10 @@ jobs:
         run: |
           set -x
           GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=60000 \
-            -Dorg.gradle.internal.http.socketTimeout=60000                   \
-            -Dorg.gradle.internal.repository.max.retries=20                  \
-            -Dorg.gradle.internal.repository.initial.backoff=500             \
-            -Dorg.gradle.jvmargs="-XX:MaxMetaspaceSize=512m"                 \
+            -Dorg.gradle.internal.http.socketTimeout=60000                  \
+            -Dorg.gradle.internal.repository.max.retries=20                 \
+            -Dorg.gradle.internal.repository.initial.backoff=500            \
+            -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m"         \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m           \
+            -Dorg.gradle.jvmargs=\"-Xmx4g -XX:MaxMetaspaceSize=512m\"       \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -235,11 +235,3 @@ jobs:
           name: artifacts_${{ env.artifact-id }}
           path: |
             ~/dist
-            !~/dist/androidTest.zip
-      - name: "Upload test APKs"
-        continue-on-error: false
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          name: integrationTests_${{ env.artifact-id }}
-          path: ~/dist/androidTest.zip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=-Xmx6g \"-XX:MaxMetaspaceSize=512m\"       \
+            -Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m                  \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -233,5 +233,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: artifacts_${{ env.artifact-id }}
-          path: |
-            ~/dist
+          path: ~/dist

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -212,14 +212,14 @@ jobs:
           set -x
           AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt || true`
           echo "::set-output name=count::$AFFECTED_MODULE_COUNT"
-      - name: "./gradlew buildOnServer buildTestApks"
+      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
         uses: gradle/gradle-command-action@v1
         if: ${{ steps.affected-module-count.outputs.count > 0 }}
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
           JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
         with:
-          arguments: buildOnServer buildTestApks ${{ needs.setup.outputs.gradlew_flags }}
+          arguments: buildOnServer zipTestConfigsWithApks ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}
           configuration-cache-enabled: false
           dependencies-cache-enabled: false
@@ -233,4 +233,13 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: artifacts_${{ env.artifact-id }}
-          path: ~/dist
+          path: |
+            ~/dist
+            !~/dist/androidTest.zip
+      - name: "Upload test APKs"
+        continue-on-error: false
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: integrationTests_${{ env.artifact-id }}
+          path: ~/dist/androidTest.zip

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=\"-Xmx4g -XX:MaxMetaspaceSize=512m\"       \
+            -Dorg.gradle.jvmargs=-Xmx6g \"-XX:MaxMetaspaceSize=512m\"       \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m"         \
+            -Dorg.gradle.jvmargs=\"-Xmx6g -XX:MaxMetaspaceSize=512m\"       \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=\"-Xmx6g -XX:MaxMetaspaceSize=512m\"       \
+            -Dorg.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=512m           \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
@@ -178,12 +178,12 @@ abstract class AndroidXRootImplPlugin : Plugin<Project> {
 
         tasks.register(AndroidXImplPlugin.BUILD_TEST_APKS_TASK)
 
+        // NOTE: this task is used by the Github CI as well. If you make any changes here,
+        // please update the .github/workflows files as well, if necessary.
         project.tasks.register(
             ZIP_TEST_CONFIGS_WITH_APKS_TASK, Zip::class.java
         ) {
             it.destinationDirectory.set(project.getDistributionDirectory())
-            // This file name is referenced by the playground setup. If you rename it, don't
-            // forget to update .github/workflows
             it.archiveFileName.set("androidTest.zip")
             it.from(project.getTestConfigDirectory())
             // We're mostly zipping a bunch of .apk files that are already compressed

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXRootImplPlugin.kt
@@ -182,6 +182,8 @@ abstract class AndroidXRootImplPlugin : Plugin<Project> {
             ZIP_TEST_CONFIGS_WITH_APKS_TASK, Zip::class.java
         ) {
             it.destinationDirectory.set(project.getDistributionDirectory())
+            // This file name is referenced by the playground setup. If you rename it, don't
+            // forget to update .github/workflows
             it.archiveFileName.set("androidTest.zip")
             it.from(project.getTestConfigDirectory())
             // We're mostly zipping a bunch of .apk files that are already compressed


### PR DESCRIPTION
This PR fixes a problem where we stopped distributing test apks hence
stopped running FTL tests (aosp/1751630).

We will now re-use what aosp does to reduce chances of this breaking
(should probably add some failsafe, this PR does not do it).

For this to take affect, we also need to update androidx-ci-action to
look for the new artifact name.

Bug: n/a
Test: CI
