### PR TITLE
Change playground rootproject name: navigation -> lifecycle

### DIFF
--- a/lifecycle/settings.gradle
+++ b/lifecycle/settings.gradle
@@ -15,7 +15,7 @@
  */
 
 // see ../playground-common/README.md for details on how this works
-rootProject.name = "navigation-playground"
+rootProject.name = "lifecycle-playground"
 apply from: "../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "..")
 selectProjectsFromAndroidX({ name ->


### PR DESCRIPTION
## Proposed Changes

  - Fix the name of the rootProject. All these time `lifecycle` project has the name `navigation-playground` instead of `lifecycle-playground`, which caused incorrect project title in Android Studio as well.

## Testing
Bug: N/A
Test: local

