### PR TITLE
Fix equals definition for LayoutWeightImpl

### DIFF
--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/RowColumnImpl.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/RowColumnImpl.kt
@@ -775,8 +775,8 @@ internal class LayoutWeightImpl(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         val otherModifier = other as? LayoutWeightImpl ?: return false
-        return weight != otherModifier.weight &&
-            fill != otherModifier.fill
+        return weight == otherModifier.weight &&
+            fill == otherModifier.fill
     }
 
     override fun hashCode(): Int {


### PR DESCRIPTION
## Proposed Changes

Fix the equals check in `LayoutWeightImpl`. It currently returns true if its `weight` and `fill` _don't_ equal the other modifier's properties.

## Testing

Bug: N/A
Test: local

