### PR TITLE
Use relative paths for ktlint arguments

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -87,7 +87,7 @@ jobs:
         id: ktlint-file-args
         run: |
           set -x
-          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=${{ github.workspace }}/&|g' | grep -v "*.txt"`
+          KTLINT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=../&|g' | grep -v "*.txt"`
           echo "::set-output name=ktlint-file-args::$KTLINT_FILES"
 
       - name: "Parse changed-files as affected files args"


### PR DESCRIPTION
The latest ktlint update removed the support for absolute paths as
arguments.
https://github.com/pinterest/ktlint/issues/1131

Github workflow used to prepend the checkout source to make paths
absolute and now it does not work anymore. This PR
replaces it with `..` since we run ktlint inside `activity` project.

There is probably a better shell magic to get this but I think .. is good
enough for now. (there does not seem to be a consistent solution between
mac and linux for relative paths).

Bug: n/a
Test: locally verified that relative paths with .. works by manually
breaking a file's style in room and invoked ktlint in activity as the
workflow does.