### PR TITLE
Fix isolalation of nested mutable snapshots

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/snapshots/Snapshot.kt
@@ -532,15 +532,18 @@ open class MutableSnapshot internal constructor(
     ): MutableSnapshot {
         validateNotDisposed()
         validateNotApplied()
+        val previousId = id
         return advance {
             sync {
                 val newId = nextSnapshotId++
                 openSnapshots = openSnapshots.set(newId)
-                val invalid = invalid
-                this.invalid = invalid.set(newId)
+                var currentInvalid = invalid
+                for (invalidId in previousId + 1 until newId) {
+                    currentInvalid = currentInvalid.set(invalidId)
+                }
                 NestedMutableSnapshot(
                     newId,
-                    invalid,
+                    currentInvalid,
                     mergedReadObserver(readObserver, this.readObserver),
                     mergedWriteObserver(writeObserver, this.writeObserver),
                     this


### PR DESCRIPTION
A nested mutable snapshot should be isolated from all changes made but currently will see changes made to objects between the time the parent was created and when the snapshot was taken.

This fixes that by considiering all snapshots between the parent old id and new nested mutable snapshot's id.

Fixes: b/200575924
Test: ./gradlew :compose:r:r:tDUT