### PR TITLE
Updated GH action setup-java distro to zulu.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'zulu'
       - name: "set output directory"
         run: echo "::set-output name=output-dir::$(readlink -f .)/outputs"
         id: dirs


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 


## Proposed Changes
  - Switch from 'adopt' to 'zulu'

## Testing
N/A GitHub Action workflow.

## Issues Fixed

Fixes: using 'zulu' as a JDK build distribution. The 'adopt' builds are discontinued. 
Test: GH workflows