### PR TITLE
bump prebuilts for lifecycle

### DIFF
--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,7 +25,7 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=7782543
+androidx.playground.snapshotBuildId=7838424
 androidx.playground.metalavaBuildId=7743859
 androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
lifecycle had source breaking changes so we need
to bump the prebuilts version to use the new
source.

Bug: n/a
Test: :lifecycle:lifecycle-viewmodel-savedstate:compileReleaseJavaWithJavac
