### PR TITLE
Avoid duplicate project dirs in playground

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXImplPlugin.kt
@@ -874,10 +874,7 @@ private const val GROUP_PREFIX = "androidx."
  * Validates the project structure against Jetpack guidelines.
  */
 fun Project.validateProjectStructure(groupId: String) {
-    // TODO(b/197253160): Re-enable this check for playground. For unknown reasons in playground
-    //  builds, automatically generated parent projects such as :activity are incorrectly
-    //  inheriting their children's build file which causes the AndroidXPlugin to get applied.
-    if (studioType() == StudioType.PLAYGROUND || !project.isValidateProjectStructureEnabled()) {
+    if (!project.isValidateProjectStructureEnabled()) {
         return
     }
 

--- a/playground-common/playground-include-settings.gradle
+++ b/playground-common/playground-include-settings.gradle
@@ -24,8 +24,9 @@
  * not, gradle will use the root project path to set the projectDir, which might conflict in
  * playground. Instead, this method checks if another project in that path exists and if so,
  * changes the project dir to avoid the conflict.
+ * see b/197253160 for details.
  */
-def includeProjectIfNotExists(String name, File projectDir) {
+def includeFakeParentProjectIfNotExists(String name, File projectDir) {
     if (name.isEmpty()) return
     if (settings.findProject(name)) {
         return
@@ -36,13 +37,19 @@ def includeProjectIfNotExists(String name, File projectDir) {
         projectDir = new File(projectDir.getParentFile(), ".ignore-${projectDir.name}")
     }
     includeProject(name, projectDir)
+    // Set it to a gradle file that does not exist.
+    // We must always include projects starting with root, if we are including nested projects.
+    settings.project(name).buildFileName = "ignored.gradle"
 }
 
 def includeProject(String name, File projectDir) {
-    // Make sure parent is created first. see: b/197253160 for details
+    if (settings.findProject(name) != null) {
+        throw new GradleException("Cannot include project twice: $name is already included.")
+    }
     def parentPath = name.substring(0, name.lastIndexOf(":"))
     def parentDir = projectDir.getParentFile()
-    includeProjectIfNotExists(
+    // Make sure parent is created first. see: b/197253160 for details
+    includeFakeParentProjectIfNotExists(
         parentPath,
         parentDir
     )

--- a/playground-common/playground-include-settings.gradle
+++ b/playground-common/playground-include-settings.gradle
@@ -18,16 +18,37 @@
 // artifacts and the playground-build.gradle build file.
 // See README.md for details
 
-def includeProject(name, filePath) {
+/**
+ * Includes the project if it does not already exist.
+ * This is invoked from `includeProject` to ensure all parent projects are included. If they are
+ * not, gradle will use the root project path to set the projectDir, which might conflict in
+ * playground. Instead, this method checks if another project in that path exists and if so,
+ * changes the project dir to avoid the conflict.
+ */
+def includeProjectIfNotExists(String name, File projectDir) {
+    if (name.isEmpty()) return
+    if (settings.findProject(name)) {
+        return
+    }
+    if (settings.findProject(projectDir) != null) {
+        // Project directory conflicts with an existing project (possibly root). Move it
+        // to another directory to avoid the conflict.
+        projectDir = new File(projectDir.getParentFile(), ".ignore-${projectDir.name}")
+    }
+    includeProject(name, projectDir)
+}
+
+def includeProject(String name, File projectDir) {
+    // Make sure parent is created first. see: b/197253160 for details
+    def parentPath = name.substring(0, name.lastIndexOf(":"))
+    def parentDir = projectDir.getParentFile()
+    includeProjectIfNotExists(
+        parentPath,
+        parentDir
+    )
     settings.include(name)
 
-    def file
-    if (filePath instanceof String) {
-        file = new File(rootDir, filePath)
-    } else {
-        file = filePath
-    }
-    project(name).projectDir = file
+    project(name).projectDir = projectDir
 }
 
 /**
@@ -94,8 +115,8 @@ def selectProjectsFromAndroidX(filter) {
         def projectGradlePath = matcher.group("name")
         def projectFilePath = matcher.group("path")
         if (filter(projectGradlePath)) {
-            settings.includeProject(projectGradlePath,
-                    new File(ext.supportRootDir, projectFilePath))
+            def projectDir = new File(ext.supportRootDir, projectFilePath)
+            settings.includeProject(projectGradlePath, projectDir)
         }
     }
 }

--- a/work/settings.gradle
+++ b/work/settings.gradle
@@ -29,4 +29,4 @@ includeProject(":inspection:inspection",
 includeProject(":inspection:inspection-testing",
     new File(supportRootDir, "inspection/inspection-testing"))
 includeProject(":inspection:inspection-gradle-plugin",
-    new File(supportRootDir, "inspection/inspection-testing"))
+    new File(supportRootDir, "inspection/inspection-gradle-plugin"))


### PR DESCRIPTION
This CL fixes a bug in playground where we might end up with duplicate
project directories when Gradle automatically creates a parent project
when it does not exist. When that case happens, Gradle will pick a
project directory relative to the playground root project. Instead, we
provide a project directory relative to the child project to ensure
consistency.

With this change, we can also enable to the project path validation in
the AndroidXPlugin.

Bug: 197253160
Test: cd activity && ./gradlew tasks // fails without this change