### PR TITLE
Set up Gradle enterprise for playground projects

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "activity-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/biometric/settings.gradle
+++ b/biometric/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "biometric-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/compose/compiler/settings.gradle
+++ b/compose/compiler/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "compose-compiler-playground"
 apply from: "../../playground-common/playground-include-settings.gradle"

--- a/compose/runtime/settings.gradle
+++ b/compose/runtime/settings.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 rootProject.name = "compose-runtime"
 apply from: "../../playground-common/playground-include-settings.gradle"
 setupPlayground(this, "../..")

--- a/datastore/settings.gradle
+++ b/datastore/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "datastore-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/fragment/settings.gradle
+++ b/fragment/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "fragment-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/lifecycle/settings.gradle
+++ b/lifecycle/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "lifecycle-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "navigation-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/paging/settings.gradle
+++ b/paging/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "paging-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/playground-common/playground-include-settings.gradle
+++ b/playground-common/playground-include-settings.gradle
@@ -72,6 +72,22 @@ def setupPlayground(settings, String relativePathToRoot) {
             new File(supportRoot, "testutils/testutils-common"))
     settings.includeProject(":internal-testutils-gradle-plugin",
             new File(supportRoot, "testutils/testutils-gradle-plugin"))
+
+    settings.gradleEnterprise {
+        server = "https://ge.androidx.dev"
+        buildScan {
+            publishAlways()
+            publishIfAuthenticated()
+            capture {
+                taskInputFiles = true
+            }
+            obfuscation {
+                username { name -> "unset" }
+                hostname { host -> "unset" }
+                ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0"} }
+            }
+        }
+    }
 }
 
 /**

--- a/room/settings.gradle
+++ b/room/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "room-playground"
 apply from: "../playground-common/playground-include-settings.gradle"

--- a/work/settings.gradle
+++ b/work/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id "com.gradle.enterprise" version "3.7.1"
+}
+
 // see ../playground-common/README.md for details on how this works
 rootProject.name = "work-playground"
 apply from: "../playground-common/playground-include-settings.gradle"


### PR DESCRIPTION
- Apply gradle enterprise settings plugin in every playground
settings.gradle file
- Configure to upload build scans when GRADLE_ENTERPRISE_ACCESS_KEY
  is set
- Obfuscate username, hostname, and IP

Test: GRADLE_ENTERPRISE_ACCESS_KEY=SOMEKEYHERE ./gradlew tasks
