### PR TITLE
[DO NOT MERGE] Testing changes to compose-compiler playground

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/playground/VerifyPlaygroundGradleConfigurationTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/playground/VerifyPlaygroundGradleConfigurationTask.kt
@@ -99,19 +99,22 @@ abstract class VerifyPlaygroundGradleConfigurationTask : DefaultTask() {
         // this includes properties that are not defined in the root androidx build as they might
         // be properties which can alter the build output. We might consider allow listing certain
         // properties in the future if necessary.
-        playgroundProperties.forEach {
-            val rootValue = rootProperties[it.key]
-            if (rootValue != it.value) {
-                throw GradleException(
-                    """
-                    ${it.key} is defined as ${it.value} in playground properties but
-                    it does not match the value defined in root properties file ($rootValue).
-                    Having inconsistent properties in playground projects might trigger wrong
-                    compilation output in the main AndroidX build, thus not allowed.
-                    """.trimIndent()
-                )
+        playgroundProperties
+            .filter { !it.key.toString().startsWith("androidx.github") }
+            .filter { !it.key.toString().startsWith("androidx.kmp") }
+            .forEach {
+                val rootValue = rootProperties[it.key]
+                if (rootValue != it.value) {
+                    throw GradleException(
+                        """
+                        ${it.key} is defined as ${it.value} in playground properties but
+                        it does not match the value defined in root properties file ($rootValue).
+                        Having inconsistent properties in playground projects might trigger wrong
+                        compilation output in the main AndroidX build, thus not allowed.
+                        """.trimIndent()
+                    )
+                }
             }
-        }
     }
 
     private fun loadPropertiesFile(file: File) = file.inputStream().use { inputStream ->

--- a/compose/compiler/compiler/integration-tests/build.gradle
+++ b/compose/compiler/compiler/integration-tests/build.gradle
@@ -30,7 +30,9 @@ dependencies {
 
 SdkResourceGenerator.generateForHostTest(project)
 
-tasks.findByPath("test").dependsOn(
-        tasks.findByPath(":compose:compiler:compiler:publish"),
-        tasks.findByPath(":compose:runtime:runtime:publish")
-)
+def githubBuild = project.properties['androidx.github.build']?.toBoolean() ?: false
+def testTask = tasks.findByPath("test")
+testTask.dependsOn(tasks.findByPath(":compose:compiler:compiler:publish"))
+if (!githubBuild) {
+     testTask.dependsOn(tasks.findByPath(":compose:runtime:runtime:publish"))
+}

--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -42,3 +42,7 @@ org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true
 org.gradle.unsafe.configuration-cache-problems=warn
 org.gradle.unsafe.configuration-cache.max-problems=4000
+
+androidx.github.build=true
+androidx.kmp.mac.enabled=true
+androidx.kmp.js.enabled=true

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,7 +25,7 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=7838424
+androidx.playground.snapshotBuildId=7884613
 androidx.playground.metalavaBuildId=7856580
 androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
… based on playground

Note: This fixes project configuration for a missing project from the
playground build. The tests still fail locally after this fix, but they
also fail from AOSP checkout, so it seems unrelated.

Test: ./gradlew :compose:compiler:compiler:integration-tests:test
Change-Id: Ifaf9f2c7bbf8c36c21ed8e91f4bad138d19a9e2e

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
