### PR TITLE
Skip build cache push if password is empty string

### DIFF
--- a/playground-common/playground-plugin/src/main/groovy/androidx/playground/GradleEnterpriseConventionsPlugin.groovy
+++ b/playground-common/playground-plugin/src/main/groovy/androidx/playground/GradleEnterpriseConventionsPlugin.groovy
@@ -45,7 +45,7 @@ class GradleEnterpriseConventionsPlugin implements Plugin<Settings> {
             remote(HttpBuildCache) {
                 url = "https://ge.androidx.dev/cache/"
                 var buildCachePassword = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")
-                if (buildCachePassword != null) {
+                if (buildCachePassword != null && !buildCachePassword.empty) {
                     push = true
                     credentials {
                         username = "ci"


### PR DESCRIPTION
PRs set GRADLE_BUILD_CACHE_PASSWORD to emtpy string. We should not
attempt to push to the cache in that case. Only when the value is
set to an non-empty string.

Test: GRADLE_BUILD_CACHE_PASSWORD="" ./gradlew tasks -> no warnings