### PR TITLE
Fix ProcessCompat.isApplicationUid always returns true

### DIFF
--- a/core/core/src/main/java/androidx/core/os/ProcessCompat.java
+++ b/core/core/src/main/java/androidx/core/os/ProcessCompat.java
@@ -106,6 +106,7 @@ public final class ProcessCompat {
                         // This should never happen, as the method returns a boolean primitive.
                         throw new NullPointerException();
                     }
+                    return result;
                 }
             } catch (Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
## Proposed Changes

  - Fix `ProcessCompat.isApplicationUid` always returns true when 17 <= SDK_INT <= 23

## Testing

Test: Test `ProcessCompat.isApplicationUid(1000)` on older AVD which should return false.

Co-authored-by: canyie <a1364259@163.com>