### PR TITLE
Copy buildCache config into `playground-plugin` settings

### DIFF
--- a/playground-common/playground-plugin/settings.gradle
+++ b/playground-common/playground-plugin/settings.gradle
@@ -13,4 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- rootProject.name = "playground-plugin"
+rootProject.name = "playground-plugin"
+
+// Build cache configuration is duplicated here, so that when building the `playground-plugin` 
+// included build the remote build cache will be used.
+// Without this, Gradle Enterprise erroneously reports a problem with 'buildSrc' build cache configuration.
+buildCache {
+    remote(HttpBuildCache) {
+        url = "https://ge.androidx.dev/cache/"
+        var buildCachePassword = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")
+        if (buildCachePassword != null && !buildCachePassword.empty) {
+            push = true
+            credentials {
+                username = "ci"
+                password = buildCachePassword
+            }
+        } else {
+            push = false
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Duplicate the build cache configuration into the 'playground-plugin' included build so that the same remote build cache config will be used.
Without this, Gradle Enterprise erroneously reports a problem with 'buildSrc' build cache configuration.

## Testing

Test: Generated [build scans](https://ge.androidx.dev/s/3eicgctkmsjog/performance/build-cache) no longer contain warnings about 'buildSrc' build cache configuration and tasks from `playground-plugin` build [are requested from remote cache](https://ge.androidx.dev/s/3eicgctkmsjog/performance/build-cache?anchor=eyJpZCI6InJlbW90ZS1taXNzIn0&cacheDetails=remote-miss).
