### PR TITLE
Enable host side tests in GitHub actions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -62,7 +62,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
       - name: "Checkout androidx repo"
@@ -171,7 +171,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk" >> $GITHUB_ENV
+          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
       # gradle action loads the dependencies cache only on the first run based on arguments.
       # to control it, we explicitly invoke it once which makes it load the dependencies cache with the parameters
@@ -214,14 +214,14 @@ jobs:
           set -x
           AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt || true`
           echo "::set-output name=count::$AFFECTED_MODULE_COUNT"
-      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
+      - name: "./gradlew buildOnServer zipTestConfigsWithApks test"
         uses: gradle/gradle-command-action@v1
         if: ${{ steps.affected-module-count.outputs.count > 0 }}
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
           JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
         with:
-          arguments: buildOnServer zipTestConfigsWithApks ${{ needs.setup.outputs.gradlew_flags }}
+          arguments: buildOnServer zipTestConfigsWithApks test ${{ needs.setup.outputs.gradlew_flags }}
           build-root-directory: ${{ env.project-root }}
           configuration-cache-enabled: false
           dependencies-cache-enabled: false

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -62,7 +62,6 @@ jobs:
         shell: bash
         run: |
           set -x
-          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
       - name: "Checkout androidx repo"
@@ -171,7 +170,6 @@ jobs:
         shell: bash
         run: |
           set -x
-          echo "ANDROID_SDK_ROOT=$ANDROID_HOME" >> $GITHUB_ENV
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
       # gradle action loads the dependencies cache only on the first run based on arguments.
       # to control it, we explicitly invoke it once which makes it load the dependencies cache with the parameters


### PR DESCRIPTION
- Removing setting ANDROID_SDK_ROOT, it is hardcode to a non existent path

Test: tested using https://github.com/androidx/androidx/actions/runs/1451151278
