### PR TITLE
Avoid using `DependencySubstitutions.all`

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -25,8 +25,6 @@ import groovy.xml.DOMBuilder
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.artifacts.DependencySubstitution
-import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.kotlin.dsl.KotlinClosure1
 import org.gradle.kotlin.dsl.extra
@@ -88,8 +86,9 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
         project.extra.set(PROJECT_OR_ARTIFACT_EXT_NAME, projectOrArtifactClosure)
         project.configurations.all { configuration ->
             configuration.resolutionStrategy.eachDependency { details ->
-                if (details.requested.version == SNAPSHOT_MARKER) {
-                    val snapshotVersion = findSnapshotVersion(details.requested.group, details.requested.name)
+                val requested = details.requested
+                if (requested.version == SNAPSHOT_MARKER) {
+                    val snapshotVersion = findSnapshotVersion(requested.group, requested.name)
                     details.useVersion(snapshotVersion)
                 }
             }


### PR DESCRIPTION
## Proposed Changes

When a substitution rule is added via `DependencySusbtitutions.all`, Gradle has no
way to determine if that rule will add new Project dependencies or not. As such,
all dependency resolution must be done when building the task execution graph,
in order to determine if the substitution will add additional tasks to the graph.

Using `ResolutionStrategy.eachDependency` avoids this overhead, since the API only permits
one external dependency to be substituted for another, and does not allow Project dependencies
to be added.

## Testing

Test: Ran `buildOnServer` for all Playground projects

