### PR TITLE
Fix cacheability of GenerateAntlrGrammarTask

### DIFF
--- a/room/room-compiler/build.gradle
+++ b/room/room-compiler/build.gradle
@@ -125,27 +125,42 @@ dependencies {
 }
 
 def generateAntlrTask = task("generateAntlrGrammar", type: GenerateAntlrGrammar) {
-    def outFolder = file(antlrOut)
-    outputDirectory = outFolder
     sqliteFile = file("$projectDir/SQLite.g4")
-    classpath configurations.compileClasspath
-    args "SQLite.g4", "-visitor", "-o", new File(outFolder, "androidx/room/parser").path,
-            "-package", "androidx.room.parser"
+    antlrClasspath = configurations.compileClasspath
+    outputDirectory = file(antlrOut)
 }
 
 @CacheableTask
-abstract class GenerateAntlrGrammar extends JavaExec {
+abstract class GenerateAntlrGrammar extends DefaultTask {
     @PathSensitive(PathSensitivity.NONE)
     @InputFile
     File sqliteFile
 
+    @Classpath
+    FileCollection antlrClasspath
+
     @OutputDirectory
     File outputDirectory
 
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    @Inject
     public GenerateAntlrGrammar() {
         description("Generates Antlr Grammar used by room")
         group("build")
-        mainClass.set("org.antlr.v4.Tool")
+    }
+
+    @TaskAction
+    void generateAntlrGrammar() {
+        execOperations.javaexec {
+            mainClass.set("org.antlr.v4.Tool")
+            classpath = antlrClasspath
+            args "SQLite.g4",
+                 "-visitor",
+                 "-o", new File(outputDirectory, "androidx/room/parser").path,
+                 "-package", "androidx.room.parser"
+        }
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

By extending `JavaExec`, the `generateAntlrGrammarTask` declares that the `args` parameter is a task input. Since this value contains the absolute path of an input file, this can be the source of cache misses.

This change converts the task to a `DefaultTask` and uses composition to delegate work to `ExecOperations.javaexec`. This allows the task to fully declare it's inputs and outputs in a path-sensitive manner.

## Testing

Test: [Running the same build from different checkout locations via Github Actions](https://github.com/bigdaz/androidx/blob/ge-experiments/.github/workflows/ge-experiments.yml) was used to demonstrate the initial cache miss, which is fixed by this PR.
