### PR TITLE
Disable background Build Scan upload on CI

### DIFF
--- a/playground-common/playground-plugin/src/main/groovy/androidx/playground/GradleEnterpriseConventionsPlugin.groovy
+++ b/playground-common/playground-plugin/src/main/groovy/androidx/playground/GradleEnterpriseConventionsPlugin.groovy
@@ -24,12 +24,17 @@ class GradleEnterpriseConventionsPlugin implements Plugin<Settings> {
         settings.apply(plugin: "com.gradle.enterprise")
         settings.apply(plugin: "com.gradle.common-custom-user-data-gradle-plugin")
 
+        // Github Actions always sets a "CI" environment variable
+        var isCI = System.getenv("CI") != null
+
         settings.gradleEnterprise {
             server = "https://ge.androidx.dev"
 
             buildScan {
                 publishAlways()
                 publishIfAuthenticated()
+
+                uploadInBackground = !isCI
 
                 capture {
                     taskInputFiles = true
@@ -45,7 +50,7 @@ class GradleEnterpriseConventionsPlugin implements Plugin<Settings> {
             remote(HttpBuildCache) {
                 url = "https://ge.androidx.dev/cache/"
                 var buildCachePassword = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")
-                if (buildCachePassword != null && !buildCachePassword.empty) {
+                if (isCI && buildCachePassword != null && !buildCachePassword.empty) {
                     push = true
                     credentials {
                         username = "ci"


### PR DESCRIPTION

## Proposed Changes

[Background upload of Gradle Build Scans](https://docs.gradle.com/enterprise/gradle-plugin/#configuring_background_uploading)  is good for developer builds, as the build completes without waiting for the upload to complete.  However this can be problematic on a CI server, as the container may shutdown before the build scan is finished uploading.

This change disables background upload when the build runs on Github Actions, or anywhere the `CI` environment variable is set.

## Testing

Test: [Without this change](https://ge.androidx.dev/s/w4xda3c63cilu#switches), build scans are uploaded in the background. [With the change](https://ge.androidx.dev/s/unnzocwpvkr5q#switches), they are not.
