### PR TITLE
[Room][XProcessing] Support for KSClassDeclaration association in filer

### DIFF
--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/XElement.kt
@@ -20,7 +20,7 @@ import androidx.room.compiler.processing.javac.JavacElement
 import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
 import androidx.room.compiler.processing.ksp.KspElement
 import androidx.room.compiler.processing.ksp.KspMemberContainer
-import androidx.room.compiler.processing.ksp.containingFileAsOriginatingElement
+import androidx.room.compiler.processing.ksp.wrapAsOriginatingElement
 import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import javax.lang.model.element.Element
 import kotlin.contracts.contract
@@ -129,13 +129,13 @@ internal fun XElement.originatingElementForPoet(): Element? {
     return when (this) {
         is JavacElement -> element
         is KspElement -> {
-            declaration.containingFileAsOriginatingElement()
+            declaration.wrapAsOriginatingElement()
         }
         is KspSyntheticPropertyMethodElement -> {
-            field.declaration.containingFileAsOriginatingElement()
+            field.declaration.wrapAsOriginatingElement()
         }
         is KspMemberContainer -> {
-            declaration?.containingFileAsOriginatingElement()
+            declaration?.wrapAsOriginatingElement()
         }
         else -> error("Originating element is not implemented for ${this.javaClass}")
     }

--- a/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSAnnotatedExt.kt
+++ b/room/room-compiler-processing/src/main/java/androidx/room/compiler/processing/ksp/KSAnnotatedExt.kt
@@ -17,6 +17,7 @@
 package androidx.room.compiler.processing.ksp
 
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 
 private fun KSAnnotated.hasAnnotationWithQName(qName: String) = annotations.any {
@@ -33,11 +34,15 @@ internal fun KSAnnotated.hasJvmFieldAnnotation() = hasAnnotationWithQName("kotli
 internal fun KSAnnotated.hasJvmDefaultAnnotation() = hasAnnotationWithQName("kotlin.jvm.JvmDefault")
 
 /**
- * Return a reference to the containing file that implements the
+ * Return a reference to the containing file or class declaration via a wrapper that implements the
  * [javax.lang.model.element.Element] API so that we can report it to JavaPoet.
  */
-internal fun KSAnnotated.containingFileAsOriginatingElement(): KSFileAsOriginatingElement? {
-    return (this as? KSDeclaration)?.containingFile?.let {
+internal fun KSAnnotated.wrapAsOriginatingElement(): OriginatingElementWrapper? {
+    val ksDeclaration = this as? KSDeclaration ?: return null
+
+    return ksDeclaration.containingFile?.let {
         KSFileAsOriginatingElement(it)
+    } ?: (ksDeclaration as? KSClassDeclaration)?.let {
+        KSClassDeclarationAsOriginatingElement(it)
     }
 }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
@@ -16,12 +16,19 @@
 
 package androidx.room.compiler.processing
 
+import androidx.room.compiler.processing.ksp.KSClassDeclarationAsOriginatingElement
 import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
+import androidx.room.compiler.processing.ksp.KspFiler
 import androidx.room.compiler.processing.ksp.KspTypeElement
 import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.runProcessorTest
 import com.google.common.truth.Truth.assertThat
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -67,6 +74,34 @@ class OriginatingElementsTest {
                 assertThat(originatingElement).isInstanceOf(TypeElement::class.java)
                 assertThat((originatingElement as TypeElement).qualifiedName.toString())
                     .isEqualTo("foo.bar.Baz")
+            }
+        }
+    }
+
+    @Test
+    fun classPathTypeIsConvertedToOriginatingElement() {
+        runProcessorTest {
+            val element = it.processingEnv
+                .requireTypeElement("com.google.devtools.ksp.processing.SymbolProcessor")
+
+            val originatingElement = element.originatingElementForPoet()
+            assertThat(originatingElement).isNotNull()
+
+            if (it.isKsp) {
+                assertThat(originatingElement)
+                    .isInstanceOf(KSClassDeclarationAsOriginatingElement::class.java)
+
+                val ksClassDeclaration =
+                    (originatingElement as KSClassDeclarationAsOriginatingElement)
+                        .ksClassDeclaration
+                assertThat(ksClassDeclaration)
+                    .isEqualTo(
+                        (element as KspTypeElement).declaration
+                    )
+            } else {
+                assertThat(originatingElement).isInstanceOf(TypeElement::class.java)
+                assertThat((originatingElement as TypeElement).qualifiedName.toString())
+                    .isEqualTo("com.google.devtools.ksp.processing.SymbolProcessor")
             }
         }
     }

--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/OriginatingElementsTest.kt
@@ -18,17 +18,11 @@ package androidx.room.compiler.processing
 
 import androidx.room.compiler.processing.ksp.KSClassDeclarationAsOriginatingElement
 import androidx.room.compiler.processing.ksp.KSFileAsOriginatingElement
-import androidx.room.compiler.processing.ksp.KspFiler
 import androidx.room.compiler.processing.ksp.KspTypeElement
 import androidx.room.compiler.processing.ksp.synthetic.KspSyntheticPropertyMethodElement
 import androidx.room.compiler.processing.util.Source
 import androidx.room.compiler.processing.util.runProcessorTest
 import com.google.common.truth.Truth.assertThat
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.Dependencies
-import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFile
-import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
## Proposed Changes
Update XProcessing to use new KSP API `CodeGenerator.associateWithClasses` when writing files with originating elements so that classpath dependencies are accurately tracked.

## Testing

Test: Added tests to OriginatingElementsTest and KspFilerTest

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/206863182
