### PR TITLE
Disable configuration-cache in gradle actions

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           arguments: tasks -PandroidXUnusedParameter=activity # add project name to cache key
           build-root-directory: activity
-          configuration-cache-enabled: true
+          configuration-cache-enabled: false
           dependencies-cache-enabled: true
           dependencies-cache-key: |
             **/libs.versions.toml
@@ -183,7 +183,7 @@ jobs:
         with:
           arguments: tasks -PandroidXUnusedParameter=${{ env.project-root }} # add project name to cache key
           build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: true
+          configuration-cache-enabled: false
           dependencies-cache-enabled: true
           dependencies-cache-key: |
             **/libs.versions.toml


### PR DESCRIPTION
This is causing a recurring problem where a bad run is getting cached
and spreading around to all the workers failing all the builds. There
isn't a good way to blowout the cache without renaming the project, but
since this is unused we can just temporarily turn it off.

Test: GH workflows passes
