### PR TITLE
Add invalid Dao method lint check

### DIFF
--- a/room/room-lint/build.gradle
+++ b/room/room-lint/build.gradle
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.build.LibraryGroups
+import androidx.build.LibraryType
+
+plugins {
+    id("AndroidXPlugin")
+    id("kotlin")
+}
+
+dependencies {
+    compileOnly(libs.androidLintMinApi)
+    compileOnly(libs.kotlinStdlib)
+
+    testImplementation(libs.kotlinStdlib)
+    testImplementation(libs.androidLint)
+    testImplementation(libs.androidLintTests)
+    testImplementation(libs.junit)
+}
+
+androidx {
+    name = "Room Lint Checks"
+    type = LibraryType.LINT
+    mavenGroup = LibraryGroups.ROOM
+    inceptionYear = "2021"
+    description = "Room Lint Checks"
+}

--- a/room/room-lint/lint-baseline.xml
+++ b/room/room-lint/lint-baseline.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 7.2.0-dev" type="baseline" client="gradle" dependencies="false" name="AGP (7.2.0-dev)" variant="all" version="7.2.0-dev">
+
+</issues>

--- a/room/room-lint/src/main/java/androidx/room/lint/InvalidDaoMethodDetector.kt
+++ b/room/room-lint/src/main/java/androidx/room/lint/InvalidDaoMethodDetector.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package androidx.room.lint
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.isKotlin
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+
+class InvalidDaoMethodDetector : Detector(), Detector.UastScanner {
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
+        return listOf(UClass::class.java)
+    }
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return AnnotationChecker(context)
+    }
+
+    private inner class AnnotationChecker(val context: JavaContext) : UElementHandler() {
+
+        override fun visitClass(node: UClass) {
+            if (!isKotlin(node.sourcePsi)) {
+                return
+            }
+            if (!node.hasDaoAnnotation()) {
+                return
+            }
+            val daoSuspendMethods = node.methods.filter { method ->
+                method.isDaoMethod() && context.evaluator.isSuspend(method)
+            }
+            daoSuspendMethods.forEach { method ->
+                if (method.hasRxJavaContinuationType()) {
+                    context.report(ISSUE, context.getNameLocation(method), DESCRIPTION)
+                }
+            }
+        }
+
+        private fun UClass.hasDaoAnnotation(): Boolean {
+            return uAnnotations.any { it.qualifiedName == DAO_ANNOTATION }
+        }
+
+        private fun UMethod.isDaoMethod(): Boolean {
+            return uAnnotations.any { it.qualifiedName in DAO_METHOD_ANNOTATIONS }
+        }
+
+        private fun UMethod.hasRxJavaContinuationType(): Boolean {
+            return uastParameters.any {
+                it.typeReference?.type?.canonicalText in CONTINUATION_NAMES
+            }
+        }
+    }
+
+    companion object {
+        private val DESCRIPTION = """
+            Invalid Dao method.
+        """.trimIndent()
+
+        @JvmField
+        val ISSUE = Issue.create(
+            id = "InvalidDaoMethod",
+            briefDescription = DESCRIPTION,
+            explanation = """
+                Dao methods that have a suspend modifier shouldn't return an RxJava type.
+                Most probably this is an error. Consider changing the return type or \
+                removing the suspend modifier.
+            """,
+            androidSpecific = true,
+            category = Category.CORRECTNESS,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                InvalidDaoMethodDetector::class.java,
+                Scope.JAVA_FILE_SCOPE
+            )
+        )
+
+        private const val DAO_ANNOTATION = "androidx.room.Dao"
+
+        private val DAO_METHOD_ANNOTATIONS = setOf(
+            "androidx.room.Update",
+            "androidx.room.Delete",
+            "androidx.room.Insert",
+            "androidx.room.Query",
+            "androidx.room.RawQuery",
+            "androidx.room.Transaction"
+        )
+
+        private val CONTINUATION_NAMES = setOf(
+            // RxJava2 types
+            "kotlin.coroutines.Continuation<? super io.reactivex.Flowable>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.Observable>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.Maybe>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.Single>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.Completable>",
+            // RxJava3 types
+            "kotlin.coroutines.Continuation<? super io.reactivex.rxjava3.core.Flowable>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.rxjava3.core.Observable>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.rxjava3.core.Maybe>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.rxjava3.core.Single>",
+            "kotlin.coroutines.Continuation<? super io.reactivex.rxjava3.core.Completable>",
+        )
+    }
+}

--- a/room/room-lint/src/main/java/androidx/room/lint/RoomIssueRegistry.kt
+++ b/room/room-lint/src/main/java/androidx/room/lint/RoomIssueRegistry.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package androidx.room.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
+import com.android.tools.lint.detector.api.Issue
+
+class RoomIssueRegistry : IssueRegistry() {
+    override val minApi = CURRENT_API
+    override val api = 11
+    override val issues: List<Issue>
+        get() = listOf(
+            InvalidDaoMethodDetector.ISSUE
+        )
+}

--- a/room/room-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
+++ b/room/room-lint/src/main/resources/META-INF/services/com.android.tools.lint.client.api.IssueRegistry
@@ -1,0 +1,1 @@
+androidx.room.lint.RoomIssueRegistry

--- a/room/room-lint/src/test/java/androidx/room/lint/ApiLintVersionsTest.kt
+++ b/room/room-lint/src/test/java/androidx/room/lint/ApiLintVersionsTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package androidx.room.lint
+
+import com.android.tools.lint.client.api.LintClient
+import com.android.tools.lint.detector.api.CURRENT_API
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ApiLintVersionsTest {
+
+    @Test
+    fun versionsCheck() {
+        LintClient.clientName = LintClient.CLIENT_UNIT_TESTS
+
+        val registry = RoomIssueRegistry()
+        // We hardcode version registry.api to the version that is used to run tests.
+        assertEquals("registry.api matches version used to run tests", CURRENT_API, registry.api)
+        // Intentionally fails in IDE, because we use different API version in Studio and CLI.
+        assertEquals("registry.minApi is set to minimum level of 8", 8, registry.minApi)
+    }
+}

--- a/room/room-lint/src/test/java/androidx/room/lint/InvalidDaoMethodTest.kt
+++ b/room/room-lint/src/test/java/androidx/room/lint/InvalidDaoMethodTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("UnstableApiUsage")
+
+package androidx.room.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestLintResult
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+class InvalidDaoMethodTest {
+
+    private fun check(testFile: TestFile): TestLintResult {
+        return lint().files(
+            java(Stubs.RX_JAVA2_COMPLETABLE),
+            java(Stubs.RX_JAVA3_COMPLETABLE),
+            java(Stubs.DAO_ANNOTATION),
+            java(Stubs.INSERT_ANNOTATION),
+            testFile
+        ).issues(InvalidDaoMethodDetector.ISSUE).run()
+    }
+
+    @Test
+    fun testValidSuspendDaoMethod() {
+        val input = kotlin(
+            """
+                package androidx.sample
+                
+                import androidx.room.Dao
+                import androidx.room.Insert
+                
+                @Dao
+                interface TestDao {
+                    
+                    @Insert
+                    suspend fun foo()
+                }
+            """.trimIndent()
+        )
+        check(input).expect("No warnings.")
+    }
+
+    @Test
+    fun testValidRxJava2TypeReturningDaoMethod() {
+        val input = kotlin(
+            """
+                package androidx.sample
+                
+                import io.reactivex.Completable
+                import androidx.room.Dao
+                import androidx.room.Insert
+                
+                @Dao
+                interface TestDao {
+                    
+                    @Insert
+                    fun foo(): Completable
+                }
+            """.trimIndent()
+        )
+        check(input).expect("No warnings.")
+    }
+
+    @Test
+    fun testValidRxJava3TypeReturningDaoMethod() {
+        val input = kotlin(
+            """
+                package androidx.sample
+                
+                import io.reactivex.rxjava3.core.Completable
+                import androidx.room.Dao
+                import androidx.room.Insert
+                
+                @Dao
+                interface TestDao {
+                    
+                    @Insert
+                    fun foo(): Completable
+                }
+            """.trimIndent()
+        )
+        check(input).expect("No warnings.")
+    }
+
+    @Test
+    fun testInvalidSuspendRxJava2TypeReturningDaoMethod() {
+        val input = kotlin(
+            """
+                package androidx.sample
+                
+                import io.reactivex.Completable
+                import androidx.room.Dao
+                import androidx.room.Insert
+                
+                @Dao
+                interface TestDao {
+                    
+                    @Insert
+                    suspend fun foo(): Completable
+                }
+            """.trimIndent()
+        )
+
+        val expected = """
+            src/androidx/sample/TestDao.kt:11: Warning: Invalid Dao method. [InvalidDaoMethod]
+                suspend fun foo(): Completable
+                            ~~~
+            0 errors, 1 warnings
+        """.trimIndent()
+        check(input).expect(expected)
+    }
+
+    @Test
+    fun testInvalidSuspendRxJava3TypeReturningDaoMethod() {
+        val input = kotlin(
+            """
+                package androidx.sample
+                
+                import io.reactivex.rxjava3.core.Completable
+                import androidx.room.Dao
+                import androidx.room.Insert
+                
+                @Dao
+                interface TestDao {
+                    
+                    @Insert
+                    suspend fun foo(): Completable
+                }
+            """.trimIndent()
+        )
+
+        val expected = """
+            src/androidx/sample/TestDao.kt:11: Warning: Invalid Dao method. [InvalidDaoMethod]
+                suspend fun foo(): Completable
+                            ~~~
+            0 errors, 1 warnings
+        """.trimIndent()
+        check(input).expect(expected)
+    }
+}

--- a/room/room-lint/src/test/java/androidx/room/lint/Stubs.kt
+++ b/room/room-lint/src/test/java/androidx/room/lint/Stubs.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.lint
+
+object Stubs {
+    val RX_JAVA2_COMPLETABLE =
+        """
+            package io.reactivex;
+            
+            public abstract class Completable {
+            }
+        """.trimIndent()
+
+    val RX_JAVA3_COMPLETABLE =
+        """
+            package io.reactivex.rxjava3.core;
+            
+            public abstract class Completable {
+            }
+        """.trimIndent()
+
+    val DAO_ANNOTATION =
+        """
+            package androidx.room;
+
+            public @interface Dao {
+            }
+        """.trimIndent()
+
+    val INSERT_ANNOTATION =
+        """
+            package androidx.room;
+
+            public @interface Insert {
+            }
+        """.trimIndent()
+}

--- a/room/room-runtime/build.gradle
+++ b/room/room-runtime/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation(libs.kotlinStdlib)
     testImplementation(libs.truth)
     testImplementation(libs.testRunner) // Needed for @FlakyTest and @Ignore
+    lintPublish(project(":room:room-lint"))
 
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.testExtJunit)

--- a/settings.gradle
+++ b/settings.gradle
@@ -630,6 +630,7 @@ includeProject(":room:room-runtime", "room/room-runtime", [BuildType.MAIN, Build
 includeProject(":room:room-rxjava2", "room/room-rxjava2", [BuildType.MAIN])
 includeProject(":room:room-rxjava3", "room/room-rxjava3", [BuildType.MAIN])
 includeProject(":room:room-testing", "room/room-testing", [BuildType.MAIN])
+includeProject(":room:room-lint", "room/room-lint", [BuildType.MAIN])
 includeProject(":savedstate:savedstate", "savedstate/savedstate", [BuildType.MAIN, BuildType.COMPOSE, BuildType.FLAN, BuildType.WEAR])
 includeProject(":savedstate:savedstate-ktx", "savedstate/savedstate-ktx", [BuildType.MAIN, BuildType.COMPOSE, BuildType.FLAN])
 includeProject(":security:security-app-authenticator", "security/security-app-authenticator", [BuildType.MAIN])


### PR DESCRIPTION
Proposed Changes
This change adds room-lint module containing a lint check which detects an invalid Dao method. In this case an invalid Dao method is a method which is suspending and returns one of RxJava2 or RxJava3 types at the same time.

Testing
Test: Added InvalidDaoMethodTest

Issues Fixed
Fixes: https://issuetracker.google.com/issues/151029087