### PR TITLE
Fix typo for `@Embedded` reference in `@PrimaryKey` docs

### DIFF
--- a/room/room-common/src/main/java/androidx/room/PrimaryKey.java
+++ b/room/room-common/src/main/java/androidx/room/PrimaryKey.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * primary key. If both an {@link Entity} and its super class defines a {@code PrimaryKey}, the
  * child's {@code PrimaryKey} definition will override the parent's {@code PrimaryKey}.
  * <p>
- * If {@code PrimaryKey} annotation is used on a {@link Embedded}d field, all columns inherited
+ * If {@code PrimaryKey} annotation is used on a {@link Embedded} field, all columns inherited
  * from that embedded field becomes the composite primary key (including its grand children
  * fields).
  */


### PR DESCRIPTION
## Proposed Changes

  - Remove additional `d` in PrimaryKey docs, `Embeddedd` -> `Embedded`
## Testing

Test: Only docs improvement, no test required
