### PR TITLE
Fix cache misses, warnings and deprecations caused by SdkResourceGenerator

### DIFF
--- a/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
@@ -137,6 +137,13 @@ abstract class SdkResourceGenerator : DefaultTask() {
             val extension = project.extensions.getByType<JavaPluginExtension>()
             val resources = extension.sourceSets.getByName("test").resources
             resources.srcDirs(setOf(resources.srcDirs, generatedDirectory))
+
+            // Ignore the sdk.prop file when generating the cache key.
+            project.normalization {
+                it.runtimeClasspath {
+                   it.ignore("sdk.prop")
+                }
+            }
         }
     }
 }

--- a/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
@@ -131,12 +131,10 @@ abstract class SdkResourceGenerator : DefaultTask() {
                         it.url.toString()
                     }
             }
-            project.tasks.named("compileTestJava").configure { it.dependsOn(provider) }
-            project.tasks.named("processTestResources").configure { it.dependsOn(provider) }
 
             val extension = project.extensions.getByType<JavaPluginExtension>()
-            val resources = extension.sourceSets.getByName("test").resources
-            resources.srcDirs(setOf(resources.srcDirs, generatedDirectory))
+            val testSources = extension.sourceSets.getByName("test")
+            testSources.getOutput().dir(mapOf("builtBy" to provider), generatedDirectory)
 
             // Ignore the sdk.prop file when generating the cache key.
             project.normalization {


### PR DESCRIPTION
## Proposed Changes

#### Ignore generated `sdk.prop` file when composing a cache key with `runtimeClasspath` normalization. 

This generated file contains absolute path references, resulting in cache misses for tasks that have this resource as an input. Since differences in this file are not significant for caching purposes the file is ignored for runtimeClasspath normalization.

#### Improve the way generated resources are registered
By registering the generated resources as a separate SourceSetOutput and including a `builtBy` reference, Gradle is able to automatically maintain the required task dependencies for any consumers of these resources. This mechanism is recommended at https://docs.gradle.org/current/dsl/org.gradle.api.tasks.SourceSetOutput.html.

This fix removes a Gradle warning about "execution optimizations are disabled" due to undeclared task dependencies with the `SdkResourceGenerator` task, as well as the associated deprecation warning.

## Testing

Test: This is a build refactor only - no new tests added

