### PR TITLE
Revert workflow changes that induced recent daemon flakes

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,7 +20,6 @@ jobs:
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
             -Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m                  \
-            -Dorg.gradle.jvmargs=-Xmx8g                                     \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"
@@ -213,7 +212,7 @@ jobs:
           set -x
           AFFECTED_MODULE_COUNT=`grep -c ".*" ${{ github.workspace }}/affected.txt || true`
           echo "::set-output name=count::$AFFECTED_MODULE_COUNT"
-      - name: "./gradlew buildOnServer zipTestConfigsWithApks test"
+      - name: "./gradlew buildOnServer zipTestConfigsWithApks"
         uses: gradle/gradle-command-action@v1
         if: ${{ steps.affected-module-count.outputs.count > 0 }}
         env:


### PR DESCRIPTION
Reverting the addition of test tasks and failed attempt to increase memory which seems to be consistently causing the gradle daemon to die unexpectedly on CI.

The github runners only have 7gb of RAM so there's no point setting heap space to 8g.

Test: GH workflows
