### PR TITLE
set github gradle daemon memory to 5g

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,7 +19,6 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=-Xmx5g -XX:MaxMetaspaceSize=512m           \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,7 +20,7 @@ jobs:
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
             -Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m                  \
-            -Dorg.gradle.jvmargs=-Xmx8g                                     \
+            -Dorg.gradle.jvmargs=-Xmx5g                                     \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,8 +19,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m                  \
-            -Dorg.gradle.jvmargs=-Xmx5g                                     \
+            -Dorg.gradle.jvmargs=-Xmx5g -XX:MaxMetaspaceSize=512m           \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"

--- a/buildSrc/private/src/main/kotlin/androidx/build/playground/VerifyPlaygroundGradleConfigurationTask.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/playground/VerifyPlaygroundGradleConfigurationTask.kt
@@ -101,7 +101,7 @@ abstract class VerifyPlaygroundGradleConfigurationTask : DefaultTask() {
         // properties in the future if necessary.
         playgroundProperties.forEach {
             val rootValue = rootProperties[it.key]
-            if (rootValue != it.value) {
+            if (rootValue != it.value && it.key != "org.gradle.jvmargs") {
                 throw GradleException(
                     """
                     ${it.key} is defined as ${it.value} in playground properties but

--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -24,7 +24,7 @@
 # This separation is necessary to ensure gradle can read certain properties
 # at configuration time.
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true
 android.useAndroidX=true
 # Disable features we do not use
 android.defaults.buildfeatures.aidl=false


### PR DESCRIPTION
docker images have 7G so asking for 8G is pointless (idk if virtual memory works here or not).

We used to be fine with 512mb so 5g seems plenty even after the addition of tests.

Test: N/A
Bug: N/A