### PR TITLE
Add lifecycle to activity

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -29,8 +29,10 @@ playground {
     selectProjectsFromAndroidX({ name ->
         if (name.startsWith(":activity")) return true
         if (name == ":annotation:annotation-sampled") return true
+        if (name == ":annotation:annotation") return true
         if (name == ":internal-testutils-runtime") return true
         if (name.startsWith(":lifecycle")) return true
+        if (name == ":internal-testutils-truth") return true
         if (isNeededForComposePlayground(name)) return true
         return false
     })

--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -30,6 +30,7 @@ playground {
         if (name.startsWith(":activity")) return true
         if (name == ":annotation:annotation-sampled") return true
         if (name == ":internal-testutils-runtime") return true
+        if (name.startsWith(":lifecycle")) return true
         if (isNeededForComposePlayground(name)) return true
         return false
     })


### PR DESCRIPTION
Activity and lifecycle has close relationship so
it is best to keep lifecycle as a project for activity
playground setup.

Bug: n/a
Test: fixes activity build
