### PR TITLE
Extended integrity error message

### DIFF
--- a/room/room-runtime/src/main/java/androidx/room/RoomOpenHelper.java
+++ b/room/room-runtime/src/main/java/androidx/room/RoomOpenHelper.java
@@ -153,7 +153,8 @@ public class RoomOpenHelper extends SupportSQLiteOpenHelper.Callback {
             if (!mIdentityHash.equals(identityHash) && !mLegacyHash.equals(identityHash)) {
                 throw new IllegalStateException("Room cannot verify the data integrity. Looks like"
                         + " you've changed schema but forgot to update the version number. You can"
-                        + " simply fix this by increasing the version number.");
+                        + " simply fix this by increasing the version number. Expected identity"
+                        + " hash: " + identityHash + ", found: " + mIdentityHash);
             }
         } else {
             // No room_master_table, this might an a pre-populated DB, we must validate to see if


### PR DESCRIPTION
Extended integrity error message with db identity hashes.

## Proposed Changes

  - Currently it is hard to tell by the data integrity exception message what database versions are being compared. With mentioned hashes it would become easy for code consumers to understand what have changed and what db versions are conflicting.

## Testing

Test: ./gradlew test connectedCheck
