### PR TITLE
[DO NOT MERGE] Removed unused environment call

### DIFF
--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -29,7 +29,6 @@ def chooseOutDir(subdir = "") {
         }
         outDir = new File("${checkoutRoot}/out${subdir}")
         project.ext.buildSrcOut = new File("${checkoutRoot}/out/buildSrc")
-        environment "OUT_DIR", "${checkoutRoot}/out${subdir}"
     } else {
         outDir = new File(outDir)
         project.ext.buildSrcOut = new File("${outDir}/buildSrc")


### PR DESCRIPTION
This method is called outside the scope of a task so it doesn't exist.

It failed playground but didn't fail the main build because main
build always has the OUR_DIR set by
https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:gradlew\;l\=14

I don't think this call was every necessary or succeeded.

Bug: n/a
Test: CI
Change-Id: Idfc1bd8257087d8b850e820c3a04d6418e236cd0