### PR TITLE
Fix lint violations in `ChangeInfoGitClientTest.kt`

### DIFF
--- a/buildSrc-tests/src/test/kotlin/androidx/build/dependencyTracker/ChangeInfoGitClientTest.kt
+++ b/buildSrc-tests/src/test/kotlin/androidx/build/dependencyTracker/ChangeInfoGitClientTest.kt
@@ -235,7 +235,6 @@ class ChangeInfoGitClientTest {
         return ChangeInfoGitClient(config, "").findChangedFilesSince("", "", false)
     }
 
-
     @Test
     fun getGitLog_hasVersion() {
         checkVersion("""

--- a/buildSrc-tests/src/test/kotlin/androidx/build/dependencyTracker/ChangeInfoGitClientTest.kt
+++ b/buildSrc-tests/src/test/kotlin/androidx/build/dependencyTracker/ChangeInfoGitClientTest.kt
@@ -16,15 +16,11 @@
 
 package androidx.build.dependencyTracker
 
-import androidx.build.gitclient.Commit
 import androidx.build.gitclient.ChangeInfoGitClient
-import androidx.build.gitclient.GitClient
 import androidx.build.gitclient.GitCommitRange
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertNull
 import org.gradle.api.GradleException
 import org.json.simple.parser.ParseException
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4


### PR DESCRIPTION
## Proposed Changes

Fix lint violations that were introduced when this test was added in d0c7ebd1880532da86aecac562322fb94c76320f.

## Testing

Test: Without this fix, `:ktlint` fails for this file.