### PR TITLE
Bump snapshot build id to a newer build

### DIFF
--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,7 +25,7 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=8097695
+androidx.playground.snapshotBuildId=8125694
 androidx.playground.metalavaBuildId=8073933
 androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
## Proposed Changes

Bump snapshot build id to a newer build. Fixes breakage from r.android.com/1950756

## Testing

Test: None
