### PR TITLE
Update `presubmit` workflow to `gradle-build-action@v2`

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -45,6 +45,8 @@ jobs:
           fi
           echo "::set-output name=repository::$REPOSITORY"
       - name: Publish build scans link
+        # No scans are produced for PRs from forked repos, so omit this notice for forked PRs.
+        if: ${{ !(github.event.pull_request && github.event.pull_request.head.repo.fork) }}
         run: echo "::notice title=All build scans for workflow::https://ge.androidx.dev/scans?search.names=CI%20run&search.values=$GITHUB_RUN_ID"
 
   lint:

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -108,7 +108,10 @@ jobs:
       - name: "Setup Gradle"
         uses: gradle/gradle-build-action@v2
         with:
-          # Don't share cache entries with other jobs          
+          # Only save Gradle User Home state for builds on the 'androidx-main' branch.
+          # Builds on other branches will only read existing entries from the cache.
+          cache-read-only: ${{ github.ref != 'refs/heads/androidx-main' }}
+          # Don't share cache entries with other jobs
           gradle-home-cache-strict-match: true
           # Limit the size of the cache entry
           gradle-home-cache-excludes: | 
@@ -175,7 +178,10 @@ jobs:
       - name: "Setup Gradle"
         uses: gradle/gradle-build-action@v2
         with:
-          # Don't share cache entries with other jobs          
+          # Only save Gradle User Home state for builds on the 'androidx-main' branch.
+          # Builds on other branches will only read existing entries from the cache.
+          cache-read-only: ${{ github.ref != 'refs/heads/androidx-main' }}
+          # Don't share cache entries with other jobs
           gradle-home-cache-strict-match: true
           # Limit the size of the cache entry
           gradle-home-cache-excludes: | 

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
 
+env:
+  GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -19,6 +22,7 @@ jobs:
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
+            --no-configuration-cache                                        \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
       - name: "Compute actions/checkout arguments"
@@ -37,6 +41,8 @@ jobs:
             REPOSITORY=${{ github.repository }}
           fi
           echo "::set-output name=repository::$REPOSITORY"
+      - name: Publish build scans link
+        run: echo "::notice title=All build scans for workflow::https://ge.androidx.dev/scans?search.names=CI%20run&search.values=$GITHUB_RUN_ID"
 
   lint:
     runs-on: ubuntu-latest
@@ -44,6 +50,9 @@ jobs:
     outputs:
       status: ${{ steps.output-status.outputs.status }}
       affectedFileArgs: ${{ steps.affected-file-args.outputs.files }}
+    env:
+      GRADLE_BUILD_CACHE_PASSWORD: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
+      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
     steps:
       - name: Pull request format
         uses: 'androidx/check-pr-format-action@main'
@@ -95,35 +104,23 @@ jobs:
           set -x
           AFFECTED_FILES=`echo "${{ steps.changed-files.outputs.files_including_removals }}" | sed 's|\([^ ]\+\)|--changedFilePath=\1|g'`
           echo "::set-output name=files::$AFFECTED_FILES"
-      - name: "warm up gradle"
-        id: warm-up-gradle-cache
-        uses: gradle/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-          JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
+
+      - name: "Setup Gradle"
+        uses: gradle/gradle-build-action@v2
         with:
-          arguments: tasks -PandroidXUnusedParameter=activity # add project name to cache key
-          build-root-directory: activity
-          configuration-cache-enabled: false
-          dependencies-cache-enabled: true
-          dependencies-cache-key: |
-            **/libs.versions.toml
-          dependencies-cache-exact: false
-          gradle-executable: activity/gradlew
-          wrapper-directory: activity/gradle/wrapper
-          distributions-cache-enabled: true
+          # Don't share cache entries with other jobs          
+          gradle-home-cache-strict-match: true
+          # Limit the size of the cache entry
+          gradle-home-cache-excludes: | 
+            caches/jars-9
+            caches/transforms-3
+
       - name: "ktlint"
-        uses: gradle/gradle-command-action@v1
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-        with:
-          arguments: -q :ktlintCheckFile ${{ steps.ktlint-file-args.outputs.ktlint-file-args }} ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: activity
-          configuration-cache-enabled: false
-          dependencies-cache-enabled: false
-          gradle-executable: activity/gradlew
-          wrapper-directory: activity/gradle/wrapper
-          distributions-cache-enabled: false
+        working-directory: activity
+        run: ./gradlew -q :ktlintCheckFile ${{ steps.ktlint-file-args.outputs.ktlint-file-args }} ${{ needs.setup.outputs.gradlew_flags }}
+
   build-modules:
     strategy:
       fail-fast: false
@@ -171,42 +168,26 @@ jobs:
         run: |
           set -x
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
+          
           # use latest NDK because the default NDK on github is older.
           # TODO b/216535050: Implement task to install the exact AndroidX ndk version.
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
-      # gradle action loads the dependencies cache only on the first run based on arguments.
-      # to control it, we explicitly invoke it once which makes it load the dependencies cache with the parameters
-      # we control
-      - name: "warm up gradle"
-        id: warm-up-gradle-cache
-        uses: gradle/gradle-command-action@v1
+      - name: "Setup Gradle"
+        uses: gradle/gradle-build-action@v2
+        with:
+          # Don't share cache entries with other jobs          
+          gradle-home-cache-strict-match: true
+          # Limit the size of the cache entry
+          gradle-home-cache-excludes: | 
+            caches/jars-9
+            caches/transforms-3
+
+      - name: "gradle buildOnServer zipTestConfigsWithApks test"
         env:
           JAVA_HOME: ${{ steps.setup-java.outputs.path }}
           JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
-        with:
-          arguments: projects -PandroidXUnusedParameter=${{ env.project-root }} # add project name to cache key
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: false
-          dependencies-cache-enabled: true
-          dependencies-cache-key: |
-            **/libs.versions.toml
-          dependencies-cache-exact: false
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
-          distributions-cache-enabled: true
-      - name: "./gradlew buildOnServer zipTestConfigsWithApks test"
-        uses: gradle/gradle-command-action@v1
-        env:
-          JAVA_HOME: ${{ steps.setup-java.outputs.path }}
-          JAVA_TOOLS_JAR: ${{ steps.setup-tools-jar.outputs.toolsJar }}
-        with:
-          arguments: buildOnServer zipTestConfigsWithApks test ${{ needs.setup.outputs.gradlew_flags }}
-          build-root-directory: ${{ env.project-root }}
-          configuration-cache-enabled: false
-          dependencies-cache-enabled: false
-          distributions-cache-enabled: false
-          gradle-executable: ${{ env.project-root }}/gradlew
-          wrapper-directory: ${{ env.project-root }}/gradle/wrapper
+        working-directory: ${{ env.project-root }}
+        run: ./gradlew buildOnServer zipTestConfigsWithApks test ${{ needs.setup.outputs.gradlew_flags }}
 
       - name: "Upload build artifacts"
         continue-on-error: true

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
 
 env:
+  # Allow precise monitoring of the save/restore of Gradle User Home by `gradle-build-action`
+  # See https://github.com/marketplace/actions/gradle-build-action?version=v2.1.1#cache-debugging-and-analysis
   GRADLE_BUILD_ACTION_CACHE_DEBUG_ENABLED: true
 
 jobs:
@@ -16,6 +18,7 @@ jobs:
     steps:
       - name: "Setup global constants"
         id: global-constants
+        # The configuration-cache cannot be used due to state excluded when caching Gradle User Home
         run: |
           set -x
           GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=60000 \
@@ -111,9 +114,12 @@ jobs:
           # Only save Gradle User Home state for builds on the 'androidx-main' branch.
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/androidx-main' }}
-          # Don't share cache entries with other jobs
+
+          # Don't reuse cache entries from any other Job.
           gradle-home-cache-strict-match: true
-          # Limit the size of the cache entry
+
+          # Limit the size of the cache entry.
+          # These directories contain instrumented/transformed dependency jars which can be reconstructed relatively quickly.
           gradle-home-cache-excludes: | 
             caches/jars-9
             caches/transforms-3
@@ -175,15 +181,19 @@ jobs:
           # use latest NDK because the default NDK on github is older.
           # TODO b/216535050: Implement task to install the exact AndroidX ndk version.
           echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+
       - name: "Setup Gradle"
         uses: gradle/gradle-build-action@v2
         with:
           # Only save Gradle User Home state for builds on the 'androidx-main' branch.
           # Builds on other branches will only read existing entries from the cache.
           cache-read-only: ${{ github.ref != 'refs/heads/androidx-main' }}
-          # Don't share cache entries with other jobs
+
+          # Don't reuse cache entries from any other Job.
           gradle-home-cache-strict-match: true
-          # Limit the size of the cache entry
+
+          # Limit the size of the cache entry.
+          # These directories contain instrumented/transformed dependency jars which can be reconstructed relatively quickly.
           gradle-home-cache-excludes: | 
             caches/jars-9
             caches/transforms-3


### PR DESCRIPTION
## Proposed Changes

  - Replace use of `gradle-command-action@v1` with `gradle-build-action@v2`.
  - Only write to the cache from the `androidx-main` branch. See https://github.com/gradle/gradle-build-action#only-write-to-the-cache-from-the-default-branch.
  - Enable build-cache and build-scans for `lint` workflow job
  - Disable Gradle configuration-cache due to errors reusing persisted state.
  - Remove use of `findAffectedModules` for build avoidance in `build-modules` job. This was causing failures to be hidden in subsequent workflow runs.
  - Add a single link to all build scans for a workflow run.

## Testing

Test: via GitHub Actions run
