### PR TITLE
Remove unused local build-cache entries on CI

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -19,12 +19,14 @@ jobs:
       - name: "Setup global constants"
         id: global-constants
         # The configuration-cache cannot be used due to state excluded when caching Gradle User Home
+        # Agressively remove old build-cache entries to avoid uncontrolled growth of the Gradle User Home
         run: |
           set -x
           GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=60000 \
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
+            -Dgradle.cache.local.removeUnusedEntriesAfterDays=P1D           \
             --no-configuration-cache                                        \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"


### PR DESCRIPTION
## Proposed Changes

By default, unused local build-cache entries are retained for 7 days.
In the context of a GitHub Actions workflow:
- these old cache entries take up additional space in the GitHub Actions cache
- these old cache entries are very unlikely to be used again at a later date
As such, there is no benefit to keeping them around in the restored Gradle User Home.

This change reduces the time these entries are retained to the minimum, a single day.
Cache cleanup will be performed every 24hrs, and at that time all build-cache entries
that have not been used in the previous day will be deleted.

## Testing

Test: Will be tested by monitoring GitHub Actions.
