### PR TITLE
Use the correct argument name for FTL action

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,7 +21,7 @@ jobs:
       - id: run_tests
         uses: androidX/androidx-ci-action@dist-latest
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          target-run-id: ${{ github.event.workflow_run.id }}
           gcp-token: ${{ secrets.GCP_SA_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           output-folder: ${{ steps.dirs.outputs.output-dir }}


### PR DESCRIPTION
Unclear why this started breaking now, maybe `github.event.workflow_run.id` was returning empty before so we were able to default the correct value?

Either way, it seems the intended arg name is target-run-id from: https://github.com/androidx/androidx-ci-action/blob/main/action.yml

Test: GH workflow
Change-Id: I8718e1efa1647133f9856712ef5735e02ac53e90