### PR TITLE
Use programmatic configuration for build-cache cleanup

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -17,14 +17,12 @@ jobs:
       - name: "Setup global constants"
         id: global-constants
         # The configuration-cache cannot be used due to state excluded when caching Gradle User Home
-        # Agressively remove old build-cache entries to avoid uncontrolled growth of the Gradle User Home
         run: |
           set -x
           GRADLEW_FLAGS="-Dorg.gradle.internal.http.connectionTimeout=60000 \
             -Dorg.gradle.internal.http.socketTimeout=60000                  \
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
-            -Dgradle.cache.local.removeUnusedEntriesAfterDays=P1D           \
             --no-configuration-cache                                        \
             --stacktrace"
           echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"

--- a/playground-common/playground-plugin/settings.gradle
+++ b/playground-common/playground-plugin/settings.gradle
@@ -15,14 +15,21 @@
  */
 rootProject.name = "playground-plugin"
 
-// Build cache configuration is duplicated here, so that when building the `playground-plugin` 
-// included build the remote build cache will be used.
+// Build cache configuration is duplicated here from the GradleEnterpriseConventionsPlugin, 
+// so that when building the `playground-plugin` included build the same build cache settings will be used.
 // Without this, Gradle Enterprise erroneously reports a problem with 'buildSrc' build cache configuration.
+def isCI = System.getenv("CI") == "true"
 buildCache {
+    local {
+        // Aggressively clean up stale build cache entries on CI
+        if (isCI) {
+            removeUnusedEntriesAfterDays = 1
+        }
+    }
     remote(HttpBuildCache) {
         url = "https://ge.androidx.dev/cache/"
         var buildCachePassword = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")
-        if (buildCachePassword != null && !buildCachePassword.empty) {
+        if (isCI && buildCachePassword != null && !buildCachePassword.empty) {
             push = true
             credentials {
                 username = "ci"

--- a/playground-common/playground-plugin/settings.gradle
+++ b/playground-common/playground-plugin/settings.gradle
@@ -15,7 +15,7 @@
  */
 rootProject.name = "playground-plugin"
 
-// Build cache configuration is duplicated here from the GradleEnterpriseConventionsPlugin, 
+// Build cache configuration is duplicated here from the GradleEnterpriseConventionsPlugin,
 // so that when building the `playground-plugin` included build the same build cache settings will be used.
 // Without this, Gradle Enterprise erroneously reports a problem with 'buildSrc' build cache configuration.
 def isCI = System.getenv("CI") == "true"

--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/GradleEnterpriseConventionsPlugin.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/GradleEnterpriseConventionsPlugin.kt
@@ -47,6 +47,13 @@ class GradleEnterpriseConventionsPlugin : Plugin<Settings> {
             }
         }
 
+        settings.buildCache.local { local ->
+            // Aggressively clean up stale build cache entries on CI
+            if (isCI) {
+                local.removeUnusedEntriesAfterDays = 1
+            }
+        }
+
         settings.buildCache.remote(HttpBuildCache::class.java) { remote ->
             remote.url = URI("https://ge.androidx.dev/cache/")
             val buildCachePassword = System.getenv("GRADLE_BUILD_CACHE_PASSWORD")


### PR DESCRIPTION
## Proposed Changes

A previous attempt to do this via a CLI argument failed, since the argument did
not apply to the cache settings for the `playground-plugin` included build.
Since the `playground-plugin` settings are loaded first, the CLI settings were
being ignored.

This change configures the cleanup threshold directly in Gradle settings, and does
so both for the Playground included build and the main build. This results in
any build-cache entries that have not been used in the previous day to be removed.

## Testing

Test: Tested by monitoring GitHub Actions pipeline
