### PR TITLE
Splash screen API fixs

### DIFF
--- a/core/core-splashscreen/src/main/res/drawable-v23/compat_splash_screen.xml
+++ b/core/core-splashscreen/src/main/res/drawable-v23/compat_splash_screen.xml
@@ -36,6 +36,7 @@
         android:width="@dimen/splashscreen_icon_mask_size_with_background"
         android:height="@dimen/splashscreen_icon_mask_size_with_background">
         <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
             <stroke
                 android:width="@dimen/splashscreen_icon_mask_stroke_with_background"
                 android:color="?windowSplashScreenBackground" />

--- a/core/core-splashscreen/src/main/res/drawable-v23/compat_splash_screen_no_icon_background.xml
+++ b/core/core-splashscreen/src/main/res/drawable-v23/compat_splash_screen_no_icon_background.xml
@@ -30,9 +30,10 @@
         android:width="@dimen/splashscreen_icon_mask_size_no_background"
         android:height="@dimen/splashscreen_icon_mask_size_no_background">
         <shape android:shape="oval">
+            <solid android:color="@android:color/transparent" />
             <stroke
                 android:width="@dimen/splashscreen_icon_mask_stroke_no_background"
-                android:color="?windowSplashScreenBackground"/>
+                android:color="?windowSplashScreenBackground" />
         </shape>
     </item>
 </layer-list>

--- a/core/core-splashscreen/src/main/res/layout/splash_screen_view.xml
+++ b/core/core-splashscreen/src/main/res/layout/splash_screen_view.xml
@@ -18,6 +18,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:animateLayoutChanges="false"
     android:fitsSystemWindows="false">
 
   <ImageView


### PR DESCRIPTION
## Proposed Changes

  - Fix the black circle issue on MIUI with dark mode (related: https://github.com/zoontek/react-native-bootsplash/issues/287)
  - Explicitly set `android:animateLayoutChanges` to `false` (fix an issue where we cannot just remove the `splashScreenView` without auto animated layout changes fading ([related tweet](https://twitter.com/zoontek/status/1460572748896423946?s=20&t=j6okazrLIhBxyfss0sExbA))

## Issues Fixed

- https://issuetracker.google.com/issues/201895453
- https://issuetracker.google.com/issues/206477820
