### PR TITLE
Use type nullability instead of declaration nullability in EmbeddedField

### DIFF
--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/TestDatabase.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/TestDatabase.kt
@@ -18,6 +18,8 @@ package androidx.room.integration.kotlintestapp
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import androidx.room.androidx.room.integration.kotlintestapp.dao.UsersDao
+import androidx.room.androidx.room.integration.kotlintestapp.vo.User
 import androidx.room.integration.kotlintestapp.dao.AbstractDao
 import androidx.room.integration.kotlintestapp.dao.BooksDao
 import androidx.room.integration.kotlintestapp.dao.DependencyDao
@@ -35,12 +37,14 @@ import androidx.room.integration.kotlintestapp.vo.Publisher
     entities = [
         Book::class, Author::class, Publisher::class, BookAuthor::class,
         NoArgClass::class, DataClassFromDependency::class, JavaEntity::class,
-        EntityWithJavaPojoList::class
+        EntityWithJavaPojoList::class, User::class
     ],
     version = 1,
     exportSchema = false
 )
 abstract class TestDatabase : RoomDatabase() {
+
+    abstract fun usersDao(): UsersDao
 
     abstract fun booksDao(): BooksDao
 

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/dao/UsersDao.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/dao/UsersDao.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.androidx.room.integration.kotlintestapp.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.Query
+import androidx.room.androidx.room.integration.kotlintestapp.vo.User
+
+@Dao
+interface UsersDao {
+    @Insert
+    fun insertUser(user: User)
+
+    @Query("SELECT * FROM user")
+    fun getUsers(): List<User>
+}

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/TestDatabaseTest.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/TestDatabaseTest.kt
@@ -18,6 +18,7 @@ package androidx.room.integration.kotlintestapp.test
 
 import androidx.arch.core.executor.testing.CountingTaskExecutorRule
 import androidx.room.Room
+import androidx.room.androidx.room.integration.kotlintestapp.dao.UsersDao
 import androidx.room.integration.kotlintestapp.TestDatabase
 import androidx.room.integration.kotlintestapp.dao.BooksDao
 import androidx.test.core.app.ApplicationProvider
@@ -32,6 +33,7 @@ abstract class TestDatabaseTest {
     val countingTaskExecutorRule = CountingTaskExecutorRule()
     protected lateinit var database: TestDatabase
     protected lateinit var booksDao: BooksDao
+    protected lateinit var usersDao: UsersDao
 
     @Before
     @Throws(Exception::class)
@@ -43,6 +45,7 @@ abstract class TestDatabaseTest {
             .build()
 
         booksDao = database.booksDao()
+        usersDao = database.usersDao()
     }
 
     @After

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/UsersDaoTest.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/UsersDaoTest.kt
@@ -20,8 +20,7 @@ import androidx.room.androidx.room.integration.kotlintestapp.vo.Email
 import androidx.room.androidx.room.integration.kotlintestapp.vo.User
 import androidx.room.integration.kotlintestapp.test.TestDatabaseTest
 import androidx.test.filters.MediumTest
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
+import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 @MediumTest
@@ -45,8 +44,6 @@ class UsersDaoTest : TestDatabaseTest() {
         expectedList.add(User(USER_3.userId, USER_3.email, null))
         expectedList.add(User(USER_4.userId, USER_4.email, null))
 
-        MatcherAssert.assertThat(
-            database.usersDao().getUsers(), CoreMatchers.`is`<List<User>>(expectedList)
-        )
+        assertThat(database.usersDao().getUsers()).containsExactlyElementsIn(expectedList)
     }
 }

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/UsersDaoTest.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/test/UsersDaoTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.androidx.room.integration.kotlintestapp.test
+
+import androidx.room.androidx.room.integration.kotlintestapp.vo.Email
+import androidx.room.androidx.room.integration.kotlintestapp.vo.User
+import androidx.room.integration.kotlintestapp.test.TestDatabaseTest
+import androidx.test.filters.MediumTest
+import org.hamcrest.CoreMatchers
+import org.hamcrest.MatcherAssert
+import org.junit.Test
+
+@MediumTest
+class UsersDaoTest : TestDatabaseTest() {
+
+    @Test
+    fun insertAndGetUsers() {
+        val USER_1 = User("u1", Email("e1", "email address 1"), Email("e2", "email address 2"))
+        val USER_2 = User("u2", Email(null, null), Email("e3", "email address 3"))
+        val USER_3 = User("u3", Email("e4", "email address 4"), Email(null, null))
+        val USER_4 = User("u4", Email(null, null), Email(null, null))
+
+        usersDao.insertUser(USER_1)
+        usersDao.insertUser(USER_2)
+        usersDao.insertUser(USER_3)
+        usersDao.insertUser(USER_4)
+
+        val expectedList = ArrayList<User>()
+        expectedList.add(USER_1)
+        expectedList.add(USER_2)
+        expectedList.add(User(USER_3.userId, USER_3.email, null))
+        expectedList.add(User(USER_4.userId, USER_4.email, null))
+
+        MatcherAssert.assertThat(
+            database.usersDao().getUsers(), CoreMatchers.`is`<List<User>>(expectedList)
+        )
+    }
+}

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/vo/Email.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/vo/Email.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.androidx.room.integration.kotlintestapp.vo
+
+data class Email(var id: String?, var address: String?)

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/vo/User.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/vo/User.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.androidx.room.integration.kotlintestapp.vo
+
+import androidx.room.Embedded
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class User(
+    @PrimaryKey var userId: String,
+    @Embedded(prefix = "email_") var email: Email,
+    @Embedded(prefix = "secondary_email_") var secondaryEmail: Email?
+)

--- a/room/room-compiler/src/main/kotlin/androidx/room/vo/EmbeddedField.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/vo/EmbeddedField.kt
@@ -16,7 +16,7 @@
 
 package androidx.room.vo
 
-import androidx.annotation.NonNull
+import androidx.room.compiler.processing.XNullability
 
 /**
  * Used when a field is embedded inside an Entity or Pojo.
@@ -29,7 +29,7 @@ data class EmbeddedField(
 ) {
     val getter by lazy { field.getter }
     val setter by lazy { field.setter }
-    val nonNull = field.element.hasAnnotation(NonNull::class)
+    val nonNull = field.type.nullability == XNullability.NONNULL
     lateinit var pojo: Pojo
     val mRootParent: EmbeddedField by lazy {
         parent?.mRootParent ?: this

--- a/room/room-compiler/src/test/kotlin/androidx/room/processor/PojoProcessorTest.kt
+++ b/room/room-compiler/src/test/kotlin/androidx/room/processor/PojoProcessorTest.kt
@@ -2154,6 +2154,28 @@ class PojoProcessorTest {
         }
     }
 
+    @Test
+    fun embedded_nullability() {
+        listOf(
+            TestData.SomeEmbeddedVals::class.java.canonicalName!!
+        ).forEach {
+            runProcessorTest { invocation ->
+                val result = PojoProcessor.createFor(
+                    context = invocation.context,
+                    element = invocation.processingEnv.requireTypeElement(it),
+                    bindingScope = FieldProcessor.BindingScope.READ_FROM_CURSOR,
+                    parent = null
+                ).process()
+
+                val embeddedFields = result.embeddedFields
+
+                assertThat(embeddedFields.size, `is`(2))
+                assertThat(embeddedFields[0].nonNull, `is`(true))
+                assertThat(embeddedFields[1].nonNull, `is`(false))
+            }
+        }
+    }
+
     private fun singleRun(
         code: String,
         vararg sources: Source,
@@ -2229,6 +2251,18 @@ class PojoProcessorTest {
             val lastName: String = "",
             var number: Int = 0,
             var bit: Boolean
+        )
+
+        data class AllNullableVals(
+            val name: String?,
+            val number: Int?,
+            val bit: Boolean?
+        )
+
+        data class SomeEmbeddedVals(
+            val id: String,
+            @Embedded(prefix = "non_nullable_") val nonNullableVal: AllNullableVals,
+            @Embedded(prefix = "nullable_") val nullableVal: AllNullableVals?
         )
     }
 }


### PR DESCRIPTION
## Proposed Changes

Previously `EmbeddedField` was set to `null` if all of its columns were `null` unless it was annotated with `androidx.annotation.NonNull`. The issue is that for non nullable properties in data classes, the Kotlin compiler automatically adds `org.jetbrains.annotations.NotNull` annotation which isn't recognized by Room. This change fixes the issue by relying on type nullability instead of declaration nullability. Type nullability in Room compiler is inferred from type declaration for Kotlin types and from annotations for Java types.

## Testing

Test: /gradlew test connectedCheck

## Issues Fixed

Fixes: b/110463870
