### PR TITLE
Setup CameraX playground

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,9 @@ contact_links:
   - name: Biometric
     url: https://issuetracker.google.com/issues/new?component=559537&template=1214425
     about: File a bug or feature request for Biometric
+  - name: Camera
+    url: https://issuetracker.google.com/issues/new?component=618491&template=1257717
+    about: File a bug or feature request for Camera
   - name: Collection
     url: https://b.corp.google.com/issues/new?component=460756&template=1422573
     about: File a bug or feature request for Collection

--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -33,6 +33,11 @@ runs:
       uses: actions/setup-java@v1
       with:
         java-version: "11"
+    # AndroidX requires a specific version of CMake.
+    - name: "Install CMake"
+      uses: jwlawson/actions-setup-cmake@v1.12
+      with:
+        cmake-version: '3.22.1'
     # Required for CMake when building workmanager.
     - name: "Install Ninja"
       shell: bash
@@ -47,7 +52,7 @@ runs:
         elif [ "$RUNNER_OS" == "Windows" ]; then
           choco install ninja --version=1.10.2
         else
-          echo "Failed to install ninja due to unsupport OS: $RUNNER_OS"
+          echo "Failed to install ninja due to unsupported OS: $RUNNER_OS"
           exit 1
         fi
         # See b/206099937. Hack needed to make ninja visible to cmake during NDK builds

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -115,7 +115,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         # if you would like to remove some projects temporarily, use .github/ci-control/ci-config.json instead.
-        project: ["activity", "biometric", "collection", "compose-runtime", "datastore", "fragment", "lifecycle", "navigation", "paging", "room", "work"]
+        project: ["activity", "biometric", "camera", "collection", "compose-runtime", "datastore", "fragment", "lifecycle", "navigation", "paging", "room", "work"]
         include:
           - project: "compose-runtime"
             project-root: "compose/runtime"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ The Android team has been exploring how we could make it easier to develop libra
 You can start contributing to any of the following library groups from GitHub:
   - [Activity](https://developer.android.com/guide/components/activities/intro-activities)
   - [Biometric](https://developer.android.com/training/sign-in/biometric-auth)
+  - [Camera](https://developer.android.com/jetpack/androidx/releases/camera)
   - [Collection](https://developer.android.com/jetpack/androidx/releases/collection)
   - [Compose Compiler](https://developer.android.com/jetpack/androidx/releases/compose-compiler)
   - [Compose Runtime](https://developer.android.com/jetpack/androidx/releases/compose-runtime)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For contributions via GitHub, see the [GitHub Contribution Guide](CONTRIBUTING.m
 Note: The contributions workflow via GitHub is currently experimental - only contributions to the following projects are being accepted at this time:
 * [Activity](activity)
 * [Biometric](biometric)
+* [Camera](camera)
 * [Collection](collection)
 * [Compose Compiler](compose/compiler)
 * [Compose Runtime](compose/runtime)

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -125,7 +125,13 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
                     // Last element is the artifact.
                     .dropLast(1)
                     .joinToString(".")
-                return "androidx.$group:${sections.last()}:$SNAPSHOT_MARKER"
+                    .let { projectGroup ->
+                        when (projectGroup) {
+                            "external" -> sections.last()
+                            else -> "androidx.$projectGroup"
+                        }
+                    }
+                return "$group:${sections.last()}:$SNAPSHOT_MARKER"
             }
 
             throw GradleException("projectOrArtifact cannot find/replace project $path")
@@ -190,7 +196,7 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
     ) {
         val snapshots = PlaygroundRepository(
             "https://androidx.dev/snapshots/builds/${props.snapshotBuildId}/artifacts/repository",
-            includeGroupRegex = """androidx\..*"""
+            includeGroupRegex = """(androidx\..*|libyuv)"""
         )
         val metalava = PlaygroundRepository(
             "https://androidx.dev/metalava/builds/${props.metalavaBuildId}/artifacts" +

--- a/camera/.idea/codeStyles/Project.xml
+++ b/camera/.idea/codeStyles/Project.xml
@@ -1,0 +1,1 @@
+../../../.idea/codeStyles/Project.xml

--- a/camera/.idea/codeStyles/codeStyleConfig.xml
+++ b/camera/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,1 @@
+../../../.idea/codeStyles/codeStyleConfig.xml

--- a/camera/.idea/copyright/AndroidCopyright.xml
+++ b/camera/.idea/copyright/AndroidCopyright.xml
@@ -1,0 +1,1 @@
+../../../.idea/copyright/AndroidCopyright.xml

--- a/camera/.idea/copyright/profiles_settings.xml
+++ b/camera/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,1 @@
+../../../.idea/copyright/profiles_settings.xml

--- a/camera/.idea/inspectionProfiles/Project_Default.xml
+++ b/camera/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,1 @@
+../../../.idea/inspectionProfiles/Project_Default.xml

--- a/camera/.idea/scopes/Ignore_API_Files.xml
+++ b/camera/.idea/scopes/Ignore_API_Files.xml
@@ -1,0 +1,1 @@
+../../../.idea/scopes/Ignore_API_Files.xml

--- a/camera/.idea/scopes/buildSrc.xml
+++ b/camera/.idea/scopes/buildSrc.xml
@@ -1,0 +1,1 @@
+../../../.idea/scopes/buildSrc.xml

--- a/camera/buildSrc
+++ b/camera/buildSrc
@@ -1,0 +1,1 @@
+./../playground-common/../buildSrc

--- a/camera/camera-camera2-pipe-integration/build.gradle
+++ b/camera/camera-camera2-pipe-integration/build.gradle
@@ -74,10 +74,10 @@ dependencies {
     androidTestImplementation(libs.kotlinCoroutinesAndroid)
     androidTestImplementation(libs.kotlinStdlib)
     androidTestImplementation(libs.truth)
-    androidTestImplementation(project(":annotation:annotation-experimental"))
+    androidTestImplementation(projectOrArtifact(":annotation:annotation-experimental"))
     androidTestImplementation(project(":camera:camera-lifecycle"))
     androidTestImplementation(project(":camera:camera-testing"))
-    androidTestImplementation(project(":concurrent:concurrent-futures-ktx"))
+    androidTestImplementation(projectOrArtifact(":concurrent:concurrent-futures-ktx"))
     androidTestImplementation(project(":internal-testutils-truth"))
 }
 

--- a/camera/camera-core/build.gradle
+++ b/camera/camera-core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation("androidx.concurrent:concurrent-futures:1.0.0")
     implementation("androidx.lifecycle:lifecycle-common:2.1.0")
     implementation(libs.autoValueAnnotations)
-    compileOnly(project(":external:libyuv"))
+    compileOnly(projectOrArtifact(":external:libyuv"))
 
     annotationProcessor(libs.autoValue)
 

--- a/camera/camera-video/build.gradle
+++ b/camera/camera-video/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     androidTestImplementation(project(":camera:camera-testing"))
     androidTestImplementation(libs.kotlinStdlib)
     androidTestImplementation(libs.kotlinCoroutinesAndroid)
-    androidTestImplementation(project(":concurrent:concurrent-futures-ktx"))
+    androidTestImplementation(projectOrArtifact(":concurrent:concurrent-futures-ktx"))
     androidTestImplementation(project(":internal-testutils-truth"))
     androidTestImplementation libs.mockitoKotlin, {
         exclude group: 'org.mockito' // to keep control on the mockito version

--- a/camera/gradle
+++ b/camera/gradle
@@ -1,0 +1,1 @@
+./../playground-common/gradle

--- a/camera/gradle.properties
+++ b/camera/gradle.properties
@@ -1,0 +1,1 @@
+./../playground-common/androidx-shared.properties

--- a/camera/gradlew
+++ b/camera/gradlew
@@ -1,0 +1,1 @@
+./../playground-common/gradlew

--- a/camera/gradlew.bat
+++ b/camera/gradlew.bat
@@ -1,0 +1,1 @@
+./../playground-common/gradlew.bat

--- a/camera/integration-tests/coretestapp/build.gradle
+++ b/camera/integration-tests/coretestapp/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation(project(":camera:camera-lifecycle"))
     implementation(project(":camera:camera-video"))
     // Needed because AGP enforces same version between main and androidTest classpaths
-    implementation(project(":concurrent:concurrent-futures"))
+    implementation(projectOrArtifact(":concurrent:concurrent-futures"))
 
     // Android Support Library
     api(libs.constraintLayout)
@@ -97,8 +97,8 @@ dependencies {
     androidTestImplementation(libs.leakcanaryInstrumentation)
     androidTestImplementation(libs.truth)
     androidTestImplementation(project(":camera:camera-testing"))
-    androidTestImplementation(project(":concurrent:concurrent-futures"))
-    androidTestImplementation(project(":concurrent:concurrent-futures-ktx"))
+    androidTestImplementation(projectOrArtifact(":concurrent:concurrent-futures"))
+    androidTestImplementation(projectOrArtifact(":concurrent:concurrent-futures-ktx"))
     androidTestImplementation(project(":internal-testutils-runtime"))
     androidTestImplementation("androidx.lifecycle:lifecycle-runtime-testing:2.3.1")
 

--- a/camera/integration-tests/timingtestapp/build.gradle
+++ b/camera/integration-tests/timingtestapp/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     implementation(project(":camera:camera-lifecycle"))
 
     // Android support library
-    implementation(project(":concurrent:concurrent-futures-ktx"))
+    implementation(projectOrArtifact(":concurrent:concurrent-futures-ktx"))
     implementation("androidx.fragment:fragment-ktx:1.3.0")
     implementation("androidx.appcompat:appcompat:1.1.0")
     implementation("androidx.collection:collection:1.0.0")

--- a/camera/integration-tests/uiwidgetstestapp/build.gradle
+++ b/camera/integration-tests/uiwidgetstestapp/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.2.0")
     implementation("androidx.viewpager2:viewpager2:1.1.0-alpha01")
     implementation("androidx.concurrent:concurrent-futures-ktx:1.1.0")
-    implementation(project(":window:window"))
-    implementation(project(":window:window-java"))
+    implementation(projectOrArtifact(":window:window"))
+    implementation(projectOrArtifact(":window:window-java"))
     implementation(libs.constraintLayout)
 
     // Guava

--- a/camera/integration-tests/viewfindertestapp/build.gradle
+++ b/camera/integration-tests/viewfindertestapp/build.gradle
@@ -53,8 +53,8 @@ dependencies {
     implementation("androidx.activity:activity-ktx:1.2.0")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.concurrent:concurrent-futures-ktx:1.1.0")
-    implementation(project(":window:window"))
-    implementation(project(":window:window-java"))
+    implementation(projectOrArtifact(":window:window"))
+    implementation(projectOrArtifact(":window:window-java"))
 
     implementation(libs.guavaAndroid)
     implementation(libs.constraintLayout)

--- a/camera/integration-tests/viewtestapp/build.gradle
+++ b/camera/integration-tests/viewtestapp/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     // DefaultLifecycleEventObserver.
     // Outside of androidx this is resolved via constraint added to lifecycle-common,
     // but it doesn't work in androidx.
-    implementation(project(":lifecycle:lifecycle-common-java8"))
+    implementation(projectOrArtifact(":lifecycle:lifecycle-common-java8"))
     compileOnly(libs.kotlinCompiler)
 
     // Lifecycle and LiveData
@@ -81,7 +81,7 @@ dependencies {
 
     // Compose UI
     kotlinPlugin(projectOrArtifact(":compose:compiler:compiler"))
-    implementation(project(":compose:runtime:runtime"))
+    implementation(projectOrArtifact(":compose:runtime:runtime"))
     implementation("androidx.compose.ui:ui:1.0.5")
     implementation("androidx.compose.material:material:1.0.5")
     implementation("androidx.compose.ui:ui-tooling:1.0.5")

--- a/camera/settings.gradle
+++ b/camera/settings.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// see ../playground-common/README.md for details on how this works
+pluginManagement {
+    includeBuild "../playground-common/playground-plugin"
+}
+plugins {
+    id "playground"
+}
+
+rootProject.name = "camera-playground"
+
+playground {
+    setupPlayground("..")
+    selectProjectsFromAndroidX({ name ->
+        if (name.startsWith(":camera")) return true
+        if (name == ":internal-testutils-ktx") return true
+        if (name == ":internal-testutils-runtime") return true
+        if (name == ":internal-testutils-truth") return true
+        if (isNeededForComposePlayground(name)) return true
+        return false
+    })
+}
+


### PR DESCRIPTION
This currently requires a version of cmake that isn't available via `sdkmanager`, but there is a publicly pre-compiled one. Using this PR to test out the github workflow for now.

Test: ANDROID_NDK_ROOT=<path> cd camera && ./gradlew bOS
Change-Id: I477920a5457557cfbc1a11195c12aad989590354
