### PR TITLE
fix artifact names in github

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -155,12 +155,12 @@ jobs:
         if: ${{ steps.check-ci-config.outputs.enabled == 'true' }}
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts_${{ inputs.project-name }}
+          name: artifacts_${{ matrix.project }}
           path: ~/dist
       - name: "Upload daemon logs"
         continue-on-error: true
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: gradle-daemon-logs_${{ inputs.project-name }}
+          name: gradle-daemon-logs_${{ matrix.project }}
           path: ~/.gradle/daemon


### PR DESCRIPTION
All projects were uploading artifacts w/ the same name because of a
bad parameter. This CL fixes it to use the project name from the
matrix.

Bug: n/a
Test: CI
