### PR TITLE
Update playground prebuilts

### DIFF
--- a/development/update_playground.sh
+++ b/development/update_playground.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
-
 MODE=${1:-s}
-
 function fn_update_snapshot {
   BUILDID_ANDROIDX=`curl -s https://androidx.dev/snapshots/builds | sed -nr 's|.*snapshots/builds/([0-9]*).*|\1|gp' | head -n 1`
   echo "Updating snapshot id: $BUILDID_ANDROIDX"
-  sed -i "s/androidx.playground.snapshotBuildId=[0-9]\+/androidx.playground.snapshotBuildId=$BUILDID_ANDROIDX/g" playground-common/playground.properties
+  sed -i '' "s/androidx.playground.snapshotBuildId=.*/androidx.playground.snapshotBuildId=$BUILDID_ANDROIDX/g" playground-common/playground.properties
 }
 
 function fn_update_metalava {
   BUILDID_METALAVA=`curl -s https://androidx.dev/metalava/builds | sed -nr 's|.*metalava/builds/([0-9]*).*|\1|gp' | head -n 1`
   echo "Updating metalava id: $BUILDID_METALAVA"
-  sed -i "s/androidx.playground.metalavaBuildId=[0-9]\+/androidx.playground.metalavaBuildId=$BUILDID_METALAVA/g" playground-common/playground.properties
+  sed -i '' "s/androidx.playground.metalavaBuildId=.*/androidx.playground.metalavaBuildId=$BUILDID_METALAVA/g" playground-common/playground.properties
 }
 
 function fn_update_dokka {
   BUILDID_DOKKA=`curl -s https://androidx.dev/dokka/builds | sed -nr 's|.*dokka/builds/([0-9]*).*|\1|gp' | head -n 1`
   echo "Updating dokka id: $BUILDID_DOKKA"
-  sed -i "s/androidx.playground.dokkaBuildId=[0-9]\+/androidx.playground.dokkaBuildId=$BUILDID_DOKKA/g" playground-common/playground.properties
+  sed -i '' "s/androidx.playground.dokkaBuildId=.*/androidx.playground.dokkaBuildId=$BUILDID_DOKKA/g" playground-common/playground.properties
 }
 
 if [ "$MODE" == "s" ]; then

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,7 +25,7 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=8312408
+androidx.playground.snapshotBuildId=8382462
 androidx.playground.metalavaBuildId=8210943
 androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
Also updated the script to support mac where the backup file
is mandatory in mac (sed -i ''). We still pass empty to skip
it.

Also needed to change the matcher to match any character instead
of digits. Not sure why but it is not matching the digits on my
mac :)

Bug: n/a
Test: CI