### PR TITLE
link buildSrc/gradle.properties -> gradle.properties

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,1 @@
+../gradle.properties


### PR DESCRIPTION
To allow buildSrc to use more of the properties from the root gradle.properties, particularly org.gradle.dependency.verification.console=verbose , which provides a clearer error when dependency verification fails

Bug: https://github.com/gradle/gradle/issues/20325
Change-Id: I61059d973b60ae6e287beb5dc12dd0e35c0046ce

## Proposed Changes

  -
  -
  -

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
