### PR TITLE
limit room test heap size to 512

### DIFF
--- a/room/room-compiler/build.gradle
+++ b/room/room-compiler/build.gradle
@@ -289,7 +289,10 @@ tasks.withType(KotlinCompile).configureEach {
 tasks.withType(Test).configureEach {
     it.systemProperty("androidx.room.compiler.processing.strict", "true")
     it.maxParallelForks(3)
-    it.maxHeapSize("512m")
+    if (project.providers.environmentVariable("GITHUB_ACTIONS").present) {
+        // limit memory usage to avoid running out of memory in the docker container.
+        it.maxHeapSize("512m")
+    }
 }
 
 androidx {

--- a/room/room-compiler/build.gradle
+++ b/room/room-compiler/build.gradle
@@ -289,6 +289,7 @@ tasks.withType(KotlinCompile).configureEach {
 tasks.withType(Test).configureEach {
     it.systemProperty("androidx.room.compiler.processing.strict", "true")
     it.maxParallelForks(3)
+    it.maxHeapSize("512m")
 }
 
 androidx {


### PR DESCRIPTION
Running 3 tests in parallel makes the docker run out of memory.
This is an effort to limit their memory consumption without slowing
the tests down too much.

Bug:  n/a
Test: CI
