### PR TITLE
temporarily disable datastore-multiprocess in github

### DIFF
--- a/datastore/settings.gradle
+++ b/datastore/settings.gradle
@@ -29,6 +29,7 @@ playground {
     selectProjectsFromAndroidX({ name ->
         // Must exclude this because AndroidXCompose plugin doesn't currently support playground.
         if (name == ":datastore:datastore-compose-samples") return false
+        if (name == ":datastore:datastore-multiprocess") return false
         if (name.startsWith(":datastore")) return true
         if (name == ":annotation:annotation-sampled") return true
         if (name == ":internal-testutils-truth") return true


### PR DESCRIPTION
We don't have proper NDK yet, until we figure it out, lets
disable it so the build turns green. It is not used anywhere
yet.

Bug: n/a
Test: cd datastore && ./gradlew bOS
