### PR TITLE
Further unify repositories used by playground

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -133,9 +133,6 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
                 }
             }
         }
-        google()
-        mavenCentral()
-        gradlePluginPortal()
     }
 
     private class PlaygroundRepositories(

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -21,12 +21,12 @@ import androidx.build.dependencyTracker.ProjectGraph
 import androidx.build.gradle.isRoot
 import androidx.build.playground.FindAffectedModulesTask
 import groovy.xml.DOMBuilder
+import java.net.URI
+import java.net.URL
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import java.net.URI
-import java.net.URL
 
 /**
  * This plugin is used in Playground projects and adds functionality like resolving to snapshot
@@ -39,7 +39,12 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
     /**
      * List of snapshot repositories to fetch AndroidX artifacts
      */
-    private lateinit var repos: PlaygroundRepositories
+    private lateinit var playgroundRepositories: PlaygroundRepositories
+
+    /**
+     * Proxy class to call methods declared in buildSrc/repos.gradle
+     */
+    private lateinit var reposProxy: ReposProxy
 
     /**
      * The configuration for the plugin read from the gradle properties
@@ -57,7 +62,8 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
         }
         rootProject = target
         config = PlaygroundProperties.load(rootProject)
-        repos = PlaygroundRepositories(config)
+        playgroundRepositories = PlaygroundRepositories(config)
+        reposProxy = ReposProxy(target)
         rootProject.repositories.addPlaygroundRepositories()
         rootProject.subprojects {
             configureSubProject(it)
@@ -102,7 +108,8 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
         return if (metadataCacheFile.exists()) {
             metadataCacheFile.readText(Charsets.UTF_8)
         } else {
-            val metadataUrl = "${repos.snapshots.url}/$groupPath/$modulePath/maven-metadata.xml"
+            val metadataUrl =
+                "${playgroundRepositories.snapshots.url}/$groupPath/$modulePath/maven-metadata.xml"
             URL(metadataUrl).openStream().use {
                 val parsedMetadata = DOMBuilder.parse(it.reader())
                 val versionNodes = parsedMetadata.getElementsByTagName("latest")
@@ -121,7 +128,7 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
     }
 
     private fun RepositoryHandler.addPlaygroundRepositories() {
-        repos.all.forEach { playgroundRepository ->
+        playgroundRepositories.all.forEach { playgroundRepository ->
             maven { repository ->
                 repository.url = URI(playgroundRepository.url)
                 repository.metadataSources {
@@ -133,6 +140,7 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
                 }
             }
         }
+        reposProxy.addMavenRepositories(this)
     }
 
     private class PlaygroundRepositories(

--- a/buildSrc/private/src/main/kotlin/androidx/build/ReposProxy.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/ReposProxy.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.build
+
+import org.codehaus.groovy.runtime.MethodClosure
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.kotlin.dsl.extra
+
+/**
+ * Proxy class to call methods declared in buildSrc/repos.gradle
+ */
+internal class ReposProxy(
+    project: Project
+) {
+    private val addRepositoriesClosure: MethodClosure
+    init {
+        @Suppress("UNCHECKED_CAST")
+        val repos = project.extra.properties["repos"] as Map<String, *>
+        addRepositoriesClosure = repos["addMavenRepositories"] as MethodClosure
+    }
+    fun addMavenRepositories(
+        repositoryHandler: RepositoryHandler
+    ) {
+        addRepositoriesClosure.call(repositoryHandler)
+    }
+}

--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// if you make changes no this file, make sure to update ReposProxy class in buildSrc
 def supportRootFolder = ext.supportRootFolder
 if (supportRootFolder == null) {
     throw new RuntimeException("Canonical root project directory is not set. You must specify " +

--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// if you make changes no this file, make sure to update ReposProxy class in buildSrc
+// if you make changes in this file, make sure to update ReposProxy class in buildSrc
 def supportRootFolder = ext.supportRootFolder
 if (supportRootFolder == null) {
     throw new RuntimeException("Canonical root project directory is not set. You must specify " +

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -24,36 +24,8 @@ buildscript {
     def playgroundCommonFolder = rootProject.buildFile.parentFile
     ext.supportRootFolder = playgroundCommonFolder.parentFile
 
-    def metalavaBuildId = rootProject.properties["androidx.playground.metalavaBuildId"]
-    def dokkaBuildId = rootProject.properties["androidx.playground.dokkaBuildId"]
-    if (metalavaBuildId == null || dokkaBuildId == null) {
-        throw new GradleException("metalava and or dokka build ids must be defined.")
-    }
-    def metalavaRepo = "https://androidx.dev/metalava/builds/${metalavaBuildId}/artifacts/repo/m2repository"
-    def dokkaRepo = "https://androidx.dev/dokka/builds/${dokkaBuildId}/artifacts/repository"
-    repositories {
-        maven {
-            url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/"
-        }
-        google()
-        mavenCentral()
-        maven {
-            url metalavaRepo
-            metadataSources {
-                mavenPom()
-                artifact()
-            }
-        }
-        maven {
-            url dokkaRepo
-            metadataSources {
-                mavenPom()
-                artifact()
-            }
-        }
-        gradlePluginPortal()
-    }
-
+    apply(from: new File(ext.supportRootFolder, "buildSrc/repos.gradle"))
+    repos.addMavenRepositories(repositories)
     ext.repos = [:]
     dependencies {
         // NOTE: It's not really clear why asm:9.1 must be explicitly declared here since it should

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -26,7 +26,6 @@ buildscript {
 
     apply(from: new File(ext.supportRootFolder, "buildSrc/repos.gradle"))
     repos.addMavenRepositories(repositories)
-    ext.repos = [:]
     dependencies {
         // NOTE: It's not really clear why asm:9.1 must be explicitly declared here since it should
         // be provided transitively.


### PR DESCRIPTION
This CL removes the common external repositories from the playground
root plugin since they are added by repos.gradle.

Furthermore, it also removes the repository list in the shared
playground-build file and instead delegates to repos.gradle.

Bug: n/a
Test: cd room && ./gradlew projects