### PR TITLE
Download cmake 3.22.1 onto build machines

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -33,27 +33,6 @@ runs:
       uses: actions/setup-java@v1
       with:
         java-version: "11"
-    # Required for CMake when building workmanager.
-    - name: "Install Ninja"
-      shell: bash
-      run: |
-        set -x
-        if [ "$RUNNER_OS" == "Linux" ]; then
-          # Should use version 1.10.2 but it is not available on apt yet.
-          sudo apt-get install ninja-build=1.10.0-1build1
-        elif [ "$RUNNER_OS" == "macOS" ]; then
-          # Should use version 1.10.2, but it is not well supported by Homebrew.
-          brew install ninja
-        elif [ "$RUNNER_OS" == "Windows" ]; then
-          choco install ninja --version=1.10.2
-        else
-          echo "Failed to install ninja due to unsupport OS: $RUNNER_OS"
-          exit 1
-        fi
-        # See b/206099937. Hack needed to make ninja visible to cmake during NDK builds
-        if [ ! -e "/usr/local/bin/ninja" ]; then
-          ln -s "/usr/bin/ninja" "/usr/local/bin/ninja"
-        fi
     - name: "Install Cmake"
       shell: bash
       run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1" --channel=3

--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -54,7 +54,9 @@ runs:
         if [ ! -e "/usr/local/bin/ninja" ]; then
           ln -s "/usr/bin/ninja" "/usr/local/bin/ninja"
         fi
-
+    - name: "Install Cmake"
+      shell: bash
+      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1" --channel=3
     - name: "Set environment variables"
       shell: bash
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ We have tried to make contributing to androidx a lot easier with this new setup.
 
   ```bash
   sdkmanager --install "ndk;23.1.7779620"
+  sdkmanager --install "cmake;3.22.1" --channel=3 #channel 3 is the canary channel
   ```
 
   Next, you need to set up the following environment variables:

--- a/datastore/settings.gradle
+++ b/datastore/settings.gradle
@@ -29,7 +29,6 @@ playground {
     selectProjectsFromAndroidX({ name ->
         // Must exclude this because AndroidXCompose plugin doesn't currently support playground.
         if (name == ":datastore:datastore-compose-samples") return false
-        if (name == ":datastore:datastore-multiprocess") return false
         if (name.startsWith(":datastore")) return true
         if (name == ":annotation:annotation-sampled") return true
         if (name == ":internal-testutils-truth") return true


### PR DESCRIPTION
AndroidX uses this Cmake version which is only available in the canary
channel.

Also re-enabled datastore-mutliprocess on playground and updated
contributing.md doc to include the cmake download instruction.

Fixes: 229400584
Test: Github CI
