### PR TITLE
make navigation import lifecycle/savedstate

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -28,8 +28,10 @@ playground {
     setupPlayground("..")
     selectProjectsFromAndroidX({ name ->
         if (name.startsWith(":activity")) return true
-        if (name == ":annotation:annotation-sampled") return true
+        if (name.startsWith(":lifecycle")) return true
+        if (name.startsWith(":annotation")) return true
         if (name == ":internal-testutils-runtime") return true
+        if (name == ":internal-testutils-truth") return true
         if (isNeededForComposePlayground(name)) return true
         return false
     })

--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -29,9 +29,10 @@ playground {
     selectProjectsFromAndroidX({ name ->
         // Compose projects are not supported in playground yet
         if (name.startsWith(":navigation")) return true
-        if (name == ":annotation:annotation-sampled") return true
+        if (name.startsWith(":annotation")) return true
         if (name == ":compose:integration-tests:demos:common") return true
-        if (name == ":lifecycle:lifecycle-viewmodel-savedstate") return true
+        if (name.startsWith(":lifecycle")) return true
+        if (name.startsWith(":savedstate")) return true
         if (name == ":internal-testutils-navigation") return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true


### PR DESCRIPTION
Make navigation import lifecycle/savedstate

There is a lot of inter-project dependencies between
navigation and lifecycle so trying to not import
them keeps failing CI when they have locked
releases.

Bug: n/a
Test: CI