### PR TITLE
Limit usage of gradlePluginPortal

### DIFF
--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -32,9 +32,6 @@ buildscript {
     def metalavaRepo = "https://androidx.dev/metalava/builds/${metalavaBuildId}/artifacts/repo/m2repository"
     def dokkaRepo = "https://androidx.dev/dokka/builds/${dokkaBuildId}/artifacts/repository"
     repositories {
-        maven {
-            url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/"
-        }
         google()
         mavenCentral()
         maven {
@@ -51,7 +48,10 @@ buildscript {
                 artifact()
             }
         }
-        gradlePluginPortal()
+        gradlePluginPortal().content {
+            it.includeModule("gradle.plugin.com.github.johnrengelman", "shadow")
+            it.includeModule("me.champeau.gradle", "japicmp-gradle-plugin")
+        }
     }
 
     ext.repos = [:]

--- a/playground-common/playground-plugin/settings.gradle
+++ b/playground-common/playground-plugin/settings.gradle
@@ -17,14 +17,19 @@
 pluginManagement {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal().content {
+            it.includeModule("org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin.jvm.gradle.plugin")
+        }
     }
 }
 
 dependencyResolutionManagement {
     repositories {
         mavenCentral()
-        gradlePluginPortal()
+        gradlePluginPortal().content {
+            it.includeModule("com.gradle", "gradle-enterprise-gradle-plugin")
+            it.includeModule("com.gradle", "common-custom-user-data-gradle-plugin")
+        }
     }
 }
 

--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
@@ -88,10 +88,9 @@ open class PlaygroundExtension @Inject constructor(
      */
     fun setupPlayground(relativePathToRoot: String) {
         // gradlePluginPortal has a variety of unsigned binaries that have proper signatures
-        // in mavenCentral, so prefer that over gradlePluginPortal.
+        // in mavenCentral, so don't use gradlePluginPortal()
         settings.pluginManagement.repositories {
             it.mavenCentral()
-            it.gradlePluginPortal()
         }
         val projectDir = settings.rootProject.projectDir
         val supportRoot = File(projectDir, relativePathToRoot).canonicalFile


### PR DESCRIPTION
gradlePluginPortal() has mirrors of various libraries, often in an
unsigned form compared to mavenCentral. Avoid using it where we can.

Test: ./gradlew tasks -> in room/
