### PR TITLE
Remove explicit loading of buildSrc dependencies for the classpath

### DIFF
--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -55,17 +55,6 @@ buildscript {
     }
 
     ext.repos = [:]
-    dependencies {
-        // NOTE: It's not really clear why asm:9.1 must be explicitly declared here since it should
-        // be provided transitively.
-        classpath("org.ow2.asm:asm:9.1")
-        classpath(libs.androidGradlePluginz)
-        classpath(libs.kotlinGradlePluginz)
-        classpath(libs.kspGradlePluginz)
-        classpath(libs.gson)
-        classpath(libs.shadow)
-        classpath(libs.japicmpPluginz)
-    }
 }
 
 apply from: "$supportRootFolder/buildSrc/dependencies.gradle"


### PR DESCRIPTION
This seems to be an old workaround that is not needed anymore.

Test: ./gradlew tasks in room/
