### PR TITLE
Paulseawa/datastore kmp

### DIFF
--- a/datastore/datastore-core-okio/src/nativeMain/kotlin/androidx.datastore.core.okio/Actuals.native.kt
+++ b/datastore/datastore-core-okio/src/nativeMain/kotlin/androidx.datastore.core.okio/Actuals.native.kt
@@ -23,9 +23,9 @@ import okio.BufferedSource
 
 
 actual fun InputStream.asBufferedSource(): BufferedSource {
-    return this as BufferedSource
+    return this
 }
 
 actual  fun OutputStream.asBufferedSink(): BufferedSink {
-    return this as BufferedSink
+    return this
 }

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/AtomicInt.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/AtomicInt.kt
@@ -16,9 +16,10 @@
 
 package androidx.datastore.core
 
-expect internal class AtomicInt {
+internal expect class AtomicInt {
     constructor(initialValue: Int)
     fun getAndIncrement(): Int
+    fun incrementAndGet(): Int
     fun decrementAndGet(): Int
     fun get(): Int
 }

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/DataStoreFactory.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/DataStoreFactory.kt
@@ -50,6 +50,6 @@ expect object DataStoreFactory {
         storage: Storage<T>,
         corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
         migrations: List<DataMigration<T>> = listOf(),
-        scope: CoroutineScope =  CoroutineScope(ioDispatcher() + SupervisorJob()),
+        scope: CoroutineScope = CoroutineScope(ioDispatcher() + SupervisorJob()),
     ): DataStore<T>
 }

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/Serializer.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/Serializer.kt
@@ -19,7 +19,9 @@ package androidx.datastore.core
 expect abstract class InputStream
 expect abstract class OutputStream
 
-expect open class IOException(message: String?, cause: Throwable?) : Exception
+expect open class IOException(message: String?, cause: Throwable?) : Exception {
+    constructor(message: String?)
+}
 /**
  * The serializer determines the on-disk format and API for accessing it.
  *

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/SingleProcessDataStore.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/SingleProcessDataStore.kt
@@ -24,7 +24,6 @@ import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.completeWith
 import kotlinx.coroutines.flow.Flow
@@ -64,7 +63,6 @@ internal class ReadException<T>(val readException: Throwable) : State<T>()
  * The scope has been cancelled. This DataStore cannot process any new reads or writes.
  */
 internal class Final<T>(val finalException: Throwable) : State<T>()
-
 
 internal expect fun ioDispatcher(): CoroutineDispatcher
 

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/Storage.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/Storage.kt
@@ -23,6 +23,5 @@ interface Storage<T> {
 
     companion object {
         internal val SCRATCH_SUFFIX = ".tmp"
-
     }
 }

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/StorageImpl.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/StorageImpl.kt
@@ -17,5 +17,5 @@
 package androidx.datastore.core
 
 internal abstract class StorageImpl<T> : Storage<T> {
-    abstract fun delete():Boolean
+    abstract fun delete(): Boolean
 }

--- a/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/StorageImpl.kt
+++ b/datastore/datastore-core/src/commonMain/kotlin/androidx/datastore/core/StorageImpl.kt
@@ -16,13 +16,6 @@
 
 package androidx.datastore.core
 
-expect class TestIO(dirName:String = "datastore-test-dir") {
-    internal fun <T> newFileStorage(
-        serializer: Serializer<T>,
-        prefix:String = "temp-file"
-    ): StorageImpl<T>
-
-    var onProduceFileCallback:()->Unit
-
-    fun cleanup()
+internal abstract class StorageImpl<T> : Storage<T> {
+    abstract fun delete():Boolean
 }

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/DataStoreFactoryTest.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/DataStoreFactoryTest.kt
@@ -36,7 +36,6 @@ class DataStoreFactoryTest {
 
     private val dataStoreScope: TestScope = TestScope(UnconfinedTestDispatcher())
 
-
     @Test
     fun testNewInstance() = dataStoreScope.runTest {
         val store = DataStoreFactory.create(
@@ -59,7 +58,8 @@ class DataStoreFactoryTest {
         val valueToReplace = 123.toByte()
 
         val store = DataStoreFactory.create(
-            storage = testIO.newFileStorage(TestingSerializer(failReadWithCorruptionException = true)),
+            storage = testIO.newFileStorage(
+                TestingSerializer(failReadWithCorruptionException = true)),
             corruptionHandler = ReplaceFileCorruptionHandler<Byte> {
                 valueToReplace
             },

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/SingleProcessDataStoreTest.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/SingleProcessDataStoreTest.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 
 @ExperimentalCoroutinesApi
-class SingleProcessDataStoreTestCommon {
+class SingleProcessDataStoreTest {
 
     // TODO add timeout
 //    @get:Rule
@@ -64,7 +64,6 @@ class SingleProcessDataStoreTestCommon {
     private lateinit var dataStoreScope: TestScope
     private lateinit var testScope: TestScope
     private lateinit var testStorage: StorageImpl<Byte>
-
 
     @BeforeTest
     fun setUp() {
@@ -96,7 +95,7 @@ class SingleProcessDataStoreTestCommon {
         }
     }
 
-    //Unable to convert these as okio doesn't support file permissions.
+    // Unable to convert these as okio doesn't support file permissions.
 //    @Test
 //    fun testReadUnreadableFile() = runBlockingTest {
 //        testFile.setReadable(false)
@@ -350,15 +349,15 @@ class SingleProcessDataStoreTestCommon {
 
     @Test
     fun testCanWriteFromInitTask() = testScope.runTest {
-        store = newDataStore(initTasksList = listOf ({ api -> api.updateData { 1 } }))
-        val one:Byte = 1
+        store = newDataStore(initTasksList = listOf({ api -> api.updateData { 1 } }))
+        val one: Byte = 1
 
         assertThat(store.data.first()).isEqualTo(one)
     }
 
     @Test
     fun testInitTaskFailsFirstTimeDueToReadFail() = testScope.runTest {
-        store = newDataStore(initTasksList = listOf ({ api -> api.updateData { 1 } }))
+        store = newDataStore(initTasksList = listOf({ api -> api.updateData { 1 } }))
 
         testingSerializer.failingRead = true
         assertThrows<IOException> { store.updateData { 2 } }
@@ -373,7 +372,7 @@ class SingleProcessDataStoreTestCommon {
     fun testInitTaskFailsFirstTimeDueToException() = testScope.runTest {
         val failInit = AtomicInt(0)
         store = newDataStore(
-            initTasksList = listOf( {
+            initTasksList = listOf({
                 if (failInit.get() == 0) {
                     throw IOException("I was asked to fail init")
                 }
@@ -391,7 +390,7 @@ class SingleProcessDataStoreTestCommon {
     fun testInitTaskOnlyRunsOnce() = testScope.runTest {
         val count = AtomicInt(0)
         val newStore = newDataStore(
-            initTasksList = listOf ({
+            initTasksList = listOf({
                 count.incrementAndGet()
             })
         )
@@ -409,7 +408,7 @@ class SingleProcessDataStoreTestCommon {
         val continueInit = CompletableDeferred<Unit>()
 
         store = newDataStore(
-            initTasksList = listOf ({ api ->
+            initTasksList = listOf({ api ->
                 continueInit.await()
                 api.updateData { 1 }
             })
@@ -433,7 +432,7 @@ class SingleProcessDataStoreTestCommon {
         val continueInit = CompletableDeferred<Unit>()
 
         store = newDataStore(
-            initTasksList = listOf ({ api ->
+            initTasksList = listOf({ api ->
                 continueInit.await()
                 api.updateData { 1 }
             })
@@ -562,7 +561,7 @@ class SingleProcessDataStoreTestCommon {
         assertThat(bytesFromSecondCollect).isEqualTo(mutableListOf<Byte>(0, 1, 2, 3, 4, 5, 6, 7))
     }
 
-    //coroutine failure issue
+    // coroutine failure issue
 //    @Test
 //    fun testExceptionInFlowDoesNotBreakUpstream() = testScope.runTest {
 //        val flowOf8 = store.data.take(8)
@@ -714,7 +713,7 @@ class SingleProcessDataStoreTestCommon {
     fun testMutatingDataStoreFails() = testScope.runTest {
 
         val dataStore = DataStoreFactory.create(
-            testIO.newFileStorage( ByteWrapper.ByteWrapperSerializer()),
+            testIO.newFileStorage(ByteWrapper.ByteWrapperSerializer()),
             scope = dataStoreScope
         )
 
@@ -781,7 +780,7 @@ class SingleProcessDataStoreTestCommon {
         companion object Key : CoroutineContext.Key<TestElement>
     }
 
-    //figure out common coroutine equiv
+    // figure out common coroutine equiv
 //    @Test
 //    fun testCancelInflightWrite() = runBlocking<Unit> {
 //        val myScope =

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/TestExpects.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/TestExpects.kt
@@ -16,13 +16,13 @@
 
 package androidx.datastore.core
 
-expect class TestIO(dirName:String = "datastore-test-dir") {
+expect class TestIO(dirName: String = "datastore-test-dir") {
     internal fun <T> newFileStorage(
         serializer: Serializer<T>,
-        prefix:String = "temp-file"
+        prefix: String = "temp-file"
     ): StorageImpl<T>
 
-    var onProduceFileCallback:()->Unit
+    var onProduceFileCallback: () -> Unit
 
     fun cleanup()
 }

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/TestingSerializer.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/datastore/core/TestingSerializer.kt
@@ -32,7 +32,7 @@ internal class TestingSerializer(
         if (failReadWithCorruptionException) {
             throw CorruptionException(
                 "CorruptionException",
-                IOException()
+                IOException("I was asked to fail with corruption on reads")
             )
         }
 

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
@@ -39,18 +39,16 @@ open class KruthAssertion<T>(
 open class KruthStringAssertion(
     actual: String?
 ) : KruthAssertion<String>(actual) {
-    fun startsWith(prefix:String) {
-        assertTrue(actual?.startsWith(prefix) ?:false)
+    fun startsWith(prefix: String) {
+        assertTrue(actual?.startsWith(prefix) ?: false)
     }
-    fun endsWith(suffix:String) {
-        assertTrue(actual?.endsWith(suffix) ?:false)
+    fun endsWith(suffix: String) {
+        assertTrue(actual?.endsWith(suffix) ?: false)
     }
-    fun contains(chars:CharSequence) {
+    fun contains(chars: CharSequence) {
         assertTrue(actual is CharSequence)
         assertContains(actual, chars)
     }
-
-
 }
 
 class KruthBooleanAssertion(
@@ -68,7 +66,7 @@ class KTruthThrowableAssertion(
     actual: Throwable?
 ) : KruthAssertion<Throwable>(actual) {
 
-    fun hasMessageThat():KruthStringAssertion {
+    fun hasMessageThat(): KruthStringAssertion {
         return KruthStringAssertion(actual?.message)
     }
 }
@@ -77,18 +75,17 @@ fun <T> assertThat(
     actual: T?
 ) = KruthAssertion(actual)
 
-fun  assertThat(
+fun assertThat(
     actual: Boolean?
 ) = KruthBooleanAssertion(actual)
 
-inline fun <reified E : Exception>  assertThrows(test:()->Unit):KTruthThrowableAssertion {
+inline fun <reified E : Exception> assertThrows(test: () -> Unit): KTruthThrowableAssertion {
     try {
         test()
         assertTrue(false, "Exception ${E::class} not thrown")
         throw AssertionError("Impossible to get here")
-    } catch (ex:Exception) {
+    } catch (ex: Exception) {
         assertTrue(ex is E, "Expected thrown ${E::class}, got ${ex::class}")
         return KTruthThrowableAssertion(ex)
     }
-
 }

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
@@ -16,6 +16,7 @@
 
 package androidx.kruth
 
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -38,14 +39,15 @@ open class KruthAssertion<T>(
 open class KruthStringAssertion(
     actual: String?
 ) : KruthAssertion<String>(actual) {
-    fun startsWith(prefix:String):Boolean {
-        return actual?.startsWith(prefix) ?:false
+    fun startsWith(prefix:String) {
+        assertTrue(actual?.startsWith(prefix) ?:false)
     }
-    fun endsWith(suffix:String):Boolean {
-        return actual?.endsWith(suffix) ?:false
+    fun endsWith(suffix:String) {
+        assertTrue(actual?.endsWith(suffix) ?:false)
     }
-    fun contains(chars:CharSequence):Boolean {
-        return actual?.contains(chars) ?:false
+    fun contains(chars:CharSequence) {
+        assertTrue(actual is CharSequence)
+        assertContains(actual, chars)
     }
 
 
@@ -54,11 +56,11 @@ open class KruthStringAssertion(
 class KruthBooleanAssertion(
     actual: Boolean?
 ) : KruthAssertion<Boolean>(actual) {
-    fun isTrue():Boolean {
-        return actual is Boolean && actual
+    fun isTrue() {
+        assertTrue(actual is Boolean && actual)
     }
-    fun isFalse():Boolean {
-        return actual is Boolean && !actual
+    fun isFalse() {
+        assertTrue(actual is Boolean && !actual)
     }
 }
 

--- a/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
+++ b/datastore/datastore-core/src/commonTest/kotlin/androidx/kruth/TruthForKotlinTest.kt
@@ -17,10 +17,11 @@
 package androidx.kruth
 
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 // This mimics truth APis. not that we would merge it but makes moving tests and trying it
 // easier
-class KruthAssertion<T>(
+open class KruthAssertion<T>(
     val actual: T?
 ) {
     fun isEqualTo(
@@ -33,6 +34,59 @@ class KruthAssertion<T>(
         )
     }
 }
+
+open class KruthStringAssertion(
+    actual: String?
+) : KruthAssertion<String>(actual) {
+    fun startsWith(prefix:String):Boolean {
+        return actual?.startsWith(prefix) ?:false
+    }
+    fun endsWith(suffix:String):Boolean {
+        return actual?.endsWith(suffix) ?:false
+    }
+    fun contains(chars:CharSequence):Boolean {
+        return actual?.contains(chars) ?:false
+    }
+
+
+}
+
+class KruthBooleanAssertion(
+    actual: Boolean?
+) : KruthAssertion<Boolean>(actual) {
+    fun isTrue():Boolean {
+        return actual is Boolean && actual
+    }
+    fun isFalse():Boolean {
+        return actual is Boolean && !actual
+    }
+}
+
+class KTruthThrowableAssertion(
+    actual: Throwable?
+) : KruthAssertion<Throwable>(actual) {
+
+    fun hasMessageThat():KruthStringAssertion {
+        return KruthStringAssertion(actual?.message)
+    }
+}
+
 fun <T> assertThat(
     actual: T?
 ) = KruthAssertion(actual)
+
+fun  assertThat(
+    actual: Boolean?
+) = KruthBooleanAssertion(actual)
+
+inline fun <reified E : Exception>  assertThrows(test:()->Unit):KTruthThrowableAssertion {
+    try {
+        test()
+        assertTrue(false, "Exception ${E::class} not thrown")
+        throw AssertionError("Impossible to get here")
+    } catch (ex:Exception) {
+        assertTrue(ex is E, "Expected thrown ${E::class}, got ${ex::class}")
+        return KTruthThrowableAssertion(ex)
+    }
+
+}

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/AtomicInt.jvm.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/AtomicInt.jvm.kt
@@ -16,7 +16,7 @@
 
 package androidx.datastore.core
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicInteger
 internal actual class AtomicInt {
     private val delegate: AtomicInteger
     actual constructor(initialValue: Int) {

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/AtomicInt.jvm.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/AtomicInt.jvm.kt
@@ -17,7 +17,7 @@
 package androidx.datastore.core
 
 import java.util.concurrent.atomic.AtomicInteger;
-actual internal class AtomicInt {
+internal actual class AtomicInt {
     private val delegate: AtomicInteger
     actual constructor(initialValue: Int) {
         delegate = AtomicInteger(initialValue)
@@ -26,4 +26,5 @@ actual internal class AtomicInt {
     actual fun getAndIncrement(): Int = delegate.getAndIncrement()
     actual fun decrementAndGet(): Int = delegate.decrementAndGet()
     actual fun get(): Int = delegate.get()
+    actual fun incrementAndGet(): Int = delegate.incrementAndGet()
 }

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/FileStorage.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/FileStorage.kt
@@ -142,7 +142,7 @@ internal class FileStorage<T>(
         internal val activeFilesLock = Any()
     }
 
-    override fun delete():Boolean {
+    override fun delete(): Boolean {
         return file.delete()
     }
 }

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/FileStorage.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/FileStorage.kt
@@ -28,7 +28,7 @@ import java.io.OutputStream
 internal class FileStorage<T>(
     val produceFile: () -> File,
     private val serializer: Serializer<T>
-) : Storage<T> {
+) : StorageImpl<T>() {
     private val file: File by lazy {
         val file = produceFile()
 
@@ -140,5 +140,9 @@ internal class FileStorage<T>(
         internal val activeFiles = mutableSetOf<String>()
 
         internal val activeFilesLock = Any()
+    }
+
+    override fun delete():Boolean {
+        return file.delete()
     }
 }

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/SingleProcessDataStore.jvm.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/SingleProcessDataStore.jvm.kt
@@ -22,12 +22,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 
-
 internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.IO
 
 // we can rename this since it is internal but also used a lot in tests so nice to have :)
 @Suppress("FunctionName")
-internal fun<T> SingleProcessDataStore(
+internal fun <T> SingleProcessDataStore(
     produceFile: () -> File,
     serializer: Serializer<T>,
     initTasksList: List<suspend (api: InitializerApi<T>) -> Unit> = emptyList(),

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/handlers/NoOpCorruptionHandler.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/handlers/NoOpCorruptionHandler.kt
@@ -15,6 +15,16 @@
  */
 package androidx.datastore.core.handlers
 
+import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.CorruptionHandler
 
-internal expect class NoOpCorruptionHandler<T>() : CorruptionHandler<T>
+/**
+ * Default corruption handler which does nothing but rethrow the exception.
+ */
+internal actual class NoOpCorruptionHandler<T> : CorruptionHandler<T> {
+
+    @Throws(CorruptionException::class)
+    override suspend fun handleCorruption(ex: CorruptionException): T {
+        throw ex
+    }
+}

--- a/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
+++ b/datastore/datastore-core/src/jvmMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
@@ -18,6 +18,7 @@ package androidx.datastore.core.handlers
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.CorruptionHandler
+import androidx.datastore.core.IOException
 
 /**
  * A corruption handler that attempts to replace the on-disk data with data from produceNewData.
@@ -30,5 +31,12 @@ import androidx.datastore.core.CorruptionHandler
  * callback fails, nothing will be written to disk. Since the exception will be swallowed after
  * writing the data, this is a good place to log the exception.
  */
-public expect class ReplaceFileCorruptionHandler<T>(produceNewData: (CorruptionException) -> T) :
-    CorruptionHandler<T>
+public actual class ReplaceFileCorruptionHandler<T> actual constructor(
+    private val produceNewData: (CorruptionException) -> T
+) : CorruptionHandler<T> {
+
+    @Throws(IOException::class)
+    override suspend fun handleCorruption(ex: CorruptionException): T {
+        return produceNewData(ex)
+    }
+}

--- a/datastore/datastore-core/src/jvmTest/kotlin/androidx/datastore/core/TestActuals.jvm.kt
+++ b/datastore/datastore-core/src/jvmTest/kotlin/androidx/datastore/core/TestActuals.jvm.kt
@@ -18,30 +18,30 @@ package androidx.datastore.core
 
 import java.nio.file.Files
 
-actual class TestIO actual constructor(dirName:String) {
+actual class TestIO actual constructor(dirName: String) {
     private val tmpDir = Files.createTempDirectory(
         dirName
     ).also {
         it.toFile().deleteOnExit()
     }
-    internal actual fun <T> newFileStorage(serializer: Serializer<T>, prefix:String): StorageImpl<T> {
+    internal actual fun <T> newFileStorage(serializer: Serializer<T>, prefix: String):
+        StorageImpl<T> {
         return FileStorage(
             produceFile = {
                 onProduceFileCallback()
                 Files.createTempFile(
                     tmpDir,
                     prefix, // prefix
-                    ""//suffix
+                    "" // suffix
                 ).toFile()
             },
             serializer = serializer
         )
     }
 
-    actual var onProduceFileCallback:()->Unit = {}
+    actual var onProduceFileCallback: () -> Unit = {}
 
     actual fun cleanup() {
         tmpDir.toFile().deleteRecursively()
     }
-
 }

--- a/datastore/datastore-core/src/jvmTest/kotlin/androidx/datastore/core/TestActuals.jvm.kt
+++ b/datastore/datastore-core/src/jvmTest/kotlin/androidx/datastore/core/TestActuals.jvm.kt
@@ -18,24 +18,27 @@ package androidx.datastore.core
 
 import java.nio.file.Files
 
-actual class TestIO {
+actual class TestIO actual constructor(dirName:String) {
     private val tmpDir = Files.createTempDirectory(
-        "datastore-test-io"
+        dirName
     ).also {
         it.toFile().deleteOnExit()
     }
-    actual fun <T> newFileStorage(serializer: Serializer<T>): Storage<T> {
+    internal actual fun <T> newFileStorage(serializer: Serializer<T>, prefix:String): StorageImpl<T> {
         return FileStorage(
             produceFile = {
+                onProduceFileCallback()
                 Files.createTempFile(
                     tmpDir,
-                    "test-file", // prefix
+                    prefix, // prefix
                     ""//suffix
                 ).toFile()
             },
             serializer = serializer
         )
     }
+
+    actual var onProduceFileCallback:()->Unit = {}
 
     actual fun cleanup() {
         tmpDir.toFile().deleteRecursively()

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/AtomicInt.native.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/AtomicInt.native.kt
@@ -25,4 +25,5 @@ internal actual class AtomicInt {
     actual fun getAndIncrement(): Int = delegate++
     actual fun decrementAndGet(): Int = --delegate
     actual fun get(): Int = delegate
+    actual fun incrementAndGet(): Int = ++delegate
 }

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/DataStoreFactory.native.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/DataStoreFactory.native.kt
@@ -19,8 +19,6 @@ package androidx.datastore.core
 import androidx.datastore.core.handlers.NoOpCorruptionHandler
 import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import okio.FileSystem
 import okio.Path
 

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/OkioStorage.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/OkioStorage.kt
@@ -23,11 +23,11 @@ import okio.FileNotFoundException
 import okio.FileSystem
 import okio.Path
 
-class OkioStorage<T>(
+internal class OkioStorage<T>(
     private val fileSystem: FileSystem,
     private val producePath: () -> Path,
     private val serializer: Serializer<T>
-) : Storage<T> {
+) : StorageImpl<T>() {
     private val canonicalPath by lazy {
         val originalPath = producePath()
         check(originalPath.isAbsolute) {
@@ -111,5 +111,10 @@ class OkioStorage<T>(
 
     companion object {
         private val activePaths = atomic(emptySet<Path>())
+    }
+
+    override fun delete(): Boolean {
+        fileSystem.delete(canonicalPath)
+        return fileSystem.exists(canonicalPath)
     }
 }

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/OkioStorage.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/OkioStorage.kt
@@ -63,7 +63,7 @@ internal class OkioStorage<T>(
                 serializer.readFrom(this.toInputStream())
             }
         } catch (th: FileNotFoundException) {
-            println("CAUGHT EXCEPTION ${th} /${th::class.qualifiedName}")
+            println("CAUGHT EXCEPTION $th /${th::class.qualifiedName}")
             if (fileSystem.exists(path = canonicalPath)) {
                 throw th
             }

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/Serializer.native.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/Serializer.native.kt
@@ -20,8 +20,8 @@ import okio.BufferedSink
 import okio.BufferedSource
 
 // TODO try to clean this up or at least have real classes.
-internal fun BufferedSource.toInputStream() = object : InputStream(this){}
-internal fun BufferedSink.toOutputStream() = object : OutputStream(this){}
+internal fun BufferedSource.toInputStream() = object : InputStream(this) {}
+internal fun BufferedSink.toOutputStream() = object : OutputStream(this) {}
 public actual abstract class InputStream(
     delegate: okio.BufferedSource
 ) : okio.BufferedSource by delegate

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/SingleProcessDataStore.native.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/SingleProcessDataStore.native.kt
@@ -20,4 +20,4 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 // TODO this should be IO, not default.
-internal actual fun ioDispatcher(): CoroutineDispatcher  = Dispatchers.Default
+internal actual fun ioDispatcher(): CoroutineDispatcher = Dispatchers.Default

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/NoOpCorruptionHandler.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/NoOpCorruptionHandler.kt
@@ -15,6 +15,15 @@
  */
 package androidx.datastore.core.handlers
 
+import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.CorruptionHandler
 
-internal expect class NoOpCorruptionHandler<T>() : CorruptionHandler<T>
+/**
+ * Default corruption handler which does nothing but rethrow the exception.
+ */
+internal actual class NoOpCorruptionHandler<T> : CorruptionHandler<T> {
+
+    override suspend fun handleCorruption(ex: CorruptionException): T {
+        throw ex
+    }
+}

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
@@ -18,6 +18,7 @@ package androidx.datastore.core.handlers
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.CorruptionHandler
+import androidx.datastore.core.IOException
 
 /**
  * A corruption handler that attempts to replace the on-disk data with data from produceNewData.
@@ -30,5 +31,11 @@ import androidx.datastore.core.CorruptionHandler
  * callback fails, nothing will be written to disk. Since the exception will be swallowed after
  * writing the data, this is a good place to log the exception.
  */
-public expect class ReplaceFileCorruptionHandler<T>(produceNewData: (CorruptionException) -> T) :
-    CorruptionHandler<T>
+public actual class ReplaceFileCorruptionHandler<T> actual constructor(
+    private val produceNewData: (CorruptionException) -> T
+) : CorruptionHandler<T> {
+
+    override suspend fun handleCorruption(ex: CorruptionException): T {
+        return produceNewData(ex)
+    }
+}

--- a/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
+++ b/datastore/datastore-core/src/nativeMain/kotlin/androidx/datastore/core/handlers/ReplaceFileCorruptionHandler.kt
@@ -18,7 +18,6 @@ package androidx.datastore.core.handlers
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.CorruptionHandler
-import androidx.datastore.core.IOException
 
 /**
  * A corruption handler that attempts to replace the on-disk data with data from produceNewData.

--- a/datastore/datastore-core/src/nativeTest/kotlin/androidx/datastore/core/TestActuals.native.kt
+++ b/datastore/datastore-core/src/nativeTest/kotlin/androidx/datastore/core/TestActuals.native.kt
@@ -19,7 +19,7 @@ package androidx.datastore.core
 import kotlin.random.Random
 import okio.FileSystem
 
-actual class TestIO actual constructor(dirName:String) {
+actual class TestIO actual constructor(dirName: String) {
     // TODO could use fake filesysyem but we actually rather test with real filesystem
     private val fileSystem = FileSystem.SYSTEM
     private fun randomFileName( // LAME :)
@@ -30,8 +30,10 @@ actual class TestIO actual constructor(dirName:String) {
         }
     }
     private val tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / randomFileName(dirName)
-    internal actual fun <T> newFileStorage(serializer: Serializer<T>,
-        prefix:String): StorageImpl<T> {
+    internal actual fun <T> newFileStorage(
+        serializer: Serializer<T>,
+        prefix: String
+    ): StorageImpl<T> {
         val storage = OkioStorage(
             fileSystem = fileSystem,
             producePath = {
@@ -43,10 +45,9 @@ actual class TestIO actual constructor(dirName:String) {
         return storage
     }
 
-    actual var onProduceFileCallback:()->Unit = {}
+    actual var onProduceFileCallback: () -> Unit = {}
 
     actual fun cleanup() {
         fileSystem.deleteRecursively(tmpDir)
     }
-
 }

--- a/datastore/datastore-core/src/nativeTest/kotlin/androidx/datastore/core/TestActuals.native.kt
+++ b/datastore/datastore-core/src/nativeTest/kotlin/androidx/datastore/core/TestActuals.native.kt
@@ -17,11 +17,9 @@
 package androidx.datastore.core
 
 import kotlin.random.Random
-import okio.BufferedSink
-import okio.BufferedSource
 import okio.FileSystem
 
-actual class TestIO {
+actual class TestIO actual constructor(dirName:String) {
     // TODO could use fake filesysyem but we actually rather test with real filesystem
     private val fileSystem = FileSystem.SYSTEM
     private fun randomFileName( // LAME :)
@@ -31,17 +29,21 @@ actual class TestIO {
             ('a' + Random.nextInt(from = 0, until = 26)).toString()
         }
     }
-    private val tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / randomFileName("datastore-test")
-    actual fun <T> newFileStorage(serializer: Serializer<T>): Storage<T> {
+    private val tmpDir = FileSystem.SYSTEM_TEMPORARY_DIRECTORY / randomFileName(dirName)
+    internal actual fun <T> newFileStorage(serializer: Serializer<T>,
+        prefix:String): StorageImpl<T> {
         val storage = OkioStorage(
             fileSystem = fileSystem,
             producePath = {
-                tmpDir / randomFileName("test-file")
+                onProduceFileCallback()
+                tmpDir / randomFileName(prefix)
             },
             serializer = serializer
         )
         return storage
     }
+
+    actual var onProduceFileCallback:()->Unit = {}
 
     actual fun cleanup() {
         fileSystem.deleteRecursively(tmpDir)


### PR DESCRIPTION
## Proposed Changes

Moved SingleProcessDatastoreTest to common.   
- A few tests commented out to be resolved.  
- All tests passing in jvm
- 4 tests failing on macosArm64

Expanded kruth library.
Expect/actual corruption handlers.
Various warning fixed.