### PR TITLE
Allowlist downloading org.jetbrains.kotlin.plugin.serialization plugin

### DIFF
--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
@@ -88,9 +88,15 @@ open class PlaygroundExtension @Inject constructor(
      */
     fun setupPlayground(relativePathToRoot: String) {
         // gradlePluginPortal has a variety of unsigned binaries that have proper signatures
-        // in mavenCentral, so don't use gradlePluginPortal()
+        // in mavenCentral, so don't use gradlePluginPortal() if you can avoid it
         settings.pluginManagement.repositories {
             it.mavenCentral()
+            it.gradlePluginPortal().content {
+                it.includeModule(
+                    "org.jetbrains.kotlin.plugin.serialization",
+                    "org.jetbrains.kotlin.plugin.serialization.gradle.plugin"
+                )
+            }
         }
         val projectDir = settings.rootProject.projectDir
         val supportRoot = File(projectDir, relativePathToRoot).canonicalFile


### PR DESCRIPTION
It seems that we were hitting Github Action Cache and now that we upgraded
Gradle, it reset, so we need an explicit allow for this module.

Test: ./gradlew tasks in navigation/
