### PR TITLE
Update Compose compiler plugin for K/Native iOS

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/ComposeIrGenerationExtension.kt
@@ -35,6 +35,8 @@ import androidx.compose.compiler.plugins.kotlin.lower.decoys.SubstituteDecoyCall
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.serialization.DeclarationTable
+import org.jetbrains.kotlin.backend.common.serialization.GlobalDeclarationTable
+import org.jetbrains.kotlin.backend.common.serialization.mangle.ir.IrBasedKotlinManglerImpl
 import org.jetbrains.kotlin.backend.common.serialization.signature.IdSignatureSerializer
 import org.jetbrains.kotlin.backend.common.serialization.signature.PublicIdSignatureComputer
 import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
@@ -43,7 +45,9 @@ import org.jetbrains.kotlin.ir.backend.js.lower.serialization.ir.JsManglerIr
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.platform.js.isJs
 import org.jetbrains.kotlin.platform.jvm.isJvm
+import org.jetbrains.kotlin.platform.konan.isNative
 import org.jetbrains.kotlin.resolve.DelegatingBindingTrace
+import kotlin.reflect.full.primaryConstructor
 
 class ComposeIrGenerationExtension(
     @Suppress("unused") private val liveLiteralsEnabled: Boolean = false,
@@ -56,6 +60,7 @@ class ComposeIrGenerationExtension(
     private val reportsDestination: String? = null
 ) : IrGenerationExtension {
     var metrics: ModuleMetrics = EmptyModuleMetrics
+
     @OptIn(ObsoleteDescriptorBasedAPI::class)
     override fun generate(
         moduleFragment: IrModuleFragment,
@@ -121,6 +126,18 @@ class ComposeIrGenerationExtension(
 
         val mangler = when {
             pluginContext.platform.isJs() -> JsManglerIr
+            // Use Reflection to get KonanManglerIr from konan
+            // TODO: Use `import` to get org.jetbrains.kotlin.backend.konan.* modules
+            pluginContext.platform.isNative() -> {
+                try {
+                    val konanManglerIrClass =
+                        Class.forName("org.jetbrains.kotlin.backend.konan.serialization." +
+                                "KonanManglerIr").kotlin
+                    konanManglerIrClass.objectInstance as IrBasedKotlinManglerImpl
+                } catch (t: Throwable) {
+                    throw t
+                }
+            }
             else -> null
         }
 
@@ -129,6 +146,21 @@ class ComposeIrGenerationExtension(
                 PublicIdSignatureComputer(mangler!!),
                 DeclarationTable(JsGlobalDeclarationTable(pluginContext.irBuiltIns))
             )
+            pluginContext.platform.isNative() -> {
+                try {
+                    // Use Reflection to get classes from konan
+                    val globalTableClassCons =
+                        Class.forName("org.jetbrains.kotlin.backend.konan.serialization." +
+                            "KonanGlobalDeclarationTable").kotlin.primaryConstructor
+                    IdSignatureSerializer(
+                        PublicIdSignatureComputer(mangler!!),
+                        DeclarationTable(globalTableClassCons?.call(pluginContext.irBuiltIns)
+                            as GlobalDeclarationTable)
+                    )
+                } catch (t: Throwable) {
+                    throw t
+                }
+            }
             else -> null
         }
         if (decoysEnabled) {

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/DecoyTransformBase.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/decoys/DecoyTransformBase.kt
@@ -28,6 +28,7 @@ import org.jetbrains.kotlin.ir.ObsoleteDescriptorBasedAPI
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.declarations.IrDeclaration
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationContainer
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
 import org.jetbrains.kotlin.ir.declarations.IrFunction
 import org.jetbrains.kotlin.ir.expressions.IrConst
 import org.jetbrains.kotlin.ir.expressions.IrExpression
@@ -175,6 +176,10 @@ internal interface DecoyTransformBase {
         idSignature: IdSignature
     ): IrSymbol = resolveBySignatureInModule(idSignature, FUNCTION_SYMBOL, moduleDescriptor.name)
 }
+
+@OptIn(ObsoleteDescriptorBasedAPI::class)
+fun IrDeclaration.isExternalDecoyImplStub(): Boolean =
+    origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB && isDecoyImplementation()
 
 @OptIn(ObsoleteDescriptorBasedAPI::class)
 fun IrDeclaration.isDecoy(): Boolean =


### PR DESCRIPTION
- Updates function copy mechanisms used in iOS to match descriptors for KLIB compilation.
- Use decoys on K/N iOS target to fix deserialization error in link phase.

Test: `cd frameworks/support/ && ./gradlew :compose:integration-tests:demos:installDebug`


