### PR TITLE
Added a flag to disable dismissal of ModalBottomSheetLayout

### DIFF
--- a/compose/material/material/samples/src/main/java/androidx/compose/material/samples/ModalBottomSheetSamples.kt
+++ b/compose/material/material/samples/src/main/java/androidx/compose/material/samples/ModalBottomSheetSamples.kt
@@ -61,6 +61,7 @@ fun ModalBottomSheetSample() {
     val scope = rememberCoroutineScope()
     ModalBottomSheetLayout(
         sheetState = state,
+        sheetGesturesEnabled = false,
         sheetContent = {
             LazyColumn {
                 items(50) {

--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/ModalBottomSheet.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/ModalBottomSheet.kt
@@ -306,6 +306,7 @@ fun rememberModalBottomSheetState(
  * bottom sheet is visible. If the color passed is [Color.Unspecified], then a scrim will no
  * longer be applied and the bottom sheet will not block interaction with the rest of the screen
  * when visible.
+ * @param sheetGesturesEnabled Whether the bottom sheet can be interacted with by gestures.
  * @param content The content of rest of the screen.
  */
 @Composable
@@ -320,6 +321,7 @@ fun ModalBottomSheetLayout(
     sheetBackgroundColor: Color = MaterialTheme.colors.surface,
     sheetContentColor: Color = contentColorFor(sheetBackgroundColor),
     scrimColor: Color = ModalBottomSheetDefaults.scrimColor,
+    sheetGesturesEnabled: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val scope = rememberCoroutineScope()
@@ -331,7 +333,7 @@ fun ModalBottomSheetLayout(
             Scrim(
                 color = scrimColor,
                 onDismiss = {
-                    if (sheetState.confirmStateChange(Hidden)) {
+                    if (sheetGesturesEnabled && sheetState.confirmStateChange(Hidden)) {
                         scope.launch { sheetState.hide() }
                     }
                 },


### PR DESCRIPTION
## Proposed Changes

Added a flag to disable dismissal of `ModalBottomSheetLayout` by touching outside of the sheet.

## Testing

Test: Opened a bottom sheet and on clicking anywhere on the screen apart from the bottom sheet itself, does not dismisses the bottom sheet if the flag `sheetGesturesEnabled` is set as false.

## Issues Fixed

Fixes: [Provide a method to make the bottom sheet non-cancellable for some use-cases. #730](https://github.com/google/accompanist/issues/730)