### PR TITLE
Remove redundant NDK instructions for Github

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -33,6 +33,8 @@ runs:
       uses: actions/setup-java@v1
       with:
         java-version: "11"
+    # TODO b/216535050: Implement task to install the exact AndroidX ndk
+    # version in case it is not available.
     - name: "Install Cmake"
       shell: bash
       run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1" --channel=3
@@ -41,9 +43,6 @@ runs:
       run: |
         set -x
         echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-        # TODO b/216535050: Implement task to install the exact AndroidX ndk
-        # version in case it is not available.
-        echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/23.1.7779620" >> $GITHUB_ENV
 
     - name: "Setup Gradle"
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -58,7 +58,6 @@ jobs:
         run: |
           set -x
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
-          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
 
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,9 +55,6 @@ creating a fork of the [androidx/androidx](https://github.com/androidx/androidx)
   sdkmanager --install "ndk;23.1.7779620"
   sdkmanager --install "cmake;3.22.1" --channel=3 #channel 3 is the canary channel
   ```
-  
-  Either way, note the installation directory. This will typically be inside your Android SDK
-  directory as `/ndk/23.1.7779620`.
 
 - Next, set up the following environment variables:
 
@@ -65,7 +62,6 @@ creating a fork of the [androidx/androidx](https://github.com/androidx/androidx)
   # You could also add this to your .{bash|zsh}rc file.
   export JAVA_HOME="location of JDK 11 directory"
   export ANDROID_SDK_ROOT="location of the Android SDK directory"
-  export ANDROID_NDK_ROOT="location of the Android NDK directory containing version 23.1.7779620"
   ```
 
 ### Checkout and importing a project


### PR DESCRIPTION
We no longer set ndkPath explicitly in AndroidxPlugin, which allows AGP
to naturally discover the ndk path based on ANDROID_SDK_ROOT, so we no
longer need to undo the override using ANDROID_NDK_ROOT.

Bug: 229631212
Test: cd work && ./gradlew bOS
Change-Id: I9e61af8f482b87c5567ee711115020839645256e
