### PR TITLE
add sha for the gradle build

### DIFF
--- a/playground-common/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-common/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220427150934+0000-bin.zip
+distributionSha256Sum=a6fac7a8a7d78152605317f2bcffb219076be7c5f3fccb3cf2b27aeade50e0a3
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bug: n/a
Test: locally cleaned .gradle and verified bad sha fails
