### PR TITLE
Remove duplicated flags from UiMode

### DIFF
--- a/compose/ui/ui-tooling-preview/src/androidMain/kotlin/androidx/compose/ui/tooling/preview/UiMode.kt
+++ b/compose/ui/ui-tooling-preview/src/androidMain/kotlin/androidx/compose/ui/tooling/preview/UiMode.kt
@@ -42,8 +42,6 @@ import androidx.annotation.IntDef
     value = [
         UI_MODE_TYPE_MASK,
         UI_MODE_TYPE_UNDEFINED,
-        UI_MODE_NIGHT_NO,
-        UI_MODE_NIGHT_YES,
         UI_MODE_TYPE_APPLIANCE,
         UI_MODE_TYPE_CAR,
         UI_MODE_TYPE_DESK,


### PR DESCRIPTION
## Proposed Changes

  - The `UI_MODE_NIGHT_NO` and `UI_MODE_NIGHT_YES` flags appear twice in `androidx.compose.ui.tooling.preview.UiMode`, but that's unnecessary.

## Testing

Test: not necessary, no functional changes

## Issues Fixed

Just a tiny bit of duplication in an `@IntDef`.
