### PR TITLE
Move playground back to gradle-7.5-20220421031748+0000

### DIFF
--- a/playground-common/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-common/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220421031748+0000-bin.zip
-distributionSha256Sum=f5f7fa2508b23a18484f84e6ad6e2de25e1822e7f654ea9177858caa0f629d5a
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/playground-common/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-common/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220427150934+0000-bin.zip
-distributionSha256Sum=a6fac7a8a7d78152605317f2bcffb219076be7c5f3fccb3cf2b27aeade50e0a3
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-7.5-20220421031748+0000-bin.zip
+distributionSha256Sum=f5f7fa2508b23a18484f84e6ad6e2de25e1822e7f654ea9177858caa0f629d5a
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
gradle-7.5-20220427150934+0000 seems to hit https://github.com/gradle/gradle/issues/20254
and we cannot move to the RC, so going back to the good old build that used to work.

Bug: n/a
Test: CI