### PR TITLE
Fix ViewportHints sent to wrong generation

### DIFF
--- a/paging/paging-common/src/main/kotlin/androidx/paging/CachedPagingData.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/CachedPagingData.kt
@@ -52,7 +52,8 @@ private class MulticastedPagingData<T : Any>(
         }.onCompletion {
             tracker?.onComplete(PAGE_EVENT_FLOW)
         },
-        receiver = parent.receiver
+        uiReceiver = parent.uiReceiver,
+        hintReceiver = parent.hintReceiver
     )
 
     suspend fun close() = accumulated.close()

--- a/paging/paging-common/src/main/kotlin/androidx/paging/HintReceiver.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/HintReceiver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Android Open Source Project
+ * Copyright 2022 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,8 @@
 package androidx.paging
 
 /**
- * Fetcher-side callbacks for presenter-side refresh/retry events communicated through [PagingData].
+ * Fetcher-side callbacks for presenter-side access events communicated through [PagingData].
  */
-internal interface UiReceiver {
-    fun retry()
-    fun refresh()
+internal interface HintReceiver {
+    fun accessHint(viewportHint: ViewportHint)
 }

--- a/paging/paging-common/src/main/kotlin/androidx/paging/PagingData.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/PagingData.kt
@@ -27,15 +27,18 @@ import kotlinx.coroutines.flow.flowOf
  */
 public class PagingData<T : Any> internal constructor(
     internal val flow: Flow<PageEvent<T>>,
-    internal val receiver: UiReceiver
+    internal val uiReceiver: UiReceiver,
+    internal val hintReceiver: HintReceiver
 ) {
     public companion object {
-        internal val NOOP_RECEIVER = object : UiReceiver {
-            override fun accessHint(viewportHint: ViewportHint) {}
-
+        internal val NOOP_UI_RECEIVER = object : UiReceiver {
             override fun retry() {}
 
             override fun refresh() {}
+        }
+
+        internal val NOOP_HINT_RECEIVER = object : HintReceiver {
+            override fun accessHint(viewportHint: ViewportHint) {}
         }
 
         /**
@@ -53,7 +56,8 @@ public class PagingData<T : Any> internal constructor(
                     mediatorLoadStates = null,
                 )
             ),
-            receiver = NOOP_RECEIVER
+            uiReceiver = NOOP_UI_RECEIVER,
+            hintReceiver = NOOP_HINT_RECEIVER,
         )
 
         /**
@@ -79,7 +83,8 @@ public class PagingData<T : Any> internal constructor(
                     mediatorLoadStates = mediatorLoadStates,
                 )
             ),
-            receiver = NOOP_RECEIVER
+            uiReceiver = NOOP_UI_RECEIVER,
+            hintReceiver = NOOP_HINT_RECEIVER,
         )
 
         /**
@@ -100,7 +105,8 @@ public class PagingData<T : Any> internal constructor(
                     mediatorLoadStates = null,
                 )
             ),
-            receiver = NOOP_RECEIVER
+            uiReceiver = NOOP_UI_RECEIVER,
+            hintReceiver = NOOP_HINT_RECEIVER,
         )
 
         /**
@@ -127,7 +133,8 @@ public class PagingData<T : Any> internal constructor(
                     mediatorLoadStates = mediatorLoadStates,
                 )
             ),
-            receiver = NOOP_RECEIVER
+            uiReceiver = NOOP_UI_RECEIVER,
+            hintReceiver = NOOP_HINT_RECEIVER,
         )
     }
 }

--- a/paging/paging-common/src/main/kotlin/androidx/paging/PagingDataDiffer.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/PagingDataDiffer.kt
@@ -43,7 +43,8 @@ public abstract class PagingDataDiffer<T : Any>(
     private val mainContext: CoroutineContext = Dispatchers.Main
 ) {
     private var presenter: PagePresenter<T> = PagePresenter.initial()
-    private var receiver: UiReceiver? = null
+    private var hintReceiver: HintReceiver? = null
+    private var uiReceiver: UiReceiver? = null
     private val combinedLoadStatesCollection = MutableCombinedLoadStateCollection()
     private val onPagesUpdatedListeners = CopyOnWriteArrayList<() -> Unit>()
 
@@ -139,10 +140,24 @@ public abstract class PagingDataDiffer<T : Any>(
 
     public suspend fun collectFrom(pagingData: PagingData<T>) {
         collectFromRunner.runInIsolation {
-            receiver = pagingData.receiver
-
+            uiReceiver = pagingData.uiReceiver
             pagingData.flow.collect { event ->
                 withContext(mainContext) {
+                    /**
+                     * The hint receiver of a new generation is set only after it has been
+                     * presented. This ensures that:
+                     *
+                     * 1. while new generation is still loading, access hints (and jump hints) will
+                     * be sent to current generation.
+                     *
+                     * 2. the access hint sent from presentNewList will have the correct
+                     * placeholders and indexInPage adjusted according to new presenter's most
+                     * recent state
+                     *
+                     * Ensuring that viewport hints are sent to the correct generation helps
+                     * synchronize fetcher/presenter in the correct calculation of the
+                     * next anchorPosition.
+                     */
                     if (event is Insert && event.loadType == REFRESH) {
                         presentNewList(
                             pages = event.pages,
@@ -151,6 +166,7 @@ public abstract class PagingDataDiffer<T : Any>(
                             dispatchLoadStates = true,
                             sourceLoadStates = event.sourceLoadStates,
                             mediatorLoadStates = event.mediatorLoadStates,
+                            newHintReceiver = pagingData.hintReceiver
                         )
                     } else if (event is StaticList) {
                         presentNewList(
@@ -166,6 +182,7 @@ public abstract class PagingDataDiffer<T : Any>(
                                 event.mediatorLoadStates != null,
                             sourceLoadStates = event.sourceLoadStates,
                             mediatorLoadStates = event.mediatorLoadStates,
+                            newHintReceiver = pagingData.hintReceiver
                         )
                     } else {
                         if (postEvents()) {
@@ -212,7 +229,7 @@ public abstract class PagingDataDiffer<T : Any>(
                                     presenter.storageCount
 
                                 if (shouldResendHint) {
-                                    receiver?.accessHint(
+                                    hintReceiver?.accessHint(
                                         presenter.accessHintForPresenterIndex(lastAccessedIndex)
                                     )
                                 } else {
@@ -247,7 +264,7 @@ public abstract class PagingDataDiffer<T : Any>(
         lastAccessedIndexUnfulfilled = true
         lastAccessedIndex = index
 
-        receiver?.accessHint(presenter.accessHintForPresenterIndex(index))
+        hintReceiver?.accessHint(presenter.accessHintForPresenterIndex(index))
         return presenter.get(index)
     }
 
@@ -280,7 +297,7 @@ public abstract class PagingDataDiffer<T : Any>(
      *  * [RemoteMediator.load] returning [RemoteMediator.MediatorResult.Error]
      */
     public fun retry() {
-        receiver?.retry()
+        uiReceiver?.retry()
     }
 
     /**
@@ -300,7 +317,7 @@ public abstract class PagingDataDiffer<T : Any>(
      * @sample androidx.paging.samples.refreshSample
      */
     public fun refresh() {
-        receiver?.refresh()
+        uiReceiver?.refresh()
     }
 
     /**
@@ -420,6 +437,7 @@ public abstract class PagingDataDiffer<T : Any>(
         dispatchLoadStates: Boolean,
         sourceLoadStates: LoadStates?,
         mediatorLoadStates: LoadStates?,
+        newHintReceiver: HintReceiver,
     ) {
         require(!dispatchLoadStates || sourceLoadStates != null) {
             "Cannot dispatch LoadStates in PagingDataDiffer without source LoadStates set."
@@ -440,6 +458,7 @@ public abstract class PagingDataDiffer<T : Any>(
             onListPresentable = {
                 presenter = newPresenter
                 onListPresentableCalled = true
+                hintReceiver = newHintReceiver
             }
         )
         check(onListPresentableCalled) {
@@ -461,7 +480,7 @@ public abstract class PagingDataDiffer<T : Any>(
             // Send an initialize hint in case the new list is empty, which would
             // prevent a ViewportHint.Access from ever getting sent since there are
             // no items to bind from initial load.
-            receiver?.accessHint(newPresenter.initializeHint())
+            hintReceiver?.accessHint(newPresenter.initializeHint())
         } else {
             // Transform the last loadAround index from the old list to the new list
             // by passing it through the DiffResult, and pass it forward as a
@@ -471,7 +490,7 @@ public abstract class PagingDataDiffer<T : Any>(
             // the prepend / append load that would have fulfilled it in the old
             // list.
             lastAccessedIndex = transformedLastAccessedIndex
-            receiver?.accessHint(
+            hintReceiver?.accessHint(
                 newPresenter.accessHintForPresenterIndex(
                     transformedLastAccessedIndex
                 )

--- a/paging/paging-common/src/main/kotlin/androidx/paging/PagingDataTransforms.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/PagingDataTransforms.kt
@@ -29,7 +29,8 @@ private inline fun <T : Any, R : Any> PagingData<T>.transform(
     crossinline transform: suspend (PageEvent<T>) -> PageEvent<R>
 ) = PagingData(
     flow = flow.map { transform(it) },
-    receiver = receiver
+    uiReceiver = uiReceiver,
+    hintReceiver = hintReceiver,
 )
 
 /**
@@ -143,7 +144,8 @@ public fun <T : R, R : Any> PagingData<T>.insertSeparators(
     //     class SeparatorModel: UiModel
     return PagingData(
         flow = flow.insertEventSeparators(terminalSeparatorType, generator),
-        receiver = receiver
+        uiReceiver = uiReceiver,
+        hintReceiver = hintReceiver
     )
 }
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
@@ -123,7 +122,7 @@ public class CachedPageEventFlowLeakTest {
                                 // invalidate only once per generation to avoid
                                 // delayed invalidates
                                 invalidated = true
-                                pagingData.receiver.refresh()
+                                pagingData.uiReceiver.refresh()
                             }
                         } else {
                             doneInvalidating?.complete(Unit)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
@@ -421,7 +421,7 @@ class CachingTest {
     private val PagingData<Item>.version
         get(): Int {
             return (
-                (receiver as PageFetcher<*, *>.PagerUiReceiver<*, *>)
+                (hintReceiver as PageFetcher<*, *>.PagerHintReceiver<*, *>)
                     .pageFetcherSnapshot.pagingSource as StringPagingSource
                 ).version
         }
@@ -435,7 +435,7 @@ class CachingTest {
                 val expectedVersion = pagingData.version
                 val items = mutableListOf<Item>()
                 yield() // this yield helps w/ cancellation wrt mapLatest
-                val receiver = pagingData.receiver
+                val receiver = pagingData.hintReceiver
                 var loadedPageCount = 0
                 pagingData.flow.filterIsInstance<PageEvent.Insert<Item>>()
                     .onEach {
@@ -504,7 +504,7 @@ class CachingTest {
 
         private suspend fun collectPassively() {
             source.collect {
-                receivedPagingDataCount ++
+                receivedPagingDataCount++
                 // clear to latest
                 val list = mutableListOf<Item>()
                 items = list

--- a/paging/paging-common/src/test/kotlin/androidx/paging/HeaderFooterTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/HeaderFooterTest.kt
@@ -42,7 +42,8 @@ class HeaderFooterTest {
 
     private fun <T : Any> PageEvent<T>.toPagingData() = PagingData(
         flowOf(this),
-        PagingData.NOOP_RECEIVER
+        PagingData.NOOP_UI_RECEIVER,
+        PagingData.NOOP_HINT_RECEIVER
     )
 
     private suspend fun <T : Any> PageEvent<T>.insertHeaderItem(item: T) = toPagingData()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
@@ -324,7 +324,7 @@ class LegacyPagingSourceTest {
                 pagingData.flow.filter {
                     it is PageEvent.Insert
                 }.first()
-                pagingData.receiver.refresh()
+                pagingData.uiReceiver.refresh()
             }
         }
         // validate method calls (to ensure test did run as expected) and their threads.

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -102,7 +102,7 @@ class PageFetcherSnapshotTest {
             createRefresh(1..2)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -136,7 +136,7 @@ class PageFetcherSnapshotTest {
             createRefresh(1..2)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -156,7 +156,7 @@ class PageFetcherSnapshotTest {
             )
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -200,7 +200,7 @@ class PageFetcherSnapshotTest {
             createRefresh(range = 97..98)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -231,7 +231,7 @@ class PageFetcherSnapshotTest {
 
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -252,7 +252,7 @@ class PageFetcherSnapshotTest {
             )
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -343,7 +343,7 @@ class PageFetcherSnapshotTest {
         val pageFetcher = PageFetcher(pagingSourceFactory, 50, config)
         val fetcherState = collectFetcherState(pageFetcher)
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -376,7 +376,7 @@ class PageFetcherSnapshotTest {
             createRefresh(range = 50..51)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -416,7 +416,7 @@ class PageFetcherSnapshotTest {
                 createRefresh(range = 50..51)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 0,
@@ -433,7 +433,7 @@ class PageFetcherSnapshotTest {
                 createPrepend(pageOffset = -1, range = 48..49)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = -1,
                     indexInPage = 0,
@@ -482,7 +482,7 @@ class PageFetcherSnapshotTest {
                 createRefresh(range = 50..54)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 0,
@@ -529,7 +529,7 @@ class PageFetcherSnapshotTest {
                 createRefresh(range = 50..51)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 0,
@@ -545,7 +545,7 @@ class PageFetcherSnapshotTest {
                 createPrepend(pageOffset = -1, range = 48..49)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = -1,
                     indexInPage = 0,
@@ -557,7 +557,7 @@ class PageFetcherSnapshotTest {
             )
             // Start hint processing until load starts, but hasn't finished.
             advanceTimeBy(500)
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 1,
@@ -605,7 +605,7 @@ class PageFetcherSnapshotTest {
             createRefresh(50..52)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -644,7 +644,7 @@ class PageFetcherSnapshotTest {
         )
 
         // PREPEND a few pages.
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -662,7 +662,7 @@ class PageFetcherSnapshotTest {
         )
 
         // APPEND a few pages causing PREPEND pages to drop
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 2,
@@ -692,7 +692,7 @@ class PageFetcherSnapshotTest {
         )
 
         // PREPEND a page, this hint would normally be ignored, but has a newer generationId.
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -735,7 +735,7 @@ class PageFetcherSnapshotTest {
             createRefresh(0..9, startState = NotLoading.Complete)
         )
         withContext(coroutineContext) {
-            val receiver = fetcherState.pagingDataList[0].receiver
+            val receiver = fetcherState.pagingDataList[0].hintReceiver
             // send a bunch of access hints while collection is paused
             (0..9).forEach { pos ->
                 receiver.accessHint(
@@ -779,7 +779,7 @@ class PageFetcherSnapshotTest {
             createRefresh(50..51)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -816,7 +816,7 @@ class PageFetcherSnapshotTest {
             createRefresh(50..52)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 2,
@@ -859,7 +859,7 @@ class PageFetcherSnapshotTest {
             createRefresh(range = 50..51)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -875,7 +875,7 @@ class PageFetcherSnapshotTest {
             createAppend(pageOffset = 1, range = 52..53)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 1,
                 indexInPage = 1,
@@ -922,7 +922,7 @@ class PageFetcherSnapshotTest {
                 createRefresh(range = 50..54)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 4,
@@ -966,7 +966,7 @@ class PageFetcherSnapshotTest {
                 createRefresh(range = 50..51)
             )
 
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 1,
@@ -983,7 +983,7 @@ class PageFetcherSnapshotTest {
             )
 
             // Start hint processing until load starts, but hasn't finished.
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 1,
                     indexInPage = 1,
@@ -994,7 +994,7 @@ class PageFetcherSnapshotTest {
                 )
             )
             advanceTimeBy(500)
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 0,
@@ -1048,7 +1048,7 @@ class PageFetcherSnapshotTest {
         )
 
         // APPEND a few pages.
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 2,
@@ -1066,7 +1066,7 @@ class PageFetcherSnapshotTest {
         )
 
         // PREPEND a few pages causing APPEND pages to drop
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -1096,7 +1096,7 @@ class PageFetcherSnapshotTest {
         )
 
         // APPEND a page, this hint would normally be ignored, but has a newer generationId.
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -1156,7 +1156,7 @@ class PageFetcherSnapshotTest {
             createRefresh(50..51)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -1752,7 +1752,7 @@ class PageFetcherSnapshotTest {
             localLoadStateUpdate<Int>(refreshLocal = Loading),
             localRefresh(createRefresh(range = 50..51).pages)
         )
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 0,
@@ -1789,7 +1789,7 @@ class PageFetcherSnapshotTest {
             localRefresh(createRefresh(range = 50..51).pages)
         )
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -1825,7 +1825,7 @@ class PageFetcherSnapshotTest {
             localLoadStateUpdate<Int>(refreshLocal = Loading),
             createRefresh(range = 50..52)
         )
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 2,
@@ -2079,7 +2079,7 @@ class PageFetcherSnapshotTest {
         // Send a hint from a presenter state that only sees pages well after the pages loaded in
         // fetcher state:
         // [hint], [50, 51], [52], [53], [54], [55]
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 4,
                 indexInPage = -6,
@@ -2119,7 +2119,7 @@ class PageFetcherSnapshotTest {
         // Send a hint from a presenter state that only sees pages well before the pages loaded in
         // fetcher state:
         // [46], [47], [48], [49], [50, 51], [hint]
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = -4,
                 indexInPage = 6,
@@ -2497,7 +2497,8 @@ class PageFetcherSnapshotTest {
         state.job.cancel()
     }
 
-    @Suppress("DEPRECATION") // b/220884819
+    @Suppress("DEPRECATION")
+    // b/220884819
     @Test
     fun remoteMediator_endOfPaginationNotReachedLoadStatePrepend() = runBlockingTest {
         val remoteMediator = object : RemoteMediatorMock() {
@@ -2702,7 +2703,8 @@ class PageFetcherSnapshotTest {
         }
     }
 
-    @Suppress("DEPRECATION") // b/220884819
+    @Suppress("DEPRECATION")
+    // b/220884819
     @Test
     fun remoteMediator_endOfPaginationNotReachedLoadStateAppend() = runBlockingTest {
         val remoteMediator = object : RemoteMediatorMock() {
@@ -3684,7 +3686,8 @@ class PageFetcherSnapshotTest {
         coroutineScope {
             val collectionJob = launch(start = CoroutineStart.LAZY) {
                 flow.flatMapLatest { data ->
-                    collectionScope.uiReceiver = data.receiver
+                    collectionScope.uiReceiver = data.uiReceiver
+                    collectionScope.hintReceiver = data.hintReceiver
                     val generationEvents = mutableListOf<PageEvent<T>>().also {
                         eventsByGeneration.add(it)
                     }
@@ -3729,9 +3732,10 @@ class PageFetcherSnapshotTest {
         val generationCount: StateFlow<Int>
         val eventsByGeneration: List<List<PageEvent<T>>>
         val uiReceiver: UiReceiver?
+        val hintReceiver: HintReceiver?
         suspend fun stop()
         fun accessHint(viewportHint: ViewportHint) {
-            uiReceiver!!.accessHint(viewportHint)
+            hintReceiver!!.accessHint(viewportHint)
         }
 
         fun retry() {
@@ -3754,7 +3758,8 @@ class PageFetcherSnapshotTest {
         override val eventCount: MutableStateFlow<Int> = MutableStateFlow(0),
         override val generationCount: MutableStateFlow<Int> = MutableStateFlow(0),
         override val eventsByGeneration: MutableList<List<PageEvent<T>>> = mutableListOf(),
-        override var uiReceiver: UiReceiver? = null
+        override var uiReceiver: UiReceiver? = null,
+        override var hintReceiver: HintReceiver? = null,
     ) : MultiGenerationCollectionScope<T> {
         val stopped = CompletableDeferred<Unit>()
         override suspend fun stop() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherTest.kt
@@ -263,7 +263,7 @@ class PageFetcherTest {
             )
 
             // append a page
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 1,
@@ -315,7 +315,7 @@ class PageFetcherTest {
                 createRefresh(50..51),
             )
             // prepend a page
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = -1,
@@ -536,7 +536,7 @@ class PageFetcherTest {
         // Assert onBoundary is not called for non-terminal page load.
         assertTrue { remoteMediatorMock.loadEvents.isEmpty() }
 
-        fetcherState.pagingDataList[0].receiver.accessHint(
+        fetcherState.pagingDataList[0].hintReceiver.accessHint(
             ViewportHint.Access(
                 pageOffset = 0,
                 indexInPage = 1,
@@ -583,7 +583,7 @@ class PageFetcherTest {
             )
 
             // Jump due to sufficiently large presentedItemsBefore
-            fetcherState.pagingDataList[0].receiver.accessHint(
+            fetcherState.pagingDataList[0].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     // indexInPage value is incorrect, but should not be considered for jumps
@@ -606,7 +606,7 @@ class PageFetcherTest {
             )
 
             // Jump due to sufficiently large presentedItemsAfter
-            fetcherState.pagingDataList[1].receiver.accessHint(
+            fetcherState.pagingDataList[1].hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     // indexInPage value is incorrect, but should not be considered for jumps
@@ -771,10 +771,10 @@ class PageFetcherTest {
             remoteMediator = remoteMediator,
         )
 
-        var receiver: UiReceiver? = null
+        var receiver: HintReceiver? = null
         val job = launch {
             pageFetcher.flow.collectLatest {
-                receiver = it.receiver
+                receiver = it.hintReceiver
                 it.flow.collect { }
             }
         }
@@ -874,10 +874,10 @@ class PageFetcherTest {
             remoteMediator = remoteMediator,
         )
 
-        var receiver: UiReceiver? = null
+        var receiver: HintReceiver? = null
         val job = launch {
             pageFetcher.flow.collectLatest {
-                receiver = it.receiver
+                receiver = it.hintReceiver
                 it.flow.collect { }
             }
         }
@@ -1022,7 +1022,7 @@ class PageFetcherTest {
             advanceUntilIdle()
 
             // Trigger access to allow PagingState to get populated for next generation.
-            pagingData.receiver.accessHint(
+            pagingData.hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 1,
@@ -1080,7 +1080,7 @@ class PageFetcherTest {
 
             advanceUntilIdle()
             // Trigger APPEND in third generation.
-            pagingData.receiver.accessHint(
+            pagingData.hintReceiver.accessHint(
                 ViewportHint.Access(
                     pageOffset = 0,
                     indexInPage = 2,
@@ -1263,7 +1263,8 @@ class PageFetcherTest {
         fetcherState.job.cancel()
     }
 
-    @Suppress("DEPRECATION") // b/220884819
+    @Suppress("DEPRECATION")
+    // b/220884819
     @Test
     fun injectRemoteEvents_remoteLoadAcrossGenerations() = runBlockingTest {
         val neverEmitCh = Channel<Int>()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.TestScope
@@ -141,7 +142,6 @@ class PagingDataDifferTest(
         }
 
         differ.retry()
-
         assertEquals(1, receiver.retryEvents.size)
 
         job.cancel()
@@ -161,6 +161,342 @@ class PagingDataDifferTest(
         assertEquals(1, receiver.refreshEvents.size)
 
         job.cancel()
+    }
+
+    @Test
+    fun uiReceiverSetImmediately() = testScope.runTest {
+        val differ = SimpleDiffer(differCallback = dummyDifferCallback)
+        val receiver = UiReceiverFake()
+        val pagingData1 = infinitelySuspendingPagingData(uiReceiver = receiver)
+
+        val job1 = launch {
+            differ.collectFrom(pagingData1)
+        }
+        assertTrue(job1.isActive) // ensure job started
+
+        assertThat(receiver.refreshEvents).hasSize(0)
+
+        differ.refresh()
+        // double check that the pagingdata's receiver was registered and had received refresh call
+        // before any PageEvent is collected/presented
+        assertThat(receiver.refreshEvents).hasSize(1)
+
+        job1.cancel()
+    }
+
+    @Test
+    fun hintReceiverSetAfterNewListPresented() = testScope.runTest {
+        val differ = SimpleDiffer(differCallback = dummyDifferCallback)
+
+        // first generation, load something so next gen can access index to trigger hint
+        val hintReceiver1 = HintReceiverFake()
+        val flow = flowOf(
+            localRefresh(pages = listOf(TransformablePage(listOf(0, 1, 2, 3, 4)))),
+        )
+
+        val job1 = launch {
+            differ.collectFrom(PagingData(flow, dummyUiReceiver, hintReceiver1))
+        }
+        assertThat(hintReceiver1.hints).hasSize(1) // initial hint
+
+        // trigger second generation
+        differ.refresh()
+
+        // second generation
+        val pageEventCh = Channel<PageEvent<Int>>(Channel.UNLIMITED)
+        val hintReceiver2 = HintReceiverFake()
+        val job2 = launch {
+            differ.collectFrom(
+                PagingData(pageEventCh.consumeAsFlow(), dummyUiReceiver, hintReceiver2)
+            )
+        }
+
+        // we send the initial load state. this should NOT cause second gen hint receiver
+        // to register
+        pageEventCh.trySend(
+            localLoadStateUpdate(refreshLocal = Loading)
+        )
+        assertThat(differ.loadStateFlow.first()).isEqualTo(
+            localLoadStatesOf(refreshLocal = Loading)
+        )
+
+        // ensure both hint receivers are idle before sending a hint
+        assertThat(hintReceiver1.hints).isEmpty()
+        assertThat(hintReceiver2.hints).isEmpty()
+
+        // try sending a hint, should be sent to first receiver
+        differ[4]
+        assertThat(hintReceiver1.hints).hasSize(1)
+        assertThat(hintReceiver2.hints).isEmpty()
+
+        // now we send actual refresh load and make sure its presented
+        pageEventCh.trySend(
+            localRefresh(
+                pages = listOf(TransformablePage(listOf(20, 21, 22, 23, 24))),
+                placeholdersBefore = 20,
+                placeholdersAfter = 75
+            ),
+        )
+        assertThat(differ.snapshot().items).containsExactlyElementsIn(20 until 25)
+
+        // second receiver was registered and received the initial viewport hint
+        assertThat(hintReceiver1.hints).isEmpty()
+        assertThat(hintReceiver2.hints).isEqualTo(
+            listOf(
+                ViewportHint.Initial(
+                    presentedItemsBefore = 2,
+                    presentedItemsAfter = 2,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                )
+            )
+        )
+
+        job2.cancel()
+        job1.cancel()
+    }
+
+    @Test
+    fun refreshOnLatestGenerationReceiver() = runTest { differ, loadDispatcher, _,
+        uiReceivers, hintReceivers ->
+        // first gen
+        loadDispatcher.executeAll()
+        assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
+
+        // append a page so we can cache an anchorPosition of [8]
+        differ[8]
+        loadDispatcher.executeAll()
+
+        assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
+
+        // trigger gen 2, the refresh signal should to sent to gen 1
+        differ.refresh()
+        assertThat(uiReceivers[0].refreshEvents).hasSize(1)
+        assertThat(uiReceivers[1].refreshEvents).hasSize(0)
+
+        // trigger gen 3, refresh signal should be sent to gen 2
+        differ.refresh()
+        assertThat(uiReceivers[0].refreshEvents).hasSize(1)
+        assertThat(uiReceivers[1].refreshEvents).hasSize(1)
+        loadDispatcher.executeAll()
+
+        assertThat(differ.snapshot()).containsExactlyElementsIn(8 until 17)
+
+        // gen 3 receiver should be recipient of the initial hint
+        assertThat(hintReceivers[2].hints).containsExactlyElementsIn(
+            listOf(
+                ViewportHint.Initial(
+                    presentedItemsBefore = 4,
+                    presentedItemsAfter = 4,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun retryOnLatestGenerationReceiver() = runTest { differ, loadDispatcher, pagingSources,
+        uiReceivers, hintReceivers ->
+
+        // first gen
+        loadDispatcher.executeAll()
+        assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
+
+        // append a page so we can cache an anchorPosition of [8]
+        differ[8]
+        loadDispatcher.executeAll()
+
+        assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
+
+        // trigger gen 2, the refresh signal should be sent to gen 1
+        differ.refresh()
+        assertThat(uiReceivers[0].refreshEvents).hasSize(1)
+        assertThat(uiReceivers[1].refreshEvents).hasSize(0)
+
+        // to recreate a real use-case of retry based on load error
+        pagingSources[1].errorNextLoad = true
+        loadDispatcher.executeAll()
+        // differ should still have first gen presenter
+        assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
+
+        // retry should be sent to gen 2 even though it wasn't presented
+        differ.retry()
+        assertThat(uiReceivers[0].retryEvents).hasSize(0)
+        assertThat(uiReceivers[1].retryEvents).hasSize(1)
+        loadDispatcher.executeAll()
+
+        // will retry with the correct cached hint
+        assertThat(differ.snapshot()).containsExactlyElementsIn(8 until 17)
+
+        // gen 2 receiver was recipient of the initial hint
+        assertThat(hintReceivers[1].hints).containsExactlyElementsIn(
+            listOf(
+                ViewportHint.Initial(
+                    presentedItemsBefore = 4,
+                    presentedItemsAfter = 4,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun refreshAfterStaticList() = testScope.runTest {
+        val differ = SimpleDiffer(dummyDifferCallback)
+
+        val pagingData1 = PagingData.from(listOf(1, 2, 3))
+        val job1 = launch { differ.collectFrom(pagingData1) }
+        assertTrue(job1.isCompleted)
+        assertThat(differ.snapshot()).containsAtLeastElementsIn(listOf(1, 2, 3))
+
+        val uiReceiver = UiReceiverFake()
+        val pagingData2 = infinitelySuspendingPagingData(uiReceiver = uiReceiver)
+        val job2 = launch { differ.collectFrom(pagingData2) }
+        assertTrue(job2.isActive)
+
+        // even though the second paging data never presented, it should be receiver of the refresh
+        differ.refresh()
+        assertThat(uiReceiver.refreshEvents).hasSize(1)
+
+        job2.cancel()
+    }
+
+    @Test
+    fun retryAfterStaticList() = testScope.runTest {
+        val differ = SimpleDiffer(dummyDifferCallback)
+
+        val pagingData1 = PagingData.from(listOf(1, 2, 3))
+        val job1 = launch { differ.collectFrom(pagingData1) }
+        assertTrue(job1.isCompleted)
+        assertThat(differ.snapshot()).containsAtLeastElementsIn(listOf(1, 2, 3))
+
+        val uiReceiver = UiReceiverFake()
+        val pagingData2 = infinitelySuspendingPagingData(uiReceiver = uiReceiver)
+        val job2 = launch { differ.collectFrom(pagingData2) }
+        assertTrue(job2.isActive)
+
+        // even though the second paging data never presented, it should be receiver of the retry
+        differ.retry()
+        assertThat(uiReceiver.retryEvents).hasSize(1)
+
+        job2.cancel()
+    }
+
+    @Test
+    fun hintCalculationBasedOnCurrentGeneration() = testScope.runTest {
+        val differ = SimpleDiffer(differCallback = dummyDifferCallback)
+
+        // first generation
+        val hintReceiver1 = HintReceiverFake()
+        val uiReceiver1 = UiReceiverFake()
+        val flow = flowOf(
+            localRefresh(
+                pages = listOf(TransformablePage(listOf(0, 1, 2, 3, 4))),
+                placeholdersBefore = 0,
+                placeholdersAfter = 95
+            )
+        )
+
+        val job1 = launch {
+            differ.collectFrom(PagingData(flow, uiReceiver1, hintReceiver1))
+        }
+        assertThat(hintReceiver1.hints).isEqualTo(
+            listOf(
+                ViewportHint.Initial(
+                    presentedItemsBefore = 2,
+                    presentedItemsAfter = 2,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                ),
+            )
+        )
+
+        // jump to another position, triggers invalidation
+        differ[20]
+        assertThat(hintReceiver1.hints).isEqualTo(
+            listOf(
+                ViewportHint.Access(
+                    pageOffset = 0,
+                    indexInPage = 20,
+                    presentedItemsBefore = 20,
+                    presentedItemsAfter = -16,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                ),
+            )
+        )
+
+        // jump invalidation happens
+        differ.refresh()
+        assertThat(uiReceiver1.refreshEvents).hasSize(1)
+
+        // second generation
+        val pageEventCh = Channel<PageEvent<Int>>(Channel.UNLIMITED)
+        val hintReceiver2 = HintReceiverFake()
+        val job2 = launch {
+            differ.collectFrom(
+                PagingData(pageEventCh.consumeAsFlow(), dummyUiReceiver, hintReceiver2)
+            )
+        }
+
+        // jump to another position while second gen is loading. It should be sent to first gen.
+        differ[40]
+        assertThat(hintReceiver1.hints).isEqualTo(
+            listOf(
+                ViewportHint.Access(
+                    pageOffset = 0,
+                    indexInPage = 40,
+                    presentedItemsBefore = 40,
+                    presentedItemsAfter = -36,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                ),
+            )
+        )
+        assertThat(hintReceiver2.hints).isEmpty()
+
+        // gen 2 initial load
+        pageEventCh.trySend(
+            localRefresh(
+                pages = listOf(TransformablePage(listOf(20, 21, 22, 23, 24))),
+                placeholdersBefore = 20,
+                placeholdersAfter = 75
+            ),
+        )
+
+        assertThat(hintReceiver2.hints).isEqualTo(
+            listOf(
+                ViewportHint.Initial(
+                    presentedItemsBefore = 2,
+                    presentedItemsAfter = 2,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                )
+            )
+        )
+
+        // jumping to index 50. Hint.indexInPage should be adjusted accordingly based on
+        // the placeholdersBefore of new presenter. It should be
+        // (index - placeholdersBefore) = 50 - 20 = 30
+        differ[50]
+        assertThat(hintReceiver2.hints).isEqualTo(
+            listOf(
+
+                ViewportHint.Access(
+                    pageOffset = 0,
+                    indexInPage = 30,
+                    presentedItemsBefore = 30,
+                    presentedItemsAfter = -26,
+                    originalPageOffsetFirst = 0,
+                    originalPageOffsetLast = 0,
+                ),
+            )
+        )
+
+        job2.cancel()
+        job1.cancel()
     }
 
     @Test
@@ -188,18 +524,19 @@ class PagingDataDifferTest(
             )
         )
 
-        val receiver = UiReceiverFake()
+        val hintReceiver = HintReceiverFake()
         val job = launch {
             differ.collectFrom(
                 // Filter the original list of 10 items to 5, removing even numbers.
-                PagingData(pageEventCh.consumeAsFlow(), receiver).filter { it % 2 != 0 }
+                PagingData(pageEventCh.consumeAsFlow(), dummyUiReceiver, hintReceiver)
+                    .filter { it % 2 != 0 }
             )
         }
 
         // Initial state:
         // [null, null, [-1], [1], [3], null, null]
         assertNull(differ[0])
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Initial(
                     presentedItemsBefore = 0,
@@ -227,7 +564,7 @@ class PagingDataDifferTest(
                 placeholdersBefore = 2,
             )
         )
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Access(
                     pageOffset = -2,
@@ -249,11 +586,11 @@ class PagingDataDifferTest(
                 source = loadStates(prepend = NotLoading.Complete)
             )
         )
-        assertThat(receiver.hints).isEmpty()
+        assertThat(hintReceiver.hints).isEmpty()
 
         // This index points to a valid placeholder that ends up removed by filter().
         assertNull(differ[5])
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Access(
                     pageOffset = 1,
@@ -275,7 +612,7 @@ class PagingDataDifferTest(
                 source = loadStates(prepend = NotLoading.Complete)
             )
         )
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Access(
                     pageOffset = 2,
@@ -297,7 +634,7 @@ class PagingDataDifferTest(
                 source = loadStates(prepend = NotLoading.Complete, append = NotLoading.Complete)
             )
         )
-        assertThat(receiver.hints).isEmpty()
+        assertThat(hintReceiver.hints).isEmpty()
 
         job.cancel()
     }
@@ -327,18 +664,19 @@ class PagingDataDifferTest(
             )
         )
 
-        val receiver = UiReceiverFake()
+        val hintReceiver = HintReceiverFake()
         val job = launch {
             differ.collectFrom(
                 // Filter the original list of 10 items to 5, removing even numbers.
-                PagingData(pageEventCh.consumeAsFlow(), receiver).filter { it % 2 != 0 }
+                PagingData(pageEventCh.consumeAsFlow(), dummyUiReceiver, hintReceiver)
+                    .filter { it % 2 != 0 }
             )
         }
 
         // Initial state:
         // [null, null, [-1], [1], [3], null, null]
         assertNull(differ[0])
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Initial(
                     presentedItemsBefore = 0,
@@ -366,7 +704,7 @@ class PagingDataDifferTest(
                 placeholdersBefore = 2,
             )
         )
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(
                 ViewportHint.Access(
                     pageOffset = -2,
@@ -427,11 +765,11 @@ class PagingDataDifferTest(
             )
         )
 
-        val receiver = UiReceiverFake()
+        val hintReceiver = HintReceiverFake()
         val job = launch {
             differ.collectFrom(
                 // Filter the original list of 10 items to 5, removing even numbers.
-                PagingData(pageEventCh.consumeAsFlow(), receiver)
+                PagingData(pageEventCh.consumeAsFlow(), dummyUiReceiver, hintReceiver)
             )
         }
 
@@ -442,7 +780,7 @@ class PagingDataDifferTest(
         assertNull(differ.peek(0))
 
         // Check that peek does not trigger page fetch.
-        assertThat(receiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf<ViewportHint>(
                 ViewportHint.Initial(
                     presentedItemsBefore = 1,
@@ -460,16 +798,22 @@ class PagingDataDifferTest(
     fun initialHint_emptyRefresh() = testScope.runTest {
         val differ = SimpleDiffer(dummyDifferCallback)
         val pageEventCh = Channel<PageEvent<Int>>(Channel.UNLIMITED)
-        val uiReceiver = UiReceiverFake()
+        val hintReceiver = HintReceiverFake()
         val job = launch {
-            differ.collectFrom(PagingData(pageEventCh.consumeAsFlow(), uiReceiver))
+            differ.collectFrom(
+                PagingData(
+                    pageEventCh.consumeAsFlow(),
+                    dummyUiReceiver,
+                    hintReceiver
+                )
+            )
         }
 
         pageEventCh.trySend(
             localRefresh(pages = listOf(TransformablePage(emptyList())))
         )
 
-        assertThat(uiReceiver.hints).isEqualTo(
+        assertThat(hintReceiver.hints).isEqualTo(
             listOf(ViewportHint.Initial(0, 0, 0, 0))
         )
 
@@ -774,7 +1118,8 @@ class PagingDataDifferTest(
                         appendRemote = Loading,
                     )
                 ),
-                receiver = PagingData.NOOP_RECEIVER,
+                uiReceiver = PagingData.NOOP_UI_RECEIVER,
+                hintReceiver = PagingData.NOOP_HINT_RECEIVER
             )
         )
         assertThat(combinedLoadStates.getAllAndClear()).containsExactly(
@@ -850,7 +1195,8 @@ class PagingDataDifferTest(
                         appendRemote = Loading,
                     )
                 ),
-                receiver = PagingData.NOOP_RECEIVER,
+                uiReceiver = PagingData.NOOP_UI_RECEIVER,
+                hintReceiver = PagingData.NOOP_HINT_RECEIVER
             )
         )
         assertThat(combinedLoadStates.getAllAndClear()).containsExactly(
@@ -1032,7 +1378,8 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refresh_loadStates() = runTest(initialKey = 50) { differ, loadDispatcher, pagingSources ->
+    fun refresh_loadStates() = runTest(initialKey = 50) { differ, loadDispatcher,
+        pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // execute queued initial REFRESH
@@ -1061,7 +1408,7 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refresh_loadStates_afterEndOfPagination() = runTest { differ, loadDispatcher, _ ->
+    fun refresh_loadStates_afterEndOfPagination() = runTest { differ, loadDispatcher, _, _, _ ->
         val loadStateCallbacks = mutableListOf<CombinedLoadStates>()
         differ.addLoadStateListener {
             loadStateCallbacks.add(it)
@@ -1112,7 +1459,7 @@ class PagingDataDifferTest(
     //  LoadStateUpdate event
 
     @Test
-    fun appendInvalid_loadStates() = runTest { differ, loadDispatcher, pagingSources ->
+    fun appendInvalid_loadStates() = runTest { differ, loadDispatcher, pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
@@ -1174,7 +1521,7 @@ class PagingDataDifferTest(
 
     @Test
     fun prependInvalid_loadStates() = runTest(initialKey = 50) { differ, loadDispatcher,
-        pagingSources ->
+        pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
@@ -1228,7 +1575,7 @@ class PagingDataDifferTest(
 
     @Test
     fun refreshInvalid_loadStates() = runTest(initialKey = 50) { differ, loadDispatcher,
-        pagingSources ->
+        pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // execute queued initial REFRESH load which will return LoadResult.Invalid()
@@ -1258,7 +1605,7 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun appendError_retryLoadStates() = runTest { differ, loadDispatcher, pagingSources ->
+    fun appendError_retryLoadStates() = runTest { differ, loadDispatcher, pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
@@ -1309,7 +1656,7 @@ class PagingDataDifferTest(
 
     @Test
     fun prependError_retryLoadStates() = runTest(initialKey = 50) { differ, loadDispatcher,
-        pagingSources ->
+        pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
@@ -1351,7 +1698,7 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refreshError_retryLoadStates() = runTest() { differ, loadDispatcher, pagingSources ->
+    fun refreshError_retryLoadStates() = runTest() { differ, loadDispatcher, pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial load returns LoadResult.Error
@@ -1384,7 +1731,7 @@ class PagingDataDifferTest(
 
     @Test
     fun prependError_refreshLoadStates() = runTest(initialKey = 50) { differ, loadDispatcher,
-        pagingSources ->
+        pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
@@ -1427,7 +1774,8 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refreshError_refreshLoadStates() = runTest() { differ, loadDispatcher, pagingSources ->
+    fun refreshError_refreshLoadStates() = runTest() { differ, loadDispatcher, pagingSources,
+        _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // the initial load will return LoadResult.Error
@@ -1577,10 +1925,28 @@ class PagingDataDifferTest(
                     ).also { pagingSources.add(it) }
                 }
             ),
-        block: (SimpleDiffer, TestDispatcher, MutableList<TestPagingSource>) -> Unit
+        block: (
+            differ: SimpleDiffer,
+            loadDispatcher: TestDispatcher,
+            pagingSources: List<TestPagingSource>,
+            uiReceivers: List<TrackableUiReceiverWrapper>,
+            hintReceivers: List<TrackableHintReceiverWrapper>
+        ) -> Unit
     ) {
+        val uiReceivers = mutableListOf<TrackableUiReceiverWrapper>()
+        val hintReceivers = mutableListOf<TrackableHintReceiverWrapper>()
+
         val collection = scope.launch {
-            pager.flow.let {
+            pager.flow
+            .map { pagingData ->
+                PagingData(
+                    flow = pagingData.flow,
+                    uiReceiver = TrackableUiReceiverWrapper(pagingData.uiReceiver)
+                        .also { uiReceivers.add(it) },
+                    hintReceiver = TrackableHintReceiverWrapper(pagingData.hintReceiver)
+                        .also { hintReceivers.add(it) }
+                )
+            }.let {
                 if (collectWithCachedIn) {
                     it.cachedIn(this)
                 } else {
@@ -1590,9 +1956,10 @@ class PagingDataDifferTest(
                 differ.collectFrom(it)
             }
         }
+
         scope.run {
             try {
-                block(differ, loadDispatcher, pagingSources)
+                block(differ, loadDispatcher, pagingSources, uiReceivers, hintReceivers)
             } finally {
                 collection.cancel()
             }
@@ -1606,12 +1973,29 @@ class PagingDataDifferTest(
     }
 }
 
-private fun infinitelySuspendingPagingData(receiver: UiReceiver = dummyReceiver) = PagingData(
+private fun infinitelySuspendingPagingData(
+    uiReceiver: UiReceiver = dummyUiReceiver,
+    hintReceiver: HintReceiver = dummyHintReceiver
+) = PagingData(
     flow { emit(suspendCancellableCoroutine<PageEvent<Int>> { }) },
-    receiver
+    uiReceiver,
+    hintReceiver
 )
 
 private class UiReceiverFake : UiReceiver {
+    val retryEvents = mutableListOf<Unit>()
+    val refreshEvents = mutableListOf<Unit>()
+
+    override fun retry() {
+        retryEvents.add(Unit)
+    }
+
+    override fun refresh() {
+        refreshEvents.add(Unit)
+    }
+}
+
+private class HintReceiverFake : HintReceiver {
     private val _hints = mutableListOf<ViewportHint>()
     val hints: List<ViewportHint>
         get() {
@@ -1621,19 +2005,43 @@ private class UiReceiverFake : UiReceiver {
             return result
         }
 
-    val retryEvents = mutableListOf<Unit>()
-    val refreshEvents = mutableListOf<Unit>()
-
     override fun accessHint(viewportHint: ViewportHint) {
         _hints.add(viewportHint)
     }
+}
+
+private class TrackableUiReceiverWrapper(
+    private val receiver: UiReceiver? = null,
+) : UiReceiver {
+    val retryEvents = mutableListOf<Unit>()
+    val refreshEvents = mutableListOf<Unit>()
 
     override fun retry() {
         retryEvents.add(Unit)
+        receiver?.retry()
     }
 
     override fun refresh() {
         refreshEvents.add(Unit)
+        receiver?.refresh()
+    }
+}
+
+private class TrackableHintReceiverWrapper(
+    private val receiver: HintReceiver? = null,
+) : HintReceiver {
+    private val _hints = mutableListOf<ViewportHint>()
+    val hints: List<ViewportHint>
+        get() {
+            val result = _hints.toList()
+            @OptIn(ExperimentalStdlibApi::class)
+            repeat(result.size) { _hints.removeFirst() }
+            return result
+        }
+
+    override fun accessHint(viewportHint: ViewportHint) {
+        _hints.add(viewportHint)
+        receiver?.accessHint(viewportHint)
     }
 }
 
@@ -1669,10 +2077,13 @@ private class SimpleDiffer(
     }
 }
 
-internal val dummyReceiver = object : UiReceiver {
-    override fun accessHint(viewportHint: ViewportHint) {}
+internal val dummyUiReceiver = object : UiReceiver {
     override fun retry() {}
     override fun refresh() {}
+}
+
+internal val dummyHintReceiver = object : HintReceiver {
+    override fun accessHint(viewportHint: ViewportHint) {}
 }
 
 private val dummyDifferCallback = object : DifferCallback {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsWithRemoteMediatorTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsWithRemoteMediatorTest.kt
@@ -56,7 +56,7 @@ class SeparatorsWithRemoteMediatorTest {
         assertFailsWith<IllegalArgumentException>(
             "Prepend after endOfPaginationReached already true is invalid"
         ) {
-            PagingData(pageEventFlow, dummyReceiver)
+            PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
                 .insertSeparators(
                     terminalSeparatorType = FULLY_COMPLETE,
                     generator = LETTER_SEPARATOR_GENERATOR
@@ -88,7 +88,7 @@ class SeparatorsWithRemoteMediatorTest {
         assertFailsWith<IllegalArgumentException>(
             "Append after endOfPaginationReached already true is invalid"
         ) {
-            PagingData(pageEventFlow, dummyReceiver)
+            PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
                 .insertSeparators(
                     terminalSeparatorType = FULLY_COMPLETE,
                     generator = LETTER_SEPARATOR_GENERATOR
@@ -120,7 +120,8 @@ class SeparatorsWithRemoteMediatorTest {
 
         // Verify asserts in separators do not throw IllegalArgumentException for a local prepend
         // or append that arrives after remote prepend or append marking endOfPagination.
-        PagingData(pageEventFlow, dummyReceiver).insertSeparators { _, _ -> -1 }.flow.toList()
+        PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
+            .insertSeparators { _, _ -> -1 }.flow.toList()
     }
 
     @Test
@@ -146,7 +147,8 @@ class SeparatorsWithRemoteMediatorTest {
 
         // Verify asserts in separators do not throw IllegalArgumentException for a local prepend
         // or append that arrives after remote prepend or append marking endOfPagination.
-        PagingData(pageEventFlow, dummyReceiver).insertSeparators { _, _ -> -1 }.flow.toList()
+        PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
+            .insertSeparators { _, _ -> -1 }.flow.toList()
     }
 
     @Test
@@ -185,7 +187,7 @@ class SeparatorsWithRemoteMediatorTest {
             )
         )
 
-        val actual = PagingData(pageEventFlow, dummyReceiver)
+        val actual = PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
             .insertSeparators(
                 terminalSeparatorType = FULLY_COMPLETE,
                 generator = LETTER_SEPARATOR_GENERATOR
@@ -231,7 +233,7 @@ class SeparatorsWithRemoteMediatorTest {
             )
         )
 
-        val actual = PagingData(pageEventFlow, dummyReceiver)
+        val actual = PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
             .insertSeparators(
                 terminalSeparatorType = SOURCE_COMPLETE,
                 generator = LETTER_SEPARATOR_GENERATOR
@@ -277,7 +279,7 @@ class SeparatorsWithRemoteMediatorTest {
             )
         )
 
-        val actual = PagingData(pageEventFlow, dummyReceiver)
+        val actual = PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
             .insertSeparators(
                 terminalSeparatorType = FULLY_COMPLETE,
                 generator = LETTER_SEPARATOR_GENERATOR
@@ -323,7 +325,7 @@ class SeparatorsWithRemoteMediatorTest {
             )
         )
 
-        val actual = PagingData(pageEventFlow, dummyReceiver)
+        val actual = PagingData(pageEventFlow, dummyUiReceiver, dummyHintReceiver)
             .insertSeparators(
                 terminalSeparatorType = SOURCE_COMPLETE,
                 generator = LETTER_SEPARATOR_GENERATOR


### PR DESCRIPTION
Currently, the new generation's receiver is set in PagingDataDiffer
before new generation is actually presented. This leads to current
generation's hints (which are calcualted based on current gen's
placeholder states) being sent to new generation.

Refactor the differ to set new receiver after new generation is
presented.

Test: ./gradlew paging:paging-common:test
Fixes: 234030464
Change-Id: Iced47b9366805cb75d5f7a666cb8ae07f038c7f1

