### PR TITLE
Disable compose-runtime-tracing in playground

### DIFF
--- a/compose/runtime/settings.gradle
+++ b/compose/runtime/settings.gradle
@@ -27,6 +27,7 @@ rootProject.name = "compose-runtime"
 playground {
     setupPlayground("../..")
     selectProjectsFromAndroidX({ name ->
+        if (name == ":compose:runtime:runtime-tracing") return false
         if (name.startsWith(":compose:runtime") && name != ":compose:runtime") return true
         if (name == ":annotation:annotation-sampled") return true
         if (isNeededForComposePlayground(name)) return true


### PR DESCRIPTION
compose:runtime:runtime-tracing currently depends on a perfetto
prebuilt, which Gradle currently expects an .aar available locally to
unzip. Since it will take some time to make this logic compatible with
GCS, this CL temporarily stops building compose:runtime:runtime-tracing
to prevent it from breaking the build.

Test: cd compose/runtime && ./gradlew bOS
