### PR TITLE
Have RxPagedListBuilder emit errors in RxJava chain

### DIFF
--- a/paging/paging-rxjava2/src/test/java/androidx/paging/RxPagedListBuilderTest.kt
+++ b/paging/paging-rxjava2/src/test/java/androidx/paging/RxPagedListBuilderTest.kt
@@ -447,6 +447,32 @@ class RxPagedListBuilderTest {
         assertEquals(2, pagingSourcesCreated)
     }
 
+    @Test
+    fun exceptionThrownFromDataSourceEmitsInRxChain() {
+        class DodgyQueryDataSourceFactory : DataSource.Factory<Int, String>() {
+            override fun create() = object : PositionalDataSource<String>() {
+                override fun loadInitial(
+                    params: LoadInitialParams,
+                    callback: LoadInitialCallback<String>,
+                ) {
+                    error("This was totally unexpected.")
+                }
+
+                override fun loadRange(
+                    params: LoadRangeParams,
+                    callback: LoadRangeCallback<String>,
+                ) = Unit
+            }
+        }
+
+        RxPagedListBuilder(DodgyQueryDataSourceFactory(), 10)
+            .setFetchScheduler(Schedulers.trampoline())
+            .setNotifyScheduler(Schedulers.trampoline())
+            .buildObservable()
+            .test()
+            .assertErrorMessage("This was totally unexpected.")
+    }
+
     companion object {
         val EXCEPTION = Exception("")
     }

--- a/paging/paging-rxjava3/src/main/java/androidx/paging/rxjava3/RxPagedListBuilder.kt
+++ b/paging/paging-rxjava3/src/main/java/androidx/paging/rxjava3/RxPagedListBuilder.kt
@@ -396,49 +396,53 @@ class RxPagedListBuilder<Key : Any, Value : Any> {
 
             currentJob?.cancel()
             currentJob = GlobalScope.launch(fetchDispatcher) {
-                currentData.pagingSource.unregisterInvalidatedCallback(callback)
-                val pagingSource = pagingSourceFactory()
-                pagingSource.registerInvalidatedCallback(callback)
-                if (pagingSource is LegacyPagingSource) {
-                    pagingSource.setPageSize(config.pageSize)
-                }
+                try {
+                    currentData.pagingSource.unregisterInvalidatedCallback(callback)
+                    val pagingSource = pagingSourceFactory()
+                    pagingSource.registerInvalidatedCallback(callback)
+                    if (pagingSource is LegacyPagingSource) {
+                        pagingSource.setPageSize(config.pageSize)
+                    }
 
-                withContext(notifyDispatcher) {
-                    currentData.setInitialLoadState(LoadType.REFRESH, Loading)
-                }
+                    withContext(notifyDispatcher) {
+                        currentData.setInitialLoadState(LoadType.REFRESH, Loading)
+                    }
 
-                @Suppress("UNCHECKED_CAST")
-                val lastKey = currentData.lastKey as Key?
-                val params = config.toRefreshLoadParams(lastKey)
-                when (val initialResult = pagingSource.load(params)) {
-                    is PagingSource.LoadResult.Invalid -> {
-                        currentData.setInitialLoadState(
-                            LoadType.REFRESH,
-                            LoadState.NotLoading(endOfPaginationReached = false)
-                        )
-                        pagingSource.invalidate()
+                    @Suppress("UNCHECKED_CAST")
+                    val lastKey = currentData.lastKey as Key?
+                    val params = config.toRefreshLoadParams(lastKey)
+                    when (val initialResult = pagingSource.load(params)) {
+                        is PagingSource.LoadResult.Invalid -> {
+                            currentData.setInitialLoadState(
+                                LoadType.REFRESH,
+                                LoadState.NotLoading(endOfPaginationReached = false)
+                            )
+                            pagingSource.invalidate()
+                        }
+                        is PagingSource.LoadResult.Error -> {
+                            currentData.setInitialLoadState(
+                                LoadType.REFRESH,
+                                LoadState.Error(initialResult.throwable)
+                            )
+                        }
+                        is PagingSource.LoadResult.Page -> {
+                            val pagedList = PagedList.create(
+                                pagingSource,
+                                initialResult,
+                                GlobalScope,
+                                notifyDispatcher,
+                                fetchDispatcher,
+                                boundaryCallback,
+                                config,
+                                lastKey
+                            )
+                            onItemUpdate(currentData, pagedList)
+                            currentData = pagedList
+                            emitter.onNext(pagedList)
+                        }
                     }
-                    is PagingSource.LoadResult.Error -> {
-                        currentData.setInitialLoadState(
-                            LoadType.REFRESH,
-                            LoadState.Error(initialResult.throwable)
-                        )
-                    }
-                    is PagingSource.LoadResult.Page -> {
-                        val pagedList = PagedList.create(
-                            pagingSource,
-                            initialResult,
-                            GlobalScope,
-                            notifyDispatcher,
-                            fetchDispatcher,
-                            boundaryCallback,
-                            config,
-                            lastKey
-                        )
-                        onItemUpdate(currentData, pagedList)
-                        currentData = pagedList
-                        emitter.onNext(pagedList)
-                    }
+                } catch (e: Throwable) {
+                    emitter.onError(e)
                 }
             }
         }


### PR DESCRIPTION
## Proposed Changes

From https://issuetracker.google.com/issues/233703110:

> In Paging 2.1.2, when an error is thrown from the `DataSource.Factory`, the error is propagated through the rx chain, so we could use things like `onErrorResumeNext(…)` when there's an error so we can fail safely. In Paging 3, this error is no longer propagated through the rx chain, so our callback in `onErrorResumeNext(…)` is never invoked.

I've just wrapped the invalidate job contents with a try-catch. This is a greatly simplified version of what [`rxObservable` does](https://github.com/Kotlin/kotlinx.coroutines/blob/2ee99e269ec37d703f44f2598b4634637d8354d6/reactive/kotlinx-coroutines-rx3/src/RxObservable.kt#L125-L139).

Note: the diff in GitHub looks like many things changed in `RxPagedListBuilder`, but checking out the diff in Android Studio shows that I did in fact just wrap it all in a try-catch.

## Testing

Test: ./gradlew paging:paging-rxjava2:test paging:paging-rxjava2:test

## Issues Fixed

Fixes: 233703110
