### PR TITLE
Use projectOrArtifact for appcompat-lint's core dependency

### DIFF
--- a/appcompat/appcompat-lint/integration-tests/build.gradle
+++ b/appcompat/appcompat-lint/integration-tests/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     implementation(project(":appcompat:appcompat"))
-    implementation(project(":core:core"))
+    implementation(projectOrArtifact(":core:core"))
     api(libs.kotlinStdlib)
 }
 


### PR DESCRIPTION
I've tried including the project but it ends up requiring many more projects.
So this seems like a better option for now.

Bug: n/a
Test: CI