### PR TITLE
Support for queries with > 999 host parameters

### DIFF
--- a/room/benchmark/src/androidTest/java/androidx/room/benchmark/LargeQueryBenchmark.kt
+++ b/room/benchmark/src/androidTest/java/androidx/room/benchmark/LargeQueryBenchmark.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room.benchmark
+
+import android.os.Build
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.filters.LargeTest
+import androidx.test.filters.SdkSuppress
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@LargeTest
+@RunWith(Parameterized::class)
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.JELLY_BEAN)
+class LargeQueryBenchmark(private val sampleSize: Int) {
+
+    @get:Rule
+    val benchmarkRule = BenchmarkRule()
+
+    private val context = ApplicationProvider.getApplicationContext() as android.content.Context
+
+    @Before
+    fun setup() {
+        for (postfix in arrayOf("", "-wal", "-shm")) {
+            val dbFile = context.getDatabasePath(DB_NAME + postfix)
+            if (dbFile.exists()) {
+                Assert.assertTrue(dbFile.delete())
+            }
+        }
+    }
+
+    @Test
+    fun testLargeQuerySingleParam() {
+        val db = Room.databaseBuilder(context, TestDatabase::class.java, DB_NAME)
+            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+            .build()
+        val dao = db.getUserDao()
+        dao.insertUsers(generateUsers())
+
+        val ids = List(sampleSize) { i -> i }
+
+        benchmarkRule.measureRepeated {
+            val result = dao.query(ids)
+            Assert.assertEquals(result.size, sampleSize)
+        }
+
+        db.close()
+    }
+
+    @Test
+    fun testLargeQueryMultipleParams() {
+        val db = Room.databaseBuilder(context, TestDatabase::class.java, DB_NAME)
+            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+            .build()
+        val dao = db.getUserDao()
+        dao.insertUsers(generateUsers())
+
+        var ids = List(sampleSize) { i -> i }
+        val id4 = ids[ids.size - 1]
+        val id3 = ids[ids.size - 2]
+        ids = ids.subList(0, ids.size - 2)
+
+        val ids1 = ids.subList(0, ids.size / 2)
+        val ids2 = ids.subList(ids.size / 2, ids.size)
+
+        benchmarkRule.measureRepeated {
+            val result = dao.query(ids1, ids2, id3, id4)
+            Assert.assertEquals(result.size, sampleSize)
+        }
+
+        db.close()
+    }
+
+    private fun generateUsers(): List<User> = List(sampleSize) { i -> User(i, "name $i") }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "sampleSize={0}")
+        fun data() = listOf(100_000)
+
+        private const val DB_NAME = "large-query-benchmark-test"
+    }
+
+    @Database(entities = [User::class], version = 1, exportSchema = false)
+    abstract class TestDatabase : RoomDatabase() {
+        abstract fun getUserDao(): UserDao
+    }
+
+    @Entity
+    data class User(@PrimaryKey val id: Int, val name: String)
+
+    @Dao
+    interface UserDao {
+        @Insert
+        fun insertUsers(user: List<User>)
+
+        @Query("SELECT * FROM User WHERE id IN (:ids)")
+        fun query(ids: List<Int>): List<User>
+
+        @Query("SELECT * FROM User WHERE id IN (:ids1) OR id IN (:ids2) OR id = :id3 OR id = :id4")
+        fun query(ids1: List<Int>, ids2: List<Int>, id3: Int, id4: Int): List<User>
+    }
+}

--- a/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/dao/BooksDao.kt
+++ b/room/integration-tests/kotlintestapp/src/androidTest/java/androidx/room/integration/kotlintestapp/dao/BooksDao.kt
@@ -16,10 +16,12 @@
 
 package androidx.room.integration.kotlintestapp.dao
 
+import android.database.Cursor
 import androidx.lifecycle.LiveData
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.RawQuery
 import androidx.room.RoomWarnings
@@ -225,6 +227,9 @@ interface BooksDao {
     @Insert
     suspend fun insertBookSuspend(book: Book)
 
+    @Update(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun updateAuthorSuspend(author: Author)
+
     @Insert
     suspend fun insertBookWithResultSuspend(book: Book): Long
 
@@ -367,8 +372,32 @@ interface BooksDao {
     @Query("SELECT * FROM author WHERE dateOfBirth IN (:dates)")
     fun getAuthorsWithBirthDatesList(dates: List<Date>): List<Author>
 
+    @Query("SELECT * FROM author WHERE authorId IN (:authorIds) OR dateOfBirth IN (:dates)")
+    fun getAuthorsWithIDsOrBirthDatesList(authorIds: List<String>, dates: List<Date>): List<Author>
+
     @Query("SELECT * FROM author WHERE dateOfBirth IN (:dates)")
     fun getAuthorsWithBirthDatesVararg(vararg dates: Date): List<Author>
+
+    @Query("SELECT * FROM author WHERE authorId IN (:authorIds)")
+    fun getAuthorsByIdsFuture(vararg authorIds: String): ListenableFuture<List<Author>>
+
+    @Query("SELECT * FROM author WHERE authorId IN (:authorIds)")
+    fun getAuthorsByIdsCursor(vararg authorIds: String): Cursor
+
+    @Query("DELETE FROM author WHERE authorId IN (:authorIds)")
+    fun deleteAuthorsWithIds(vararg authorIds: String): Int
+
+    @Query("DELETE FROM author WHERE authorId IN (:authorIds) OR dateOfBirth IN (:dates)")
+    fun deleteAuthorsWithIdsOrBirthDates(authorIds: List<String>, dates: List<Date>): Int
+
+    @Query("UPDATE author SET name = :name WHERE authorId IN (:authorIds)")
+    fun updateAuthorName(name: String, vararg authorIds: String): Int
+
+    @Query("SELECT * FROM author WHERE authorId IN (:authorIds)")
+    fun getAuthorsByIdsFlow(vararg authorIds: String): Flow<List<Author>>
+
+    @Query("SELECT * FROM author WHERE authorId IN (:authorIds)")
+    suspend fun getAuthorsByIdsSuspend(vararg authorIds: String): List<Author>
 
     // see: b/123767877, suspend function with inner class as parameter issues.
     @Query("SELECT 0 FROM book WHERE bookId = :param")

--- a/room/integration-tests/testapp/src/androidTest/java/androidx/room/integration/testapp/dao/UserDao.java
+++ b/room/integration-tests/testapp/src/androidTest/java/androidx/room/integration/testapp/dao/UserDao.java
@@ -166,6 +166,9 @@ public abstract class UserDao {
     @Query("select * from user where mName LIKE '%' || :name || '%' ORDER BY mId DESC")
     public abstract LiveData<List<User>> liveUsersListByName(String name);
 
+    @Query("select * from user where mId IN(:ids)")
+    public abstract LiveData<List<User>> liveUsersListByByIds(int... ids);
+
     @Query("select * from user where length(mName) = :length")
     public abstract List<User> findByNameLength(int length);
 
@@ -193,8 +196,15 @@ public abstract class UserDao {
     @Query("select * from user where mId = :id")
     public abstract io.reactivex.Observable<User> rx2_observableUserById(int id);
 
+    @Query("select * from user where mId IN (:ids)")
+    public abstract io.reactivex.Observable<List<User>> rx2_observableUsersByIds(int... ids);
+
     @Query("select * from user where mId = :id")
     public abstract io.reactivex.rxjava3.core.Observable<User> rx3_observableUserById(int id);
+
+    @Query("select * from user where mId IN (:ids)")
+    public abstract io.reactivex.rxjava3.core.Observable<List<User>> rx3_observableUsersByIds(
+            int... ids);
 
     @Query("select * from user where mId = :id")
     public abstract io.reactivex.Maybe<User> rx2_maybeUserById(int id);

--- a/room/room-common/api/current.txt
+++ b/room/room-common/api/current.txt
@@ -291,6 +291,47 @@ package androidx.room {
     field @Deprecated public static final int ROLLBACK = 2; // 0x2
   }
 
+  public abstract sealed class ParsedQuerySection {
+    method public static final androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public abstract String getText();
+    method public static final androidx.room.ParsedQuerySection.Text text(String text);
+    property public abstract String text;
+    field public static final androidx.room.ParsedQuerySection.Companion Companion;
+  }
+
+  public static final class ParsedQuerySection.BindVar extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.BindVar(String text, boolean isMultiple, Object? value);
+    method public String component1();
+    method public boolean component2();
+    method public Object? component3();
+    method public androidx.room.ParsedQuerySection.BindVar copy(String text, boolean isMultiple, Object? value);
+    method public java.util.Iterator<?>? getIterator();
+    method public int getParameterCount();
+    method public String getText();
+    method public Object? getValue();
+    method public String? getVarName();
+    method public boolean isMultiple();
+    property public final boolean isMultiple;
+    property public final java.util.Iterator<?>? iterator;
+    property public final int parameterCount;
+    property public String text;
+    property public final Object? value;
+    property public final String? varName;
+  }
+
+  public static final class ParsedQuerySection.Companion {
+    method public androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public androidx.room.ParsedQuerySection.Text text(String text);
+  }
+
+  public static final class ParsedQuerySection.Text extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.Text(String text);
+    method public String component1();
+    method public androidx.room.ParsedQuerySection.Text copy(String text);
+    method public String getText();
+    property public String text;
+  }
+
   @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.FIELD, kotlin.annotation.AnnotationTarget.FUNCTION}) public @interface PrimaryKey {
     method public abstract boolean autoGenerate() default false;
     property public abstract boolean autoGenerate;

--- a/room/room-common/api/public_plus_experimental_current.txt
+++ b/room/room-common/api/public_plus_experimental_current.txt
@@ -291,6 +291,47 @@ package androidx.room {
     field @Deprecated public static final int ROLLBACK = 2; // 0x2
   }
 
+  public abstract sealed class ParsedQuerySection {
+    method public static final androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public abstract String getText();
+    method public static final androidx.room.ParsedQuerySection.Text text(String text);
+    property public abstract String text;
+    field public static final androidx.room.ParsedQuerySection.Companion Companion;
+  }
+
+  public static final class ParsedQuerySection.BindVar extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.BindVar(String text, boolean isMultiple, Object? value);
+    method public String component1();
+    method public boolean component2();
+    method public Object? component3();
+    method public androidx.room.ParsedQuerySection.BindVar copy(String text, boolean isMultiple, Object? value);
+    method public java.util.Iterator<?>? getIterator();
+    method public int getParameterCount();
+    method public String getText();
+    method public Object? getValue();
+    method public String? getVarName();
+    method public boolean isMultiple();
+    property public final boolean isMultiple;
+    property public final java.util.Iterator<?>? iterator;
+    property public final int parameterCount;
+    property public String text;
+    property public final Object? value;
+    property public final String? varName;
+  }
+
+  public static final class ParsedQuerySection.Companion {
+    method public androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public androidx.room.ParsedQuerySection.Text text(String text);
+  }
+
+  public static final class ParsedQuerySection.Text extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.Text(String text);
+    method public String component1();
+    method public androidx.room.ParsedQuerySection.Text copy(String text);
+    method public String getText();
+    property public String text;
+  }
+
   @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.FIELD, kotlin.annotation.AnnotationTarget.FUNCTION}) public @interface PrimaryKey {
     method public abstract boolean autoGenerate() default false;
     property public abstract boolean autoGenerate;

--- a/room/room-common/api/restricted_current.txt
+++ b/room/room-common/api/restricted_current.txt
@@ -291,6 +291,47 @@ package androidx.room {
     field @Deprecated public static final int ROLLBACK = 2; // 0x2
   }
 
+  public abstract sealed class ParsedQuerySection {
+    method public static final androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public abstract String getText();
+    method public static final androidx.room.ParsedQuerySection.Text text(String text);
+    property public abstract String text;
+    field public static final androidx.room.ParsedQuerySection.Companion Companion;
+  }
+
+  public static final class ParsedQuerySection.BindVar extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.BindVar(String text, boolean isMultiple, Object? value);
+    method public String component1();
+    method public boolean component2();
+    method public Object? component3();
+    method public androidx.room.ParsedQuerySection.BindVar copy(String text, boolean isMultiple, Object? value);
+    method public java.util.Iterator<?>? getIterator();
+    method public int getParameterCount();
+    method public String getText();
+    method public Object? getValue();
+    method public String? getVarName();
+    method public boolean isMultiple();
+    property public final boolean isMultiple;
+    property public final java.util.Iterator<?>? iterator;
+    property public final int parameterCount;
+    property public String text;
+    property public final Object? value;
+    property public final String? varName;
+  }
+
+  public static final class ParsedQuerySection.Companion {
+    method public androidx.room.ParsedQuerySection.BindVar bindVar(String text, boolean isMultiple, Object? value);
+    method public androidx.room.ParsedQuerySection.Text text(String text);
+  }
+
+  public static final class ParsedQuerySection.Text extends androidx.room.ParsedQuerySection {
+    ctor public ParsedQuerySection.Text(String text);
+    method public String component1();
+    method public androidx.room.ParsedQuerySection.Text copy(String text);
+    method public String getText();
+    property public String text;
+  }
+
   @kotlin.annotation.Retention(kotlin.annotation.AnnotationRetention.BINARY) @kotlin.annotation.Target(allowedTargets={kotlin.annotation.AnnotationTarget.FIELD, kotlin.annotation.AnnotationTarget.FUNCTION}) public @interface PrimaryKey {
     method public abstract boolean autoGenerate() default false;
     property public abstract boolean autoGenerate;

--- a/room/room-common/src/main/java/androidx/room/ParsedQuerySection.kt
+++ b/room/room-common/src/main/java/androidx/room/ParsedQuerySection.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room
+
+public sealed class ParsedQuerySection {
+
+    public abstract val text: String
+
+    public data class Text(override val text: String) : ParsedQuerySection()
+
+    public data class BindVar(
+        override val text: String,
+        val isMultiple: Boolean,
+        val value: Any?
+    ) : ParsedQuerySection() {
+        val varName: String? by lazy {
+            if (text.startsWith(":")) {
+                text.substring(1)
+            } else {
+                null
+            }
+        }
+
+        val parameterCount: Int
+            get() {
+                if (!isMultiple) {
+                    return 1
+                }
+                return when (value) {
+                    is Collection<*> -> value.size
+                    is Array<*> -> value.size
+                    is ByteArray -> value.size
+                    is CharArray -> value.size
+                    is ShortArray -> value.size
+                    is IntArray -> value.size
+                    is LongArray -> value.size
+                    is FloatArray -> value.size
+                    is DoubleArray -> value.size
+                    is BooleanArray -> value.size
+                    else -> 1
+                }
+            }
+
+        val iterator: Iterator<*>?
+            get() {
+                if (!isMultiple) {
+                    return null
+                }
+                return when (value) {
+                    is Collection<*> -> value.iterator()
+                    is Array<*> -> value.iterator()
+                    is ByteArray -> value.iterator()
+                    is CharArray -> value.iterator()
+                    is ShortArray -> value.iterator()
+                    is IntArray -> value.iterator()
+                    is LongArray -> value.iterator()
+                    is FloatArray -> value.iterator()
+                    is DoubleArray -> value.iterator()
+                    is BooleanArray -> value.iterator()
+                    else -> null
+                }
+            }
+    }
+
+    public companion object {
+        @JvmStatic
+        public fun text(text: String): Text = Text(text)
+
+        @JvmStatic
+        public fun bindVar(text: String, isMultiple: Boolean, value: Any?): BindVar =
+            BindVar(text, isMultiple, value)
+    }
+}

--- a/room/room-compiler/src/main/kotlin/androidx/room/ext/javapoet_ext.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/ext/javapoet_ext.kt
@@ -91,6 +91,8 @@ object RoomTypeNames {
         ClassName.get("$ROOM_PACKAGE.paging", "LimitOffsetDataSource")
     val DB_UTIL: ClassName =
         ClassName.get("$ROOM_PACKAGE.util", "DBUtil")
+    val QUERY_UTIL: ClassName =
+        ClassName.get("$ROOM_PACKAGE.util", "QueryUtil")
     val CURSOR_UTIL: ClassName =
         ClassName.get("$ROOM_PACKAGE.util", "CursorUtil")
     val MIGRATION: ClassName = ClassName.get("$ROOM_PACKAGE.migration", "Migration")
@@ -282,6 +284,19 @@ fun CallableTypeSpecBuilder(
         MethodSpec.methodBuilder("call").apply {
             returns(parameterTypeName)
             addException(Exception::class.typeName)
+            addModifiers(Modifier.PUBLIC)
+            addAnnotation(Override::class.java)
+            callBody()
+        }.build()
+    )
+}
+
+fun RunnableTypeSpecBuilder(
+    callBody: MethodSpec.Builder.() -> Unit
+) = TypeSpec.anonymousClassBuilder("").apply {
+    superclass(Runnable::class.typeName)
+    addMethod(
+        MethodSpec.methodBuilder("run").apply {
             addModifiers(Modifier.PUBLIC)
             addAnnotation(Override::class.java)
             callBody()

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/CallablePreparedQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/CallablePreparedQueryResultBinder.kt
@@ -16,8 +16,8 @@
 
 package androidx.room.solver.prepared.binder
 
-import androidx.room.ext.CallableTypeSpecBuilder
 import androidx.room.compiler.processing.XType
+import androidx.room.ext.CallableTypeSpecBuilder
 import androidx.room.solver.CodeGenScope
 import androidx.room.solver.prepared.result.PreparedQueryResultAdapter
 import com.squareup.javapoet.CodeBlock
@@ -47,6 +47,8 @@ class CallablePreparedQueryResultBinder private constructor(
 
     override fun executeAndReturn(
         prepareQueryStmtBlock: CodeGenScope.() -> String,
+        sectionsVar: String?,
+        tempTableVar: String,
         preparedStmtField: String?,
         dbField: FieldSpec,
         scope: CodeGenScope
@@ -55,6 +57,8 @@ class CallablePreparedQueryResultBinder private constructor(
         val callableImpl = CallableTypeSpecBuilder(returnType.typeName) {
             adapter?.executeAndReturn(
                 binderScope.prepareQueryStmtBlock(),
+                sectionsVar,
+                tempTableVar,
                 preparedStmtField,
                 dbField,
                 binderScope

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/InstantPreparedQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/InstantPreparedQueryResultBinder.kt
@@ -30,6 +30,8 @@ class InstantPreparedQueryResultBinder(adapter: PreparedQueryResultAdapter?) :
 
     override fun executeAndReturn(
         prepareQueryStmtBlock: CodeGenScope.() -> String,
+        sectionsVar: String?,
+        tempTableVar: String,
         preparedStmtField: String?,
         dbField: FieldSpec,
         scope: CodeGenScope
@@ -39,6 +41,8 @@ class InstantPreparedQueryResultBinder(adapter: PreparedQueryResultAdapter?) :
         }
         adapter?.executeAndReturn(
             stmtQueryVal = scope.prepareQueryStmtBlock(),
+            sectionsVar = sectionsVar,
+            tempTableVar = tempTableVar,
             preparedStmtField = preparedStmtField,
             dbField = dbField,
             scope = scope

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/PreparedQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/prepared/binder/PreparedQueryResultBinder.kt
@@ -34,6 +34,8 @@ abstract class PreparedQueryResultBinder(val adapter: PreparedQueryResultAdapter
      */
     abstract fun executeAndReturn(
         prepareQueryStmtBlock: CodeGenScope.() -> String,
+        sectionsVar: String?,
+        tempTableVar: String,
         preparedStmtField: String?, // null when the query is not shared
         dbField: FieldSpec,
         scope: CodeGenScope

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/BasicQueryParameterAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/BasicQueryParameterAdapter.kt
@@ -41,4 +41,8 @@ class BasicQueryParameterAdapter(val bindAdapter: StatementValueBinder) :
                 "It is always one."
         )
     }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return bindAdapter.convert(inputVarName, scope)
+    }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/CollectionQueryParameterAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/CollectionQueryParameterAdapter.kt
@@ -20,6 +20,8 @@ import androidx.room.ext.L
 import androidx.room.ext.T
 import androidx.room.solver.CodeGenScope
 import androidx.room.solver.types.StatementValueBinder
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 
 /**
@@ -49,5 +51,32 @@ class CollectionQueryParameterAdapter(val bindAdapter: StatementValueBinder) :
     override fun getArgCount(inputVarName: String, outputVarName: String, scope: CodeGenScope) {
         scope.builder()
             .addStatement("final $T $L = $L.size()", TypeName.INT, outputVarName, inputVarName)
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        val convertedType = bindAdapter.convertedType() ?: return null
+        val convertedVar = scope.getTmpVar("_convertedItems")
+        scope.builder().addStatement(
+            "final $T $L = new $T()",
+            ParameterizedTypeName.get(
+                ClassName.get(List::class.java),
+                convertedType.box()
+            ),
+            convertedVar,
+            ParameterizedTypeName.get(
+                ClassName.get(ArrayList::class.java),
+                convertedType.box()
+            )
+        )
+        val itrVar = scope.getTmpVar("_item")
+        scope.builder().beginControlFlow(
+            "for ($T $L : $L)", bindAdapter.typeMirror().typeName, itrVar,
+            inputVarName
+        ).apply {
+            val converted = bindAdapter.convert(itrVar, scope)
+            scope.builder().addStatement("$L.add($L)", convertedVar, converted)
+        }
+        scope.builder().endControlFlow()
+        return convertedVar
     }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/QueryParameterAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/parameter/QueryParameterAdapter.kt
@@ -36,4 +36,6 @@ abstract class QueryParameterAdapter(val isMultiple: Boolean) {
      * Should declare and set the given value with the count
      */
     abstract fun getArgCount(inputVarName: String, outputVarName: String, scope: CodeGenScope)
+
+    abstract fun convert(inputVarName: String, scope: CodeGenScope): String?
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/CoroutineFlowResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/CoroutineFlowResultBinder.kt
@@ -16,15 +16,17 @@
 
 package androidx.room.solver.query.result
 
+import androidx.room.compiler.processing.XType
 import androidx.room.ext.CallableTypeSpecBuilder
 import androidx.room.ext.L
 import androidx.room.ext.N
 import androidx.room.ext.RoomCoroutinesTypeNames
+import androidx.room.ext.RoomTypeNames
 import androidx.room.ext.T
 import androidx.room.ext.arrayTypeName
-import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
 import com.squareup.javapoet.FieldSpec
+import javax.lang.model.element.Modifier
 
 /**
  * Binds the result of a of a Kotlin Coroutine Flow<T>
@@ -37,6 +39,8 @@ class CoroutineFlowResultBinder(
 
     override fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean,
         dbField: FieldSpec,
         inTransaction: Boolean,
@@ -46,12 +50,17 @@ class CoroutineFlowResultBinder(
             createRunQueryAndReturnStatements(
                 builder = this,
                 roomSQLiteQueryVar = roomSQLiteQueryVar,
+                sectionsVar = sectionsVar,
+                tempTableVar = tempTableVar,
                 dbField = dbField,
                 inTransaction = inTransaction,
                 scope = scope,
                 cancellationSignalVar = "null"
             )
         }.apply {
+            if (sectionsVar != null) {
+                addField(RoomTypeNames.ROOM_SQL_QUERY, roomSQLiteQueryVar, Modifier.PRIVATE)
+            }
             if (canReleaseQuery) {
                 addMethod(createFinalizeMethod(roomSQLiteQueryVar))
             }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/CursorQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/CursorQueryResultBinder.kt
@@ -19,13 +19,20 @@ package androidx.room.solver.query.result
 import androidx.room.ext.AndroidTypeNames
 import androidx.room.ext.L
 import androidx.room.ext.N
+import androidx.room.ext.RoomTypeNames
+import androidx.room.ext.S
 import androidx.room.ext.T
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeName
 
 class CursorQueryResultBinder : QueryResultBinder(NO_OP_RESULT_ADAPTER) {
     override fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean,
         dbField: FieldSpec,
         inTransaction: Boolean,
@@ -39,12 +46,36 @@ class CursorQueryResultBinder : QueryResultBinder(NO_OP_RESULT_ADAPTER) {
         }
         transactionWrapper?.beginTransactionWithControlFlow()
         val resultName = scope.getTmpVar("_tmpResult")
-        builder.addStatement(
-            "final $T $L = $N.query($L)", AndroidTypeNames.CURSOR, resultName,
-            dbField, roomSQLiteQueryVar
-        )
-        transactionWrapper?.commitTransaction()
-        builder.addStatement("return $L", resultName)
+        val cursorVar = scope.getTmpVar("_cursor")
+
+        scope.builder().apply {
+            if (sectionsVar != null) {
+                addStatement("$T $L = null", RoomTypeNames.ROOM_SQL_QUERY, roomSQLiteQueryVar)
+            }
+            addStatement("$T $L = null", AndroidTypeNames.CURSOR, cursorVar)
+
+            if (sectionsVar != null) {
+                val pairVar = scope.getTmpVar("_resultPair")
+                addStatement(
+                    "final $T $L = $T.prepareQuery($N, $L, $S, $L, true)",
+                    ParameterizedTypeName.get(
+                        ClassName.get(Pair::class.java),
+                        RoomTypeNames.ROOM_SQL_QUERY,
+                        TypeName.BOOLEAN.box()
+                    ),
+                    pairVar,
+                    RoomTypeNames.QUERY_UTIL, dbField, inTransaction, tempTableVar, sectionsVar
+                )
+                addStatement("$L = $L.getFirst()", roomSQLiteQueryVar, pairVar)
+            }
+
+            addStatement(
+                "final $T $L = $N.query($L)", AndroidTypeNames.CURSOR, resultName,
+                dbField, roomSQLiteQueryVar
+            )
+            transactionWrapper?.commitTransaction()
+            addStatement("return $L", resultName)
+        }
         transactionWrapper?.endTransactionWithControlFlow()
     }
 

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/DataSourceFactoryQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/DataSourceFactoryQueryResultBinder.kt
@@ -18,14 +18,14 @@ package androidx.room.solver.query.result
 
 import androidx.room.ext.L
 import androidx.room.ext.PagingTypeNames
+import androidx.room.ext.typeName
 import androidx.room.solver.CodeGenScope
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
-import androidx.room.ext.typeName
-import com.squareup.javapoet.TypeName
 
 class DataSourceFactoryQueryResultBinder(
     val positionalDataSourceQueryResultBinder: PositionalDataSourceQueryResultBinder
@@ -35,6 +35,8 @@ class DataSourceFactoryQueryResultBinder(
 
     override fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean,
         dbField: FieldSpec,
         inTransaction: Boolean,
@@ -54,6 +56,8 @@ class DataSourceFactoryQueryResultBinder(
                     addMethod(
                         createCreateMethod(
                             roomSQLiteQueryVar = roomSQLiteQueryVar,
+                            sectionsVar = sectionsVar,
+                            tempTableVar = tempTableVar,
                             dbField = dbField,
                             inTransaction = inTransaction,
                             scope = scope
@@ -67,6 +71,8 @@ class DataSourceFactoryQueryResultBinder(
 
     private fun createCreateMethod(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         dbField: FieldSpec,
         inTransaction: Boolean,
         scope: CodeGenScope
@@ -77,6 +83,8 @@ class DataSourceFactoryQueryResultBinder(
         val countedBinderScope = scope.fork()
         positionalDataSourceQueryResultBinder.convertAndReturn(
             roomSQLiteQueryVar = roomSQLiteQueryVar,
+            sectionsVar = sectionsVar,
+            tempTableVar = tempTableVar,
             canReleaseQuery = true,
             dbField = dbField,
             inTransaction = inTransaction,

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/LiveDataQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/LiveDataQueryResultBinder.kt
@@ -16,14 +16,16 @@
 
 package androidx.room.solver.query.result
 
+import androidx.room.compiler.processing.XType
 import androidx.room.ext.CallableTypeSpecBuilder
 import androidx.room.ext.L
 import androidx.room.ext.N
+import androidx.room.ext.RoomTypeNames
 import androidx.room.ext.T
 import androidx.room.ext.arrayTypeName
-import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
 import com.squareup.javapoet.FieldSpec
+import javax.lang.model.element.Modifier
 
 /**
  * Converts the query into a LiveData and returns it. No query is run until necessary.
@@ -36,6 +38,8 @@ class LiveDataQueryResultBinder(
     @Suppress("JoinDeclarationAndAssignment")
     override fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean,
         dbField: FieldSpec,
         inTransaction: Boolean,
@@ -46,11 +50,16 @@ class LiveDataQueryResultBinder(
                 builder = this,
                 roomSQLiteQueryVar = roomSQLiteQueryVar,
                 inTransaction = inTransaction,
+                sectionsVar = sectionsVar,
+                tempTableVar = tempTableVar,
                 dbField = dbField,
                 scope = scope,
                 cancellationSignalVar = "null" // LiveData can't be cancelled
             )
         }.apply {
+            if (sectionsVar != null) {
+                addField(RoomTypeNames.ROOM_SQL_QUERY, roomSQLiteQueryVar, Modifier.PRIVATE)
+            }
             if (canReleaseQuery) {
                 addMethod(createFinalizeMethod(roomSQLiteQueryVar))
             }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/QueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/QueryResultBinder.kt
@@ -33,6 +33,8 @@ abstract class QueryResultBinder(val adapter: QueryResultAdapter?) {
      */
     abstract fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean, // false if query is provided by the user
         dbField: FieldSpec,
         inTransaction: Boolean,

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/RxQueryResultBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/query/result/RxQueryResultBinder.kt
@@ -16,15 +16,17 @@
 
 package androidx.room.solver.query.result
 
+import androidx.room.compiler.processing.XType
 import androidx.room.ext.CallableTypeSpecBuilder
 import androidx.room.ext.L
 import androidx.room.ext.N
+import androidx.room.ext.RoomTypeNames
 import androidx.room.ext.T
 import androidx.room.ext.arrayTypeName
-import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
 import androidx.room.solver.RxType
 import com.squareup.javapoet.FieldSpec
+import javax.lang.model.element.Modifier
 
 /**
  * Binds the result as an RxJava2 Flowable, Publisher and Observable.
@@ -37,6 +39,8 @@ internal class RxQueryResultBinder(
 ) : BaseObservableQueryResultBinder(adapter) {
     override fun convertAndReturn(
         roomSQLiteQueryVar: String,
+        sectionsVar: String?,
+        tempTableVar: String,
         canReleaseQuery: Boolean,
         dbField: FieldSpec,
         inTransaction: Boolean,
@@ -47,11 +51,16 @@ internal class RxQueryResultBinder(
                 builder = this,
                 roomSQLiteQueryVar = roomSQLiteQueryVar,
                 inTransaction = inTransaction,
+                sectionsVar = sectionsVar,
+                tempTableVar = tempTableVar,
                 dbField = dbField,
                 scope = scope,
                 cancellationSignalVar = "null"
             )
         }.apply {
+            if (sectionsVar != null) {
+                addField(RoomTypeNames.ROOM_SQL_QUERY, roomSQLiteQueryVar, Modifier.PRIVATE)
+            }
             if (canReleaseQuery) {
                 addMethod(createFinalizeMethod(roomSQLiteQueryVar))
             }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/BoxedPrimitiveColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/BoxedPrimitiveColumnTypeAdapter.kt
@@ -19,6 +19,7 @@ package androidx.room.solver.types
 import androidx.room.ext.L
 import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 
 /**
  * Adapters for all boxed primitives that has direct cursor mappings.
@@ -73,5 +74,13 @@ open class BoxedPrimitiveColumnTypeAdapter(
             }
             endControlFlow()
         }
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return null
+    }
+
+    override fun convertedType(): TypeName? {
+        return null
     }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/ByteArrayColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/ByteArrayColumnTypeAdapter.kt
@@ -63,6 +63,14 @@ class ByteArrayColumnTypeAdapter private constructor(
         }
     }
 
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return null
+    }
+
+    override fun convertedType(): TypeName? {
+        return null
+    }
+
     companion object {
         fun create(env: XProcessingEnv): List<ByteArrayColumnTypeAdapter> {
             val arrayType = env.getArrayType(TypeName.BYTE)

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/ByteBufferColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/ByteBufferColumnTypeAdapter.kt
@@ -64,6 +64,14 @@ class ByteBufferColumnTypeAdapter private constructor(out: XType) : ColumnTypeAd
         }
     }
 
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return null
+    }
+
+    override fun convertedType(): TypeName? {
+        return null
+    }
+
     companion object {
         fun create(env: XProcessingEnv): List<ByteBufferColumnTypeAdapter> {
             val byteBufferType = env.requireType("java.nio.ByteBuffer")

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/CompositeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/CompositeAdapter.kt
@@ -20,6 +20,7 @@ import androidx.room.ext.L
 import androidx.room.ext.T
 import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 
 /**
  * A column adapter that uses a type converter to do the conversion. The type converter may be
@@ -62,5 +63,13 @@ class CompositeAdapter(
             val bindVar = intoStatementConverter.convert(valueVarName, scope)
             columnTypeAdapter.bindToStmt(stmtName, indexVarName, bindVar, scope)
         }
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return intoStatementConverter?.convert(inputVarName, scope)
+    }
+
+    override fun convertedType(): TypeName? {
+        return intoStatementConverter?.to?.typeName
     }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/EnumColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/EnumColumnTypeAdapter.kt
@@ -27,6 +27,7 @@ import androidx.room.solver.CodeGenScope
 import androidx.room.writer.ClassWriter
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
 import javax.lang.model.element.Modifier
 
 /**
@@ -66,6 +67,25 @@ class EnumColumnTypeAdapter(
                 )
             endControlFlow()
         }
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        val enumToStringMethod = enumToStringMethod(scope)
+        val outVarName = scope.getTmpVar()
+        scope.builder().apply {
+            addStatement(
+                "final $T $L = $N($L)",
+                TypeName.get(String::class.java),
+                outVarName,
+                enumToStringMethod,
+                inputVarName
+            )
+        }
+        return outVarName
+    }
+
+    override fun convertedType(): TypeName? {
+        return TypeName.get(String::class.java)
     }
 
     private fun enumToStringMethod(scope: CodeGenScope): MethodSpec {

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/PrimitiveColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/PrimitiveColumnTypeAdapter.kt
@@ -23,6 +23,7 @@ import androidx.room.ext.capitalize
 import androidx.room.parser.SQLTypeAffinity
 import androidx.room.parser.SQLTypeAffinity.REAL
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 import com.squareup.javapoet.TypeName.BYTE
 import com.squareup.javapoet.TypeName.CHAR
 import com.squareup.javapoet.TypeName.DOUBLE
@@ -94,5 +95,13 @@ open class PrimitiveColumnTypeAdapter(
                 "$L = $L$L.$L($L)", outVarName, cast, cursorVarName,
                 cursorGetter, indexVarName
             )
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return null
+    }
+
+    override fun convertedType(): TypeName? {
+        return null
     }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/StatementValueBinder.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/StatementValueBinder.kt
@@ -18,6 +18,7 @@ package androidx.room.solver.types
 
 import androidx.room.compiler.processing.XType
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 
 /**
  * Binds a value into a statement
@@ -31,4 +32,6 @@ interface StatementValueBinder {
         valueVarName: String,
         scope: CodeGenScope
     )
+    fun convert(inputVarName: String, scope: CodeGenScope): String?
+    fun convertedType(): TypeName?
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/StringColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/StringColumnTypeAdapter.kt
@@ -22,6 +22,7 @@ import androidx.room.ext.CommonTypeNames
 import androidx.room.ext.L
 import androidx.room.parser.SQLTypeAffinity.TEXT
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 
 class StringColumnTypeAdapter private constructor(
     out: XType
@@ -58,6 +59,14 @@ class StringColumnTypeAdapter private constructor(
                 .addStatement("$L.bindString($L, $L)", stmtName, indexVarName, valueVarName)
             endControlFlow()
         }
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        return null
+    }
+
+    override fun convertedType(): TypeName? {
+        return null
     }
 
     companion object {

--- a/room/room-compiler/src/main/kotlin/androidx/room/solver/types/UuidColumnTypeAdapter.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/solver/types/UuidColumnTypeAdapter.kt
@@ -22,6 +22,7 @@ import androidx.room.ext.RoomTypeNames
 import androidx.room.ext.T
 import androidx.room.parser.SQLTypeAffinity
 import androidx.room.solver.CodeGenScope
+import com.squareup.javapoet.TypeName
 
 class UuidColumnTypeAdapter(
     out: XType,
@@ -73,5 +74,25 @@ class UuidColumnTypeAdapter(
                 )
             endControlFlow()
         }
+    }
+
+    override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+        val conversionMethodName = "convertUUIDToByte"
+        val outVarName = scope.getTmpVar()
+        scope.builder().apply {
+            addStatement(
+                "final $T $L = $T.$L($L)",
+                TypeName.get(ByteArray::class.java),
+                outVarName,
+                RoomTypeNames.UUID_UTIL,
+                conversionMethodName,
+                inputVarName
+            )
+        }
+        return outVarName
+    }
+
+    override fun convertedType(): TypeName? {
+        return TypeName.get(ByteArray::class.java)
     }
 }

--- a/room/room-compiler/src/main/kotlin/androidx/room/vo/RelationCollector.kt
+++ b/room/room-compiler/src/main/kotlin/androidx/room/vo/RelationCollector.kt
@@ -44,8 +44,6 @@ import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.ParameterizedTypeName
 import com.squareup.javapoet.TypeName
 import java.nio.ByteBuffer
-import java.util.ArrayList
-import java.util.HashSet
 import java.util.Locale
 
 /**
@@ -224,6 +222,10 @@ data class RelationCollector(
                 "final $T $L = $L.size()",
                 TypeName.INT, outputVarName, inputVarName
             )
+        }
+
+        override fun convert(inputVarName: String, scope: CodeGenScope): String? {
+            return null
         }
     }
 

--- a/room/room-compiler/src/test/data/common/input/GuavaRoom.java
+++ b/room/room-compiler/src/test/data/common/input/GuavaRoom.java
@@ -16,7 +16,7 @@ public class GuavaRoom {
             final @NonNull RoomDatabase roomDatabase,
             final boolean inTransaction,
             final @NonNull Callable<T> callable,
-            final @NonNull RoomSQLiteQuery query,
+            final @NonNull Runnable releaseRunnable,
             final boolean releaseQuery,
             final @Nullable CancellationSignal cancellationSignal) {
         return null;

--- a/room/room-compiler/src/test/data/daoWriter/output/ComplexDao.java
+++ b/room/room-compiler/src/test/data/daoWriter/output/ComplexDao.java
@@ -3,26 +3,29 @@ package foo.bar;
 import android.database.Cursor;
 import android.os.CancellationSignal;
 import androidx.lifecycle.LiveData;
+import androidx.room.ParsedQuerySection;
 import androidx.room.RoomDatabase;
 import androidx.room.RoomSQLiteQuery;
 import androidx.room.guava.GuavaRoom;
 import androidx.room.util.CursorUtil;
 import androidx.room.util.DBUtil;
-import androidx.room.util.StringUtil;
+import androidx.room.util.QueryUtil;
 import androidx.sqlite.db.SupportSQLiteQuery;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.lang.Boolean;
 import java.lang.Class;
 import java.lang.Exception;
 import java.lang.Integer;
 import java.lang.Override;
+import java.lang.Runnable;
 import java.lang.String;
-import java.lang.StringBuilder;
 import java.lang.SuppressWarnings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.processing.Generated;
+import kotlin.Pair;
 
 @Generated("androidx.room.RoomProcessor")
 @SuppressWarnings({"unchecked", "deprecation"})
@@ -48,13 +51,18 @@ public final class ComplexDao_Impl extends ComplexDao {
 
     @Override
     public List<ComplexDao.FullName> fullNames(final int id) {
-        final String _sql = "SELECT name || lastName as fullName, uid as id FROM user where uid = ?";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 1);
-        int _argIndex = 1;
-        _statement.bindLong(_argIndex, id);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT name || lastName as fullName, uid as id FROM user where uid = "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":id", false, id));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfFullName = 0;
             final int _cursorIndexOfId = 1;
             final List<ComplexDao.FullName> _result = new ArrayList<ComplexDao.FullName>(_cursor.getCount());
@@ -69,22 +77,36 @@ public final class ComplexDao_Impl extends ComplexDao {
                 _item.id = _cursor.getInt(_cursorIndexOfId);
                 _result.add(_item);
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public User getById(final int id) {
-        final String _sql = "SELECT * FROM user where uid = ?";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 1);
-        int _argIndex = 1;
-        _statement.bindLong(_argIndex, id);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM user where uid = "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":id", false, id));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfUid = CursorUtil.getColumnIndexOrThrow(_cursor, "uid");
             final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
             final int _cursorIndexOfLastName = CursorUtil.getColumnIndexOrThrow(_cursor, "lastName");
@@ -109,32 +131,38 @@ public final class ComplexDao_Impl extends ComplexDao {
             } else {
                 _result = null;
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public User findByName(final String name, final String lastName) {
-        final String _sql = "SELECT * FROM user where name LIKE ? AND lastName LIKE ?";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 2);
-        int _argIndex = 1;
-        if (name == null) {
-            _statement.bindNull(_argIndex);
-        } else {
-            _statement.bindString(_argIndex, name);
-        }
-        _argIndex = 2;
-        if (lastName == null) {
-            _statement.bindNull(_argIndex);
-        } else {
-            _statement.bindString(_argIndex, lastName);
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM user where name LIKE "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":name", false, name));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(" AND lastName LIKE "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":lastName", false, lastName));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfUid = CursorUtil.getColumnIndexOrThrow(_cursor, "uid");
             final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
             final int _cursorIndexOfLastName = CursorUtil.getColumnIndexOrThrow(_cursor, "lastName");
@@ -159,44 +187,50 @@ public final class ComplexDao_Impl extends ComplexDao {
             } else {
                 _result = null;
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public List<User> loadAllByIds(final int... ids) {
-        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-        _stringBuilder.append("SELECT * FROM user where uid IN (");
-        final int _inputSize = ids.length;
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-        _stringBuilder.append(")");
-        final String _sql = _stringBuilder.toString();
-        final int _argCount = 0 + _inputSize;
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, _argCount);
-        int _argIndex = 1;
-        for (int _item : ids) {
-            _statement.bindLong(_argIndex, _item);
-            _argIndex ++;
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM user where uid IN ("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids", true, ids));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfUid = CursorUtil.getColumnIndexOrThrow(_cursor, "uid");
             final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
             final int _cursorIndexOfLastName = CursorUtil.getColumnIndexOrThrow(_cursor, "lastName");
             final int _cursorIndexOfAge = CursorUtil.getColumnIndexOrThrow(_cursor, "ageColumn");
             final List<User> _result = new ArrayList<User>(_cursor.getCount());
             while(_cursor.moveToNext()) {
-                final User _item_1;
-                _item_1 = new User();
-                _item_1.uid = _cursor.getInt(_cursorIndexOfUid);
+                final User _item;
+                _item = new User();
+                _item.uid = _cursor.getInt(_cursorIndexOfUid);
                 if (_cursor.isNull(_cursorIndexOfName)) {
-                    _item_1.name = null;
+                    _item.name = null;
                 } else {
-                    _item_1.name = _cursor.getString(_cursorIndexOfName);
+                    _item.name = _cursor.getString(_cursorIndexOfName);
                 }
                 final String _tmpLastName;
                 if (_cursor.isNull(_cursorIndexOfLastName)) {
@@ -204,178 +238,205 @@ public final class ComplexDao_Impl extends ComplexDao {
                 } else {
                     _tmpLastName = _cursor.getString(_cursorIndexOfLastName);
                 }
-                _item_1.setLastName(_tmpLastName);
-                _item_1.age = _cursor.getInt(_cursorIndexOfAge);
-                _result.add(_item_1);
+                _item.setLastName(_tmpLastName);
+                _item.age = _cursor.getInt(_cursorIndexOfAge);
+                _result.add(_item);
+            }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
             }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     int getAge(final int id) {
-        final String _sql = "SELECT ageColumn FROM user where uid = ?";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 1);
-        int _argIndex = 1;
-        _statement.bindLong(_argIndex, id);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT ageColumn FROM user where uid = "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":id", false, id));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _result;
             if(_cursor.moveToFirst()) {
                 _result = _cursor.getInt(0);
             } else {
                 _result = 0;
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public int[] getAllAges(final int... ids) {
-        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-        _stringBuilder.append("SELECT ageColumn FROM user where uid IN(");
-        final int _inputSize = ids.length;
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-        _stringBuilder.append(")");
-        final String _sql = _stringBuilder.toString();
-        final int _argCount = 0 + _inputSize;
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, _argCount);
-        int _argIndex = 1;
-        for (int _item : ids) {
-            _statement.bindLong(_argIndex, _item);
-            _argIndex ++;
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT ageColumn FROM user where uid IN("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids", true, ids));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int[] _result = new int[_cursor.getCount()];
             int _index = 0;
             while(_cursor.moveToNext()) {
-                final int _item_1;
-                _item_1 = _cursor.getInt(0);
-                _result[_index] = _item_1;
+                final int _item;
+                _item = _cursor.getInt(0);
+                _result[_index] = _item;
                 _index ++;
+            }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
             }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public List<Integer> getAllAgesAsList(final List<Integer> ids) {
-        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-        _stringBuilder.append("SELECT ageColumn FROM user where uid IN(");
-        final int _inputSize = ids.size();
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-        _stringBuilder.append(")");
-        final String _sql = _stringBuilder.toString();
-        final int _argCount = 0 + _inputSize;
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, _argCount);
-        int _argIndex = 1;
-        for (Integer _item : ids) {
-            if (_item == null) {
-                _statement.bindNull(_argIndex);
-            } else {
-                _statement.bindLong(_argIndex, _item);
-            }
-            _argIndex ++;
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT ageColumn FROM user where uid IN("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids", true, ids));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final List<Integer> _result = new ArrayList<Integer>(_cursor.getCount());
             while(_cursor.moveToNext()) {
-                final Integer _item_1;
+                final Integer _item;
                 if (_cursor.isNull(0)) {
-                    _item_1 = null;
+                    _item = null;
                 } else {
-                    _item_1 = _cursor.getInt(0);
+                    _item = _cursor.getInt(0);
                 }
-                _result.add(_item_1);
+                _result.add(_item);
+            }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
             }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public List<Integer> getAllAgesAsList(final List<Integer> ids1, final int[] ids2,
             final int... ids3) {
-        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-        _stringBuilder.append("SELECT ageColumn FROM user where uid IN(");
-        final int _inputSize = ids1.size();
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-        _stringBuilder.append(") OR uid IN (");
-        final int _inputSize_1 = ids2.length;
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize_1);
-        _stringBuilder.append(") OR uid IN (");
-        final int _inputSize_2 = ids3.length;
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize_2);
-        _stringBuilder.append(")");
-        final String _sql = _stringBuilder.toString();
-        final int _argCount = 0 + _inputSize + _inputSize_1 + _inputSize_2;
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, _argCount);
-        int _argIndex = 1;
-        for (Integer _item : ids1) {
-            if (_item == null) {
-                _statement.bindNull(_argIndex);
-            } else {
-                _statement.bindLong(_argIndex, _item);
-            }
-            _argIndex ++;
-        }
-        _argIndex = 1 + _inputSize;
-        for (int _item_1 : ids2) {
-            _statement.bindLong(_argIndex, _item_1);
-            _argIndex ++;
-        }
-        _argIndex = 1 + _inputSize + _inputSize_1;
-        for (int _item_2 : ids3) {
-            _statement.bindLong(_argIndex, _item_2);
-            _argIndex ++;
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT ageColumn FROM user where uid IN("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids1", true, ids1));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(") OR uid IN ("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids2", true, ids2));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(") OR uid IN ("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids3", true, ids3));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final List<Integer> _result = new ArrayList<Integer>(_cursor.getCount());
             while(_cursor.moveToNext()) {
-                final Integer _item_3;
+                final Integer _item;
                 if (_cursor.isNull(0)) {
-                    _item_3 = null;
+                    _item = null;
                 } else {
-                    _item_3 = _cursor.getInt(0);
+                    _item = _cursor.getInt(0);
                 }
-                _result.add(_item_3);
+                _result.add(_item);
+            }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
             }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public LiveData<User> getByIdLive(final int id) {
-        final String _sql = "SELECT * FROM user where uid = ?";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 1);
-        int _argIndex = 1;
-        _statement.bindLong(_argIndex, id);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM user where uid = "));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":id", false, id));
         return __db.getInvalidationTracker().createLiveData(new String[]{"user"}, false, new Callable<User>() {
+            private RoomSQLiteQuery _statement;
+
             @Override
             public User call() throws Exception {
-                final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+                Cursor _cursor = null;
                 try {
+                    boolean _isLargeQuery = false;
+                    final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+                    _statement = _resultPair.getFirst();
+                    _isLargeQuery = _resultPair.getSecond();
+                    _cursor = DBUtil.query(__db, _statement, false, null);
                     final int _cursorIndexOfUid = CursorUtil.getColumnIndexOrThrow(_cursor, "uid");
                     final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
                     final int _cursorIndexOfLastName = CursorUtil.getColumnIndexOrThrow(_cursor, "lastName");
@@ -400,52 +461,59 @@ public final class ComplexDao_Impl extends ComplexDao {
                     } else {
                         _result = null;
                     }
+                    if (_isLargeQuery) {
+                        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                        __db.setTransactionSuccessful();
+                        __db.endTransaction();
+                    }
                     return _result;
                 } finally {
-                    _cursor.close();
+                    if (_cursor != null) {
+                        _cursor.close();
+                    }
                 }
             }
 
             @Override
             protected void finalize() {
-                _statement.release();
+                if (_statement != null) {
+                    _statement.release();
+                }
             }
         });
     }
 
     @Override
     public LiveData<List<User>> loadUsersByIdsLive(final int... ids) {
-        StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-        _stringBuilder.append("SELECT * FROM user where uid IN (");
-        final int _inputSize = ids.length;
-        StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-        _stringBuilder.append(")");
-        final String _sql = _stringBuilder.toString();
-        final int _argCount = 0 + _inputSize;
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, _argCount);
-        int _argIndex = 1;
-        for (int _item : ids) {
-            _statement.bindLong(_argIndex, _item);
-            _argIndex ++;
-        }
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM user where uid IN ("));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":ids", true, ids));
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
         return __db.getInvalidationTracker().createLiveData(new String[]{"user"}, false, new Callable<List<User>>() {
+            private RoomSQLiteQuery _statement;
+
             @Override
             public List<User> call() throws Exception {
-                final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+                Cursor _cursor = null;
                 try {
+                    boolean _isLargeQuery = false;
+                    final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+                    _statement = _resultPair.getFirst();
+                    _isLargeQuery = _resultPair.getSecond();
+                    _cursor = DBUtil.query(__db, _statement, false, null);
                     final int _cursorIndexOfUid = CursorUtil.getColumnIndexOrThrow(_cursor, "uid");
                     final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
                     final int _cursorIndexOfLastName = CursorUtil.getColumnIndexOrThrow(_cursor, "lastName");
                     final int _cursorIndexOfAge = CursorUtil.getColumnIndexOrThrow(_cursor, "ageColumn");
                     final List<User> _result = new ArrayList<User>(_cursor.getCount());
                     while(_cursor.moveToNext()) {
-                        final User _item_1;
-                        _item_1 = new User();
-                        _item_1.uid = _cursor.getInt(_cursorIndexOfUid);
+                        final User _item;
+                        _item = new User();
+                        _item.uid = _cursor.getInt(_cursorIndexOfUid);
                         if (_cursor.isNull(_cursorIndexOfName)) {
-                            _item_1.name = null;
+                            _item.name = null;
                         } else {
-                            _item_1.name = _cursor.getString(_cursorIndexOfName);
+                            _item.name = _cursor.getString(_cursorIndexOfName);
                         }
                         final String _tmpLastName;
                         if (_cursor.isNull(_cursorIndexOfLastName)) {
@@ -453,30 +521,45 @@ public final class ComplexDao_Impl extends ComplexDao {
                         } else {
                             _tmpLastName = _cursor.getString(_cursorIndexOfLastName);
                         }
-                        _item_1.setLastName(_tmpLastName);
-                        _item_1.age = _cursor.getInt(_cursorIndexOfAge);
-                        _result.add(_item_1);
+                        _item.setLastName(_tmpLastName);
+                        _item.age = _cursor.getInt(_cursorIndexOfAge);
+                        _result.add(_item);
+                    }
+                    if (_isLargeQuery) {
+                        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                        __db.setTransactionSuccessful();
+                        __db.endTransaction();
                     }
                     return _result;
                 } finally {
-                    _cursor.close();
+                    if (_cursor != null) {
+                        _cursor.close();
+                    }
                 }
             }
 
             @Override
             protected void finalize() {
-                _statement.release();
+                if (_statement != null) {
+                    _statement.release();
+                }
             }
         });
     }
 
     @Override
     public List<Child1> getChild1List() {
-        final String _sql = "SELECT * FROM Child1";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 0);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM Child1"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfId = CursorUtil.getColumnIndexOrThrow(_cursor, "id");
             final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
             final int _cursorIndexOfSerial = CursorUtil.getColumnIndexOrThrow(_cursor, "serial");
@@ -507,20 +590,35 @@ public final class ComplexDao_Impl extends ComplexDao {
                 _item = new Child1(_tmpId,_tmpName,_tmpInfo);
                 _result.add(_item);
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public List<Child2> getChild2List() {
-        final String _sql = "SELECT * FROM Child2";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 0);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM Child2"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfId = CursorUtil.getColumnIndexOrThrow(_cursor, "id");
             final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
             final int _cursorIndexOfSerial = CursorUtil.getColumnIndexOrThrow(_cursor, "serial");
@@ -551,23 +649,38 @@ public final class ComplexDao_Impl extends ComplexDao {
                 _item = new Child2(_tmpId,_tmpName,_tmpInfo);
                 _result.add(_item);
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
     @Override
     public ListenableFuture<List<Child1>> getChild1ListListenableFuture() {
-        final String _sql = "SELECT * FROM Child1";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 0);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT * FROM Child1"));
         final CancellationSignal _cancellationSignal = DBUtil.createCancellationSignal();
+        final SupportSQLiteQuery[] _query = new SupportSQLiteQuery[]{null};
         return GuavaRoom.createListenableFuture(__db, false, new Callable<List<Child1>>() {
             @Override
             public List<Child1> call() throws Exception {
-                final Cursor _cursor = DBUtil.query(__db, _statement, false, _cancellationSignal);
+                Cursor _cursor = null;
                 try {
+                    boolean _isLargeQuery = false;
+                    final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+                    _query[0] = _resultPair.getFirst();
+                    _isLargeQuery = _resultPair.getSecond();
+                    _cursor = DBUtil.query(__db, _query[0], false, _cancellationSignal);
                     final int _cursorIndexOfId = CursorUtil.getColumnIndexOrThrow(_cursor, "id");
                     final int _cursorIndexOfName = CursorUtil.getColumnIndexOrThrow(_cursor, "name");
                     final int _cursorIndexOfSerial = CursorUtil.getColumnIndexOrThrow(_cursor, "serial");
@@ -598,21 +711,41 @@ public final class ComplexDao_Impl extends ComplexDao {
                         _item = new Child1(_tmpId,_tmpName,_tmpInfo);
                         _result.add(_item);
                     }
+                    if (_isLargeQuery) {
+                        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                        __db.setTransactionSuccessful();
+                        __db.endTransaction();
+                    }
                     return _result;
                 } finally {
-                    _cursor.close();
+                    if (_cursor != null) {
+                        _cursor.close();
+                    }
                 }
             }
-        }, _statement, true, _cancellationSignal);
+        }, new Runnable() {
+            @Override
+            public void run() {
+                if ((_query[0] != null) && (_query[0] instanceof RoomSQLiteQuery)) {
+                    ((RoomSQLiteQuery)_query[0]).release();
+                }
+            }
+        }, true, _cancellationSignal);
     }
 
     @Override
     public List<UserSummary> getUserNames() {
-        final String _sql = "SELECT `uid`, `name` FROM (SELECT * FROM User)";
-        final RoomSQLiteQuery _statement = RoomSQLiteQuery.acquire(_sql, 0);
+        final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+        _parsedQuerySections.add(ParsedQuerySection.Companion.text("SELECT `uid`, `name` FROM (SELECT * FROM User)"));
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _statement, false, null);
+        RoomSQLiteQuery _statement = null;
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            final Pair<RoomSQLiteQuery, Boolean> _resultPair = QueryUtil.prepareQuery(__db, false, "_tempTable", _parsedQuerySections, false);
+            _statement = _resultPair.getFirst();
+            _isLargeQuery = _resultPair.getSecond();
+            _cursor = DBUtil.query(__db, _statement, false, null);
             final int _cursorIndexOfUid = 0;
             final int _cursorIndexOfName = 1;
             final List<UserSummary> _result = new ArrayList<UserSummary>(_cursor.getCount());
@@ -627,10 +760,19 @@ public final class ComplexDao_Impl extends ComplexDao {
                 }
                 _result.add(_item);
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
-            _statement.release();
+            if (_cursor != null) {
+                _cursor.close();
+            }
+            if (_statement != null) {
+                _statement.release();
+            }
         }
     }
 
@@ -638,17 +780,26 @@ public final class ComplexDao_Impl extends ComplexDao {
     public User getUserViaRawQuery(final SupportSQLiteQuery rawQuery) {
         final SupportSQLiteQuery _internalQuery = rawQuery;
         __db.assertNotSuspendingTransaction();
-        final Cursor _cursor = DBUtil.query(__db, _internalQuery, false, null);
+        Cursor _cursor = null;
         try {
+            boolean _isLargeQuery = false;
+            _cursor = DBUtil.query(__db, _internalQuery, false, null);
             final User _result;
             if(_cursor.moveToFirst()) {
                 _result = __entityCursorConverter_fooBarUser(_cursor);
             } else {
                 _result = null;
             }
+            if (_isLargeQuery) {
+                __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+                __db.setTransactionSuccessful();
+                __db.endTransaction();
+            }
             return _result;
         } finally {
-            _cursor.close();
+            if (_cursor != null) {
+                _cursor.close();
+            }
         }
     }
 

--- a/room/room-compiler/src/test/data/daoWriter/output/DeletionDao.java
+++ b/room/room-compiler/src/test/data/daoWriter/output/DeletionDao.java
@@ -1,25 +1,28 @@
 package foo.bar;
 
 import androidx.room.EntityDeletionOrUpdateAdapter;
+import androidx.room.ParsedQuerySection;
 import androidx.room.RoomDatabase;
 import androidx.room.SharedSQLiteStatement;
-import androidx.room.util.StringUtil;
+import androidx.room.util.QueryUtil;
 import androidx.sqlite.db.SupportSQLiteStatement;
 import io.reactivex.Completable;
 import io.reactivex.Maybe;
 import io.reactivex.Single;
+import java.lang.Boolean;
 import java.lang.Class;
 import java.lang.Exception;
 import java.lang.Integer;
 import java.lang.Override;
 import java.lang.String;
-import java.lang.StringBuilder;
 import java.lang.SuppressWarnings;
 import java.lang.Void;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.processing.Generated;
+import kotlin.Pair;
 
 @Generated("androidx.room.RoomProcessor")
 @SuppressWarnings({"unchecked", "deprecation"})
@@ -278,7 +281,11 @@ public final class DeletionDao_Impl implements DeletionDao {
     _stmt.bindLong(_argIndex, uid);
     __db.beginTransaction();
     try {
+      boolean _isLargeQuery = false;
       final int _result = _stmt.executeUpdateDelete();
+      if (_isLargeQuery) {
+        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+      }
       __db.setTransactionSuccessful();
       return _result;
     } finally {
@@ -297,7 +304,11 @@ public final class DeletionDao_Impl implements DeletionDao {
         _stmt.bindLong(_argIndex, uid);
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return null;
         } finally {
@@ -318,7 +329,11 @@ public final class DeletionDao_Impl implements DeletionDao {
         _stmt.bindLong(_argIndex, uid);
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           final java.lang.Integer _result = _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return _result;
         } finally {
@@ -339,7 +354,11 @@ public final class DeletionDao_Impl implements DeletionDao {
         _stmt.bindLong(_argIndex, uid);
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           final java.lang.Integer _result = _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return _result;
         } finally {
@@ -356,7 +375,11 @@ public final class DeletionDao_Impl implements DeletionDao {
     final SupportSQLiteStatement _stmt = __preparedStmtOfDeleteEverything.acquire();
     __db.beginTransaction();
     try {
+      boolean _isLargeQuery = false;
       final int _result = _stmt.executeUpdateDelete();
+      if (_isLargeQuery) {
+        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+      }
       __db.setTransactionSuccessful();
       return _result;
     } finally {
@@ -368,21 +391,20 @@ public final class DeletionDao_Impl implements DeletionDao {
   @Override
   public int deleteByUidList(final int... uid) {
     __db.assertNotSuspendingTransaction();
-    StringBuilder _stringBuilder = StringUtil.newStringBuilder();
-    _stringBuilder.append("DELETE FROM user where uid IN(");
-    final int _inputSize = uid.length;
-    StringUtil.appendPlaceholders(_stringBuilder, _inputSize);
-    _stringBuilder.append(")");
-    final String _sql = _stringBuilder.toString();
-    final SupportSQLiteStatement _stmt = __db.compileStatement(_sql);
-    int _argIndex = 1;
-    for (int _item : uid) {
-      _stmt.bindLong(_argIndex, _item);
-      _argIndex ++;
-    }
+    final List<ParsedQuerySection> _parsedQuerySections = new ArrayList<ParsedQuerySection>();
+    _parsedQuerySections.add(ParsedQuerySection.Companion.text("DELETE FROM user where uid IN("));
+    _parsedQuerySections.add(ParsedQuerySection.Companion.bindVar(":uid", true, uid));
+    _parsedQuerySections.add(ParsedQuerySection.Companion.text(")"));
     __db.beginTransaction();
     try {
+      boolean _isLargeQuery = false;
+      final Pair<SupportSQLiteStatement, Boolean> _resultPair = QueryUtil.prepareStatement(__db, "_tempTable", _parsedQuerySections, false);
+      final SupportSQLiteStatement _stmt = _resultPair.getFirst();
+      _isLargeQuery = _resultPair.getSecond();
       final int _result = _stmt.executeUpdateDelete();
+      if (_isLargeQuery) {
+        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+      }
       __db.setTransactionSuccessful();
       return _result;
     } finally {

--- a/room/room-compiler/src/test/data/daoWriter/output/UpdateDao.java
+++ b/room/room-compiler/src/test/data/daoWriter/output/UpdateDao.java
@@ -353,7 +353,11 @@ public final class UpdateDao_Impl implements UpdateDao {
     }
     __db.beginTransaction();
     try {
+      boolean _isLargeQuery = false;
       _stmt.executeUpdateDelete();
+      if (_isLargeQuery) {
+        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+      }
       __db.setTransactionSuccessful();
     } finally {
       __db.endTransaction();
@@ -367,7 +371,11 @@ public final class UpdateDao_Impl implements UpdateDao {
     final SupportSQLiteStatement _stmt = __preparedStmtOfAgeUserAll.acquire();
     __db.beginTransaction();
     try {
+      boolean _isLargeQuery = false;
       _stmt.executeUpdateDelete();
+      if (_isLargeQuery) {
+        __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+      }
       __db.setTransactionSuccessful();
     } finally {
       __db.endTransaction();
@@ -383,7 +391,11 @@ public final class UpdateDao_Impl implements UpdateDao {
         final SupportSQLiteStatement _stmt = __preparedStmtOfAgeUserAll.acquire();
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return null;
         } finally {
@@ -402,7 +414,11 @@ public final class UpdateDao_Impl implements UpdateDao {
         final SupportSQLiteStatement _stmt = __preparedStmtOfAgeUserAll.acquire();
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           final java.lang.Integer _result = _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return _result;
         } finally {
@@ -421,7 +437,11 @@ public final class UpdateDao_Impl implements UpdateDao {
         final SupportSQLiteStatement _stmt = __preparedStmtOfAgeUserAll.acquire();
         __db.beginTransaction();
         try {
+          boolean _isLargeQuery = false;
           final java.lang.Integer _result = _stmt.executeUpdateDelete();
+          if (_isLargeQuery) {
+            __db.getOpenHelper().getWritableDatabase().execSQL("DROP TABLE IF EXISTS _tempTable");
+          }
           __db.setTransactionSuccessful();
           return _result;
         } finally {

--- a/room/room-guava/api/restricted_current.txt
+++ b/room/room-guava/api/restricted_current.txt
@@ -6,6 +6,7 @@ package androidx.room.guava {
     method @Deprecated public static <T> com.google.common.util.concurrent.ListenableFuture<T!>! createListenableFuture(androidx.room.RoomDatabase!, java.util.concurrent.Callable<T!>!, androidx.room.RoomSQLiteQuery!, boolean);
     method public static <T> com.google.common.util.concurrent.ListenableFuture<T!>! createListenableFuture(androidx.room.RoomDatabase!, boolean, java.util.concurrent.Callable<T!>!, androidx.room.RoomSQLiteQuery!, boolean);
     method public static <T> com.google.common.util.concurrent.ListenableFuture<T!> createListenableFuture(androidx.room.RoomDatabase, boolean, java.util.concurrent.Callable<T!>, androidx.room.RoomSQLiteQuery, boolean, android.os.CancellationSignal?);
+    method public static <T> com.google.common.util.concurrent.ListenableFuture<T!> createListenableFuture(androidx.room.RoomDatabase, boolean, java.util.concurrent.Callable<T!>, Runnable, boolean, android.os.CancellationSignal?);
     method @Deprecated public static <T> com.google.common.util.concurrent.ListenableFuture<T!> createListenableFuture(androidx.room.RoomDatabase, java.util.concurrent.Callable<T!>);
     method public static <T> com.google.common.util.concurrent.ListenableFuture<T!> createListenableFuture(androidx.room.RoomDatabase, boolean, java.util.concurrent.Callable<T!>);
   }

--- a/room/room-guava/src/androidTest/java/androidx/room/guava/GuavaRoomTest.java
+++ b/room/room-guava/src/androidTest/java/androidx/room/guava/GuavaRoomTest.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import androidx.room.DatabaseConfiguration;
 import androidx.room.InvalidationTracker;
 import androidx.room.RoomDatabase;
+import androidx.room.RoomSQLiteQuery;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 import androidx.test.filters.SdkSuppress;
 import androidx.test.filters.SmallTest;
@@ -44,7 +45,7 @@ public class GuavaRoomTest {
 
         CancellationSignal signal = new CancellationSignal();
         ListenableFuture<Integer> future = GuavaRoom.createListenableFuture(
-                new TestDatabase(executor), false, () -> 1, null, false, signal);
+                new TestDatabase(executor), false, () -> 1, (RoomSQLiteQuery) null, false, signal);
 
         future.cancel(true);
 

--- a/room/room-runtime/api/restricted_current.txt
+++ b/room/room-runtime/api/restricted_current.txt
@@ -248,6 +248,7 @@ package androidx.room {
 
   public static final class RoomSQLiteQuery.Companion {
     method public androidx.room.RoomSQLiteQuery acquire(String query, int argumentCount);
+    method public void bind(androidx.room.RoomSQLiteQuery query, int index, Object? arg);
     method public androidx.room.RoomSQLiteQuery copyFrom(androidx.sqlite.db.SupportSQLiteQuery supportSQLiteQuery);
   }
 
@@ -329,7 +330,13 @@ package androidx.room.util {
     method public androidx.room.util.FtsTableInfo read(androidx.sqlite.db.SupportSQLiteDatabase database, String tableName);
   }
 
+  @RestrictTo({androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX}) public final class QueryUtil {
+    method public static kotlin.Pair<androidx.room.RoomSQLiteQuery,java.lang.Boolean> prepareQuery(androidx.room.RoomDatabase db, boolean inTransaction, String tempTable, java.util.List<? extends androidx.room.ParsedQuerySection> sections, boolean throwForLargeQueries);
+    method public static kotlin.Pair<androidx.sqlite.db.SupportSQLiteStatement,java.lang.Boolean> prepareStatement(androidx.room.RoomDatabase db, String tempTable, java.util.List<? extends androidx.room.ParsedQuerySection> sections, boolean throwForLargeQueries);
+  }
+
   @RestrictTo({androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX}) public final class StringUtil {
+    method public static void appendParenthesizedPlaceholders(StringBuilder builder, int count);
     method public static void appendPlaceholders(StringBuilder builder, int count);
     method public static String? joinIntoString(java.util.List<java.lang.Integer>? input);
     method public static StringBuilder newStringBuilder();

--- a/room/room-runtime/src/main/java/androidx/room/RoomSQLiteQuery.kt
+++ b/room/room-runtime/src/main/java/androidx/room/RoomSQLiteQuery.kt
@@ -220,6 +220,43 @@ open class RoomSQLiteQuery private constructor(
             return sqLiteQuery
         }
 
+        /**
+         * Binds the given argument into the given Room SQLite query.
+         *
+         * @param query The Room SQLite query
+         * @param index The 1-based index to the parameter to bind
+         * @param arg   The argument to bind
+         */
+        fun bind(query: RoomSQLiteQuery, index: Int, arg: Any?) {
+            // extracted from android.database.sqlite.SQLiteConnection
+            if (arg == null) {
+                query.bindNull(index)
+            } else if (arg is ByteArray) {
+                query.bindBlob(index, arg)
+            } else if (arg is Float) {
+                query.bindDouble(index, arg.toDouble())
+            } else if (arg is Double) {
+                query.bindDouble(index, arg)
+            } else if (arg is Long) {
+                query.bindLong(index, arg)
+            } else if (arg is Int) {
+                query.bindLong(index, arg.toLong())
+            } else if (arg is Short) {
+                query.bindLong(index, arg.toLong())
+            } else if (arg is Byte) {
+                query.bindLong(index, arg.toLong())
+            } else if (arg is String) {
+                query.bindString(index, arg)
+            } else if (arg is Boolean) {
+                query.bindLong(index, (if (arg) 1 else 0).toLong())
+            } else {
+                throw IllegalArgumentException(
+                    "Cannot bind $arg at index $index Supported types: null, byte[], float, " +
+                        "double, long, int, short, byte, string"
+                )
+            }
+        }
+
         internal fun prunePoolLocked() {
             if (queryPool.size > POOL_LIMIT) {
                 var toBeRemoved = queryPool.size - DESIRED_POOL_SIZE

--- a/room/room-runtime/src/main/java/androidx/room/util/QueryUtil.kt
+++ b/room/room-runtime/src/main/java/androidx/room/util/QueryUtil.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("QueryUtil")
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+
+package androidx.room.util
+
+import androidx.annotation.RestrictTo
+import androidx.room.ParsedQuerySection
+import androidx.room.RoomDatabase
+import androidx.room.RoomSQLiteQuery
+import androidx.sqlite.db.SimpleSQLiteQuery
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteStatement
+import java.lang.Integer.min
+
+/**
+ * Prepares the query at runtime. Checks the number of query parameters and if it's larger than
+ * [RoomDatabase.MAX_BIND_PARAMETER_CNT], then it uses a special logic to handle such big queries.
+ *
+ * @param db - a [RoomDatabase] instance
+ * @param tempTable - the name of the temp table that will be created for large queries
+ * @param sections - a list of [ParsedQuerySection]
+ * @param throwForLargeQueries - if this parameter is true then the method will throw an exception
+ * for large queries instead of preparing them
+ *
+ * @return a pair of [RoomSQLiteQuery] and a boolean flag where true means that this is a
+ * large query (has more than [RoomDatabase.MAX_BIND_PARAMETER_CNT] parametrs, false otherwise.
+ */
+fun prepareStatement(
+    db: RoomDatabase,
+    tempTable: String,
+    sections: List<ParsedQuerySection>,
+    throwForLargeQueries: Boolean
+): Pair<SupportSQLiteStatement, Boolean> {
+    val bindVars = sections.filterIsInstance<ParsedQuerySection.BindVar>()
+
+    val paramCount = bindVars.sumOf { it.parameterCount }
+
+    val isLargeQuery = paramCount > RoomDatabase.MAX_BIND_PARAMETER_CNT
+
+    if (isLargeQuery) {
+        if (throwForLargeQueries) {
+            throw java.lang.IllegalStateException(
+                "Room doesn't support paging and Cursor returning queries with more " +
+                    "than ${RoomDatabase.MAX_BIND_PARAMETER_CNT} parameters."
+            )
+        }
+        return prepareLargeStatement(db, tempTable, sections)
+    }
+
+    val sql = newStringBuilder()
+    sections.forEach { section ->
+        when (section) {
+            is ParsedQuerySection.Text -> sql.append(section.text)
+            is ParsedQuerySection.BindVar -> appendPlaceholders(sql, section.parameterCount)
+        }
+    }
+
+    val statement = db.compileStatement(sql.toString())
+    var argIndex = 1
+
+    bindVars.forEach { section ->
+        val iterator = section.iterator
+        if (iterator != null) {
+            iterator.forEach { item ->
+                SimpleSQLiteQuery.bind(statement, argIndex, item)
+                argIndex++
+            }
+        } else {
+            SimpleSQLiteQuery.bind(statement, argIndex, section.value)
+            argIndex++
+        }
+    }
+
+    return Pair(statement, false)
+}
+
+private fun prepareLargeStatement(
+    db: RoomDatabase,
+    tempTable: String,
+    sections: List<ParsedQuerySection>
+): Pair<SupportSQLiteStatement, Boolean> {
+    val writableDB = db.openHelper.writableDatabase
+
+    writableDB.execSQL("PRAGMA temp_store = MEMORY")
+    writableDB.execSQL("CREATE TEMP TABLE $tempTable(value TEXT)")
+
+    sections.filterIsInstance<ParsedQuerySection.BindVar>().forEach { section ->
+        val iterator = section.iterator
+        if (iterator != null) {
+            insertIntoTempTable(writableDB, tempTable, iterator, section.parameterCount)
+        } else {
+            writableDB.execSQL("INSERT INTO $tempTable (value) VALUES(?)", arrayOf(section.value))
+        }
+    }
+
+    val sql = newStringBuilder()
+    var startRow = 1
+    sections.forEach { section ->
+        when (section) {
+            is ParsedQuerySection.Text -> sql.append(section.text)
+            is ParsedQuerySection.BindVar -> {
+                if (section.isMultiple) {
+                    sql.append("SELECT value FROM $tempTable WHERE _rowid_ >= ")
+                    sql.append(startRow)
+                    sql.append(" AND _rowid_ < ")
+                    sql.append(startRow + section.parameterCount)
+                    startRow += section.parameterCount
+                } else {
+                    sql.append("(SELECT value FROM $tempTable WHERE _rowid_ >= ")
+                    sql.append(startRow)
+                    sql.append(" AND _rowid_ < ")
+                    sql.append(startRow + 1)
+                    sql.append(")")
+                    startRow += 1
+                }
+            }
+        }
+    }
+
+    return Pair(db.compileStatement(sql.toString()), true)
+}
+
+/**
+ * Prepares the query at runtime. Checks the number of query parameters and if it's larger than
+ * [RoomDatabase.MAX_BIND_PARAMETER_CNT], then it uses a special logic to handle such big queries.
+ *
+ * @param db - a [RoomDatabase] instance
+ * @param inTransaction - true if this method is being called within transaction, false otherwise
+ * @param tempTable - the name of the temp table that will be created for large queries
+ * @param sections - a list of [ParsedQuerySection]
+ * @param throwForLargeQueries - if this parameter is true then the method will throw an exception
+ * for large queries instead of preparing them
+ *
+ * @return a pair of [RoomSQLiteQuery] and a boolean flag where true means that this is a
+ * large query (has more than [RoomDatabase.MAX_BIND_PARAMETER_CNT] parametrs, false otherwise.
+ */
+fun prepareQuery(
+    db: RoomDatabase,
+    inTransaction: Boolean,
+    tempTable: String,
+    sections: List<ParsedQuerySection>,
+    throwForLargeQueries: Boolean
+): Pair<RoomSQLiteQuery, Boolean> {
+    val bindVars = sections.filterIsInstance<ParsedQuerySection.BindVar>()
+
+    val paramCount = bindVars.sumOf { it.parameterCount }
+
+    val isLargeQuery = paramCount > RoomDatabase.MAX_BIND_PARAMETER_CNT
+
+    if (isLargeQuery) {
+        if (throwForLargeQueries) {
+            throw java.lang.IllegalStateException(
+                "Room doesn't support paging and Cursor returning queries with more " +
+                    "than ${RoomDatabase.MAX_BIND_PARAMETER_CNT} parameters."
+            )
+        }
+        return prepareLargeQuery(db, inTransaction, tempTable, sections)
+    }
+
+    val sql = newStringBuilder()
+    sections.forEach { section ->
+        when (section) {
+            is ParsedQuerySection.Text -> sql.append(section.text)
+            is ParsedQuerySection.BindVar -> appendPlaceholders(sql, section.parameterCount)
+        }
+    }
+
+    val statement = RoomSQLiteQuery.acquire(sql.toString(), paramCount)
+    var argIndex = 1
+
+    bindVars.forEach { section ->
+        val iterator = section.iterator
+        if (iterator != null) {
+            iterator.forEach { item ->
+                RoomSQLiteQuery.bind(statement, argIndex, item)
+                argIndex++
+            }
+        } else {
+            RoomSQLiteQuery.bind(statement, argIndex, section.value)
+            argIndex++
+        }
+    }
+
+    return Pair(statement, false)
+}
+
+private fun prepareLargeQuery(
+    db: RoomDatabase,
+    inTransaction: Boolean,
+    tempTable: String,
+    sections: List<ParsedQuerySection>
+): Pair<RoomSQLiteQuery, Boolean> {
+    val writableDB = db.openHelper.writableDatabase
+
+    // Operations on temp table have to be performed inside a transaction so we have to begin a
+    // transaction if we're not inside one already.
+    if (!inTransaction) {
+        db.beginTransaction()
+    }
+
+    writableDB.execSQL("PRAGMA temp_store = MEMORY")
+    writableDB.execSQL("CREATE TEMP TABLE $tempTable(value TEXT)")
+
+    sections.filterIsInstance<ParsedQuerySection.BindVar>().forEach { section ->
+        val iterator = section.iterator
+        if (iterator != null) {
+            insertIntoTempTable(writableDB, tempTable, iterator, section.parameterCount)
+        } else {
+            writableDB.execSQL("INSERT INTO $tempTable (value) VALUES(?)", arrayOf(section.value))
+        }
+    }
+
+    val sql = newStringBuilder()
+    var startRow = 1
+    sections.forEach { section ->
+        when (section) {
+            is ParsedQuerySection.Text -> sql.append(section.text)
+            is ParsedQuerySection.BindVar -> {
+                if (section.isMultiple) {
+                    sql.append("SELECT value FROM $tempTable WHERE _rowid_ >= ")
+                    sql.append(startRow)
+                    sql.append(" AND _rowid_ < ")
+                    sql.append(startRow + section.parameterCount)
+                    startRow += section.parameterCount
+                } else {
+                    sql.append("(SELECT value FROM $tempTable WHERE _rowid_ >= ")
+                    sql.append(startRow)
+                    sql.append(" AND _rowid_ < ")
+                    sql.append(startRow + 1)
+                    sql.append(")")
+                    startRow += 1
+                }
+            }
+        }
+    }
+
+    return Pair(RoomSQLiteQuery.acquire(sql.toString(), 0), true)
+}
+
+/**
+ * Safely inserts data into the temp table. Inserts the values in chunks if there are
+ * more than [RoomDatabase.MAX_BIND_PARAMETER_CNT] parameters.
+ */
+private fun insertIntoTempTable(
+    db: SupportSQLiteDatabase,
+    tempTable: String,
+    iterator: Iterator<*>,
+    parameterCount: Int
+) {
+    val parts: MutableList<Any?> = ArrayList()
+
+    var start = 0
+    while (start < parameterCount) {
+        val end = min(start + RoomDatabase.MAX_BIND_PARAMETER_CNT, parameterCount)
+        val stringBuilder = newStringBuilder()
+        stringBuilder.append("INSERT INTO $tempTable (value) VALUES ")
+        val inputSize = end - start
+        appendParenthesizedPlaceholders(stringBuilder, inputSize)
+        while (iterator.hasNext() && parts.size < inputSize) {
+            parts.add(iterator.next())
+        }
+        db.execSQL(stringBuilder.toString(), parts.toTypedArray())
+        parts.clear()
+        start += RoomDatabase.MAX_BIND_PARAMETER_CNT
+    }
+}

--- a/room/room-runtime/src/main/java/androidx/room/util/StringUtil.kt
+++ b/room/room-runtime/src/main/java/androidx/room/util/StringUtil.kt
@@ -20,8 +20,6 @@ package androidx.room.util
 
 import android.util.Log
 import androidx.annotation.RestrictTo
-import java.lang.NumberFormatException
-import java.lang.StringBuilder
 
 @Suppress("unused")
 @JvmField
@@ -47,6 +45,22 @@ fun newStringBuilder(): StringBuilder {
 fun appendPlaceholders(builder: StringBuilder, count: Int) {
     for (i in 0 until count) {
         builder.append("?")
+        if (i < count - 1) {
+            builder.append(",")
+        }
+    }
+}
+
+/**
+ * Adds bind variable placeholders (?) to the given string. Each placeholder is separated
+ * by a comma and parenthesized.
+ *
+ * @param builder The StringBuilder for the query
+ * @param count Number of placeholders
+ */
+fun appendParenthesizedPlaceholders(builder: StringBuilder, count: Int) {
+    for (i in 0 until count) {
+        builder.append("(?)")
         if (i < count - 1) {
             builder.append(",")
         }

--- a/sqlite/sqlite/api/current.txt
+++ b/sqlite/sqlite/api/current.txt
@@ -5,6 +5,7 @@ package androidx.sqlite.db {
     ctor public SimpleSQLiteQuery(String, Object![]?);
     ctor public SimpleSQLiteQuery(String);
     method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, Object![]?);
+    method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, int, Object?);
     method public void bindTo(androidx.sqlite.db.SupportSQLiteProgram);
     method public int getArgCount();
     method public String getSql();

--- a/sqlite/sqlite/api/public_plus_experimental_current.txt
+++ b/sqlite/sqlite/api/public_plus_experimental_current.txt
@@ -5,6 +5,7 @@ package androidx.sqlite.db {
     ctor public SimpleSQLiteQuery(String, Object![]?);
     ctor public SimpleSQLiteQuery(String);
     method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, Object![]?);
+    method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, int, Object?);
     method public void bindTo(androidx.sqlite.db.SupportSQLiteProgram);
     method public int getArgCount();
     method public String getSql();

--- a/sqlite/sqlite/api/restricted_current.txt
+++ b/sqlite/sqlite/api/restricted_current.txt
@@ -5,6 +5,7 @@ package androidx.sqlite.db {
     ctor public SimpleSQLiteQuery(String, Object![]?);
     ctor public SimpleSQLiteQuery(String);
     method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, Object![]?);
+    method public static void bind(androidx.sqlite.db.SupportSQLiteProgram, int, Object?);
     method public void bindTo(androidx.sqlite.db.SupportSQLiteProgram);
     method public int getArgCount();
     method public String getSql();

--- a/sqlite/sqlite/src/main/java/androidx/sqlite/db/SimpleSQLiteQuery.java
+++ b/sqlite/sqlite/src/main/java/androidx/sqlite/db/SimpleSQLiteQuery.java
@@ -81,7 +81,15 @@ public final class SimpleSQLiteQuery implements SupportSQLiteQuery {
         }
     }
 
-    private static void bind(SupportSQLiteProgram statement, int index, Object arg) {
+    /**
+     * Binds the given arguments into the given sqlite statement.
+     *
+     * @param statement The sqlite statement
+     * @param index     The 1-based index to the parameter to bind
+     * @param arg       The argument to bind
+     */
+    public static void bind(@NonNull SupportSQLiteProgram statement, int index,
+            @Nullable Object arg) {
         // extracted from android.database.sqlite.SQLiteConnection
         if (arg == null) {
             statement.bindNull(index);


### PR DESCRIPTION
## Proposed Changes

This change adds support for large SQLite queries. Large queries are queries with more than 999 host parameters. 

Prior to this change, if someone created a query like:
```
@Query("DELETE * FROM user WHERE id IN (:ids)")
fun delete(ids: List<Int>)
```
and invoked this function passing a list larger than 999 items, the library would throw a `SQLiteException`.

The implementation details and codegen changes are documented in the design doc: https://docs.google.com/document/d/1tQPjWLmBS55Cu-1lxa3Nn-eUaOCT6HCnftsmOo_NEfo/edit?usp=sharing

### Limitations

The solution supports everything except:
 - `@RawQuery` - it's not possible to support raw queries, because the implemented solution relies on query parsing which happens during compilation while raw queries are executed at runtime.
 - `Cursor` returning dao methods - The implemented solution uses temp tables which have to be closed as soon as the dao method finishes execution. Cursor is lazy, so the underlying query is executed when the Cursor is accessed for the first time at which point the temp table probably no longer exists.
 - Paging - it may be possible to support it, but I don't have enough experience with Paging to tell and the change got quite big already so I decided to skip this part for now.

## Testing

Test: Added new large query unit tests tests and a benchmark test

## Issues Fixed

Fixes: b/73634057

RelNote: Room now supports queries with more than 999 host parameters.
