### PR TITLE
Bump playground to gradle 7.5 stable

### DIFF
--- a/playground-common/gradle/wrapper/gradle-wrapper.properties
+++ b/playground-common/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-rc-2-bin.zip
-distributionSha256Sum=ba761aa1563f5d893d1a6e7ddca48bbdc4385fdd527974e6472b873b7eae9a32
+distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Test: ./gradlew wrapper --gradle-version=7.5 --distribution-type=bin --gradle-distribution-sha256-sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
Change-Id: I9cc0f278a2679f6e82b7513a3319c486abc48927