### PR TITLE
Add annotation:annotation-experimental to core playground

### DIFF
--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -16,6 +16,7 @@ playground {
         if (name == ":internal-testutils-fonts") return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true
+        if (name.startsWith(":annotation:annotation-experimental")) return true
         if (name == ":annotation:annotation-sampled") return true
         if (name == ":test:screenshot:screenshot") return true
         if (name == ":test:screenshot:screenshot-proto") return true


### PR DESCRIPTION
This fixes the current failure ToT due to missing this artifact from the
playground's settings.gradle

Test: cd core && ./gradlew bOS
Change-Id: I8f81a019469c3e35e7a373fd01c3774dc665626b
