### PR TITLE
Add the rememberUpdatedStateWithLifecycle APIs

### DIFF
--- a/lifecycle/lifecycle-runtime-compose/api/current.txt
+++ b/lifecycle/lifecycle-runtime-compose/api/current.txt
@@ -4,5 +4,8 @@ package androidx.lifecycle.compose {
   public final class FlowExtKt {
   }
 
+  public final class StateKt {
+  }
+
 }
 

--- a/lifecycle/lifecycle-runtime-compose/api/public_plus_experimental_current.txt
+++ b/lifecycle/lifecycle-runtime-compose/api/public_plus_experimental_current.txt
@@ -11,5 +11,10 @@ package androidx.lifecycle.compose {
     method @androidx.compose.runtime.Composable @androidx.lifecycle.compose.ExperimentalLifecycleComposeApi public static <T> androidx.compose.runtime.State<T> collectAsStateWithLifecycle(kotlinx.coroutines.flow.Flow<? extends T>, T? initialValue, androidx.lifecycle.Lifecycle lifecycle, optional androidx.lifecycle.Lifecycle.State minActiveState, optional kotlin.coroutines.CoroutineContext context);
   }
 
+  public final class StateKt {
+    method @androidx.compose.runtime.Composable @androidx.lifecycle.compose.ExperimentalLifecycleComposeApi public static <T> androidx.compose.runtime.State<T> rememberUpdatedStateWithLifecycle(T? initialValue, optional androidx.lifecycle.LifecycleOwner lifecycleOwner, optional androidx.lifecycle.Lifecycle.State minActiveState, optional kotlin.coroutines.CoroutineContext context, kotlin.jvm.functions.Function0<? extends T> updater);
+    method @androidx.compose.runtime.Composable @androidx.lifecycle.compose.ExperimentalLifecycleComposeApi public static <T> androidx.compose.runtime.State<T> rememberUpdatedStateWithLifecycle(T? initialValue, androidx.lifecycle.Lifecycle lifecycle, optional androidx.lifecycle.Lifecycle.State minActiveState, optional kotlin.coroutines.CoroutineContext context, kotlin.jvm.functions.Function0<? extends T> updater);
+  }
+
 }
 

--- a/lifecycle/lifecycle-runtime-compose/api/restricted_current.txt
+++ b/lifecycle/lifecycle-runtime-compose/api/restricted_current.txt
@@ -4,5 +4,8 @@ package androidx.lifecycle.compose {
   public final class FlowExtKt {
   }
 
+  public final class StateKt {
+  }
+
 }
 

--- a/lifecycle/lifecycle-runtime-compose/samples/src/main/java/androidx/lifecycle/compose/samples/LifecycleComposeSamples.kt
+++ b/lifecycle/lifecycle-runtime-compose/samples/src/main/java/androidx/lifecycle/compose/samples/LifecycleComposeSamples.kt
@@ -23,8 +23,11 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.ExperimentalLifecycleComposeApi
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.compose.rememberUpdatedStateWithLifecycle
+import kotlin.random.Random
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -61,4 +64,15 @@ fun FlowCollectAsStateWithLifecycle() {
     val state = remember { ExampleState() }
     val count by state.counter.collectAsStateWithLifecycle(initialValue = 0)
     Text(text = "$count")
+}
+
+@Sampled
+@Composable
+fun UpdatedStateWithLifecycle() {
+    val random by rememberUpdatedStateWithLifecycle(
+        initialValue = 0,
+        minActiveState = Lifecycle.State.RESUMED,
+        updater = { Random.nextInt() },
+    )
+    Text(text = "$random")
 }

--- a/lifecycle/lifecycle-runtime-compose/src/androidTest/java/androidx/lifecycle/compose/UpdatedStateWithLifecycleTests.kt
+++ b/lifecycle/lifecycle-runtime-compose/src/androidTest/java/androidx/lifecycle/compose/UpdatedStateWithLifecycleTests.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.lifecycle.compose
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalLifecycleComposeApi::class)
+class UpdatedStateWithLifecycleTests {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun test_getsInitialValue() {
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        var realValue: String? = null
+
+        rule.setContent {
+            realValue = rememberUpdatedStateWithLifecycle(
+                initialValue = "0",
+                lifecycleOwner = lifecycleOwner,
+                minActiveState = Lifecycle.State.RESUMED,
+                updater = { "1" },
+            ).value
+        }
+
+        rule.runOnIdle {
+            Truth.assertThat(realValue).isEqualTo("0")
+        }
+    }
+
+    @Test
+    fun test_getsSubsequentEmissions() {
+        val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.CREATED)
+        var count = 0
+        var state: State<Int> = mutableStateOf(-1)
+        rule.setContent {
+            state = rememberUpdatedStateWithLifecycle(
+                initialValue = 0,
+                lifecycle = lifecycleOwner.lifecycle,
+                minActiveState = Lifecycle.State.RESUMED,
+                updater = { ++count },
+            )
+        }
+
+        rule.runOnIdle {
+            Truth.assertThat(state.value).isEqualTo(0)
+        }
+
+        lifecycleOwner.currentState = Lifecycle.State.RESUMED
+
+        rule.runOnIdle {
+            Truth.assertThat(state.value).isEqualTo(1)
+        }
+    }
+}

--- a/lifecycle/lifecycle-runtime-compose/src/main/java/androidx/lifecycle/compose/State.kt
+++ b/lifecycle/lifecycle-runtime-compose/src/main/java/androidx/lifecycle/compose/State.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.lifecycle.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlinx.coroutines.withContext
+
+/**
+ * Represents its latest value via [State] in a lifecycle-aware manner.
+ *
+ * Warning: [Lifecycle.State.INITIALIZED] is not allowed in this API. Passing it as a
+ * parameter will throw an [IllegalArgumentException].
+ *
+ * @sample androidx.lifecycle.compose.samples.UpdatedStateWithLifecycle
+ *
+ * @param initialValue The initial value given to the returned [State.value].
+ * @param lifecycleOwner [LifecycleOwner] whose `lifecycle` is used to re-updating this [State].
+ * @param minActiveState [Lifecycle.State] in which the value gets updated. The update will stop
+ * if the lifecycle falls below that state, and will restart if it's in that state again.
+ * @param context [CoroutineContext] to use for updating value.
+ * @param updater Runs block to produce new value to [State].
+ */
+@ExperimentalLifecycleComposeApi
+@Composable
+fun <T> rememberUpdatedStateWithLifecycle(
+    initialValue: T,
+    lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    context: CoroutineContext = EmptyCoroutineContext,
+    updater: () -> T,
+): State<T> = rememberUpdatedStateWithLifecycle(
+    initialValue = initialValue,
+    lifecycle = lifecycleOwner.lifecycle,
+    minActiveState = minActiveState,
+    context = context,
+    updater = updater,
+)
+
+/**
+ * Represents its latest value via [State] in a lifecycle-aware manner.
+ *
+ * Warning: [Lifecycle.State.INITIALIZED] is not allowed in this API. Passing it as a
+ * parameter will throw an [IllegalArgumentException].
+ *
+ * @sample androidx.lifecycle.compose.samples.UpdatedStateWithLifecycle
+ *
+ * @param initialValue The initial value given to the returned [State.value].
+ * @param lifecycle [Lifecycle] is used to re-updating this [State].
+ * @param minActiveState [Lifecycle.State] in which the value gets updated. The update will stop
+ * if the lifecycle falls below that state, and will restart if it's in that state again.
+ * @param context [CoroutineContext] to use for updating value.
+ * @param updater Runs block to produce new value to [State].
+ */
+@ExperimentalLifecycleComposeApi
+@Composable
+fun <T> rememberUpdatedStateWithLifecycle(
+    initialValue: T,
+    lifecycle: Lifecycle,
+    minActiveState: Lifecycle.State = Lifecycle.State.STARTED,
+    context: CoroutineContext = EmptyCoroutineContext,
+    updater: () -> T,
+): State<T> = produceState(initialValue, lifecycle, minActiveState, context, updater) {
+    lifecycle.repeatOnLifecycle(minActiveState) {
+        if (context == EmptyCoroutineContext) {
+            this@produceState.value = updater()
+        } else withContext(context) {
+            this@produceState.value = updater()
+        }
+    }
+}


### PR DESCRIPTION
Add the rememberUpdatedStateWithLifecycle APIs that represents its latest value via State in a lifecycle-aware manner. Only update the latest value while the lifecycle is at least in a certain Lifecycle.State.

Test: UpdatedStateWithLifecycleTests

## Proposed Changes

  - Add the rememberUpdatedStateWithLifecycle APIs. Also, it may be related to https://issuetracker.google.com/issues/235529345.

## Testing

Test: ./gradlew lifecycle:lifecycle-runtime-compose:test

