### PR TITLE
Use projectOrArtifact for lifecycle-runtime so it is accessible playground

### DIFF
--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     constraints {
         implementation(project(":lifecycle:lifecycle-common-java8"))
-        implementation(project(":lifecycle:lifecycle-runtime"))
+        implementation(projectOrArtifact(":lifecycle:lifecycle-runtime"))
     }
 }
 

--- a/room/integration-tests/kotlintestapp/build.gradle
+++ b/room/integration-tests/kotlintestapp/build.gradle
@@ -112,7 +112,7 @@ dependencies {
     androidTestImplementation(project(":internal-testutils-common"))
     androidTestImplementation("androidx.arch.core:core-testing:2.0.1")
     androidTestImplementation("androidx.paging:paging-runtime:3.1.1")
-    androidTestImplementation(project(":lifecycle:lifecycle-runtime-testing"))
+    androidTestImplementation(projectOrArtifact(":lifecycle:lifecycle-runtime-testing"))
     androidTestImplementation(libs.rxjava2)
     testImplementation(libs.mockitoCore)
 }


### PR DESCRIPTION
The playground helper, isNeededForCompose also pulls in lifecycle-common
project into Compose playgrounds, but not lifecycle-runtime.

Test: cd compose/runtime && ./gradlew bOS