### PR TITLE
Install cmake from stable channel in playground

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -37,7 +37,7 @@ runs:
     # version in case it is not available.
     - name: "Install Cmake"
       shell: bash
-      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1" --channel=3
+      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1"
     - name: "Set environment variables"
       shell: bash
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ creating a fork of the [androidx/androidx](https://github.com/androidx/androidx)
 
   ```bash
   sdkmanager --install "ndk;23.1.7779620"
-  sdkmanager --install "cmake;3.22.1" --channel=3 #channel 3 is the canary channel
+  sdkmanager --install "cmake;3.22.1"
   ```
 
 - Next, set up the following environment variables:


### PR DESCRIPTION
cmake 3.22.1 used to be only available from sdkmanager in canary channel, but
seems to have since been released to stable.

Test: GH actions
Change-Id: I38eae737f0fc00bfddba6c6e68c7c9b41aa91564
