### PR TITLE
Decouple lifecycle from compose playgrounds

### DIFF
--- a/lifecycle/lifecycle-common/build.gradle
+++ b/lifecycle/lifecycle-common/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 
     constraints {
         implementation(project(":lifecycle:lifecycle-common-java8"))
-        implementation(projectOrArtifact(":lifecycle:lifecycle-runtime"))
+        implementation(project(":lifecycle:lifecycle-runtime"))
         implementation(project(":lifecycle:lifecycle-livedata-core"))
     }
 }

--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
@@ -164,8 +164,6 @@ open class PlaygroundExtension @Inject constructor(
         if (name == ":compose:lint:common-test") return true
         if (name == ":test:screenshot:screenshot") return true
         if (name == ":test:screenshot:screenshot-proto") return true
-        if (name == ":lifecycle:lifecycle-common") return true
-        if (name == ":lifecycle:lifecycle-common-java8") return true
         return false
     }
 }


### PR DESCRIPTION
It's not clear why the lifecycle project is automatically included for
playgrounds with Compose, but it is starting to cause issues with project
dependencies - so removing it since it doesn't seem necessary

Test: cd compose/runtime && ./gradlew bOS
Change-Id: Ifca074255546f56a9bac733de20f974cc8350c88