### PR TITLE
Fix appcompat playground

### DIFF
--- a/appcompat/appcompat/build.gradle
+++ b/appcompat/appcompat/build.gradle
@@ -54,7 +54,7 @@ dependencies {
         exclude group: "androidx.appcompat", module: "appcompat"
         exclude group: "androidx.core", module: "core"
     })
-    androidTestImplementation(project(":recyclerview:recyclerview"))
+    androidTestImplementation(projectOrArtifact(":recyclerview:recyclerview"))
     androidTestImplementation(libs.multidex)
 
     testImplementation(libs.kotlinStdlib)


### PR DESCRIPTION
- Recyclerview needed to be added via projectOrArtifact

Test: cd appcompat && ./gradlew appcompat:appcompat:cC
Change-Id: I46cc97d22434cb00bba1f080a9b02c29fca3f575
