### PR TITLE
Set proper default values for path strokeLineJoin and strokeMiterLimit in xml vector parser

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/graphics/vector/compat/XmlVectorParser.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/graphics/vector/compat/XmlVectorParser.android.kt
@@ -305,12 +305,12 @@ internal fun AndroidVectorParser.parsePath(
         AndroidVectorResources.STYLEABLE_VECTOR_DRAWABLE_PATH_STROKE_LINE_JOIN, -1
     )
     val strokeLineJoin =
-        getStrokeLineJoin(lineJoin, StrokeJoin.Bevel)
+        getStrokeLineJoin(lineJoin, StrokeJoin.Miter)
     val strokeMiterLimit = getNamedFloat(
         a,
         "strokeMiterLimit",
         AndroidVectorResources.STYLEABLE_VECTOR_DRAWABLE_PATH_STROKE_MITER_LIMIT,
-        1.0f
+        4.0f
     )
     val strokeColor = getNamedComplexColor(
         a,


### PR DESCRIPTION
## Proposed Changes

  - According to documentation default values for path strokeLineJoin and strokeMiterLimit should be appropriately miter and 4. SRC: https://developer.android.com/reference/android/graphics/drawable/VectorDrawable

## Testing

Test: None, just changed default values to proper ones.

## Issues Fixed

Fixes: [https://issuetracker.google.com/issues/182794035](https://issuetracker.google.com/issues/182794035) 
