### PR TITLE
Bump playground metalava build id to 9297860

### DIFF
--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -26,6 +26,6 @@ kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
 androidx.playground.snapshotBuildId=9304612
-androidx.playground.metalavaBuildId=9295138
+androidx.playground.metalavaBuildId=9297860
 androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
The last metalava bump seems to be a single build behind before the version bump, so it is causing GH to fail to find the artifact from snapshot servers

Test: cd collection && ./gradlew updateApi
Change-Id: I038e71bb2fa5565b90f7713115c8793937ab14d8