### PR TITLE
Add arch.core-runtime and core-common to lifecycle playground

### DIFF
--- a/activity/settings.gradle
+++ b/activity/settings.gradle
@@ -28,7 +28,7 @@ playground {
     setupPlayground("..")
     selectProjectsFromAndroidX({ name ->
         if (name.startsWith(":activity")) return true
-        if (name.startsWith(":lifecycle")) return true
+        if (name.startsWith(":lifecycle") && !name.contains("integration-tests")) return true
         if (name.startsWith(":annotation")) return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true

--- a/lifecycle/settings.gradle
+++ b/lifecycle/settings.gradle
@@ -29,6 +29,8 @@ playground {
     selectProjectsFromAndroidX({ name ->
         if (name.startsWith(":lifecycle")) return true
         if (name.startsWith(":annotation")) return true
+        if (name.startsWith(":arch:core:core-common")) return true
+        if (name.startsWith(":arch:core:core-runtime")) return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true
         if (isNeededForComposePlayground(name)) return true

--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -31,7 +31,7 @@ playground {
         if (name.startsWith(":navigation")) return true
         if (name.startsWith(":annotation")) return true
         if (name == ":compose:integration-tests:demos:common") return true
-        if (name.startsWith(":lifecycle")) return true
+        if (name.startsWith(":lifecycle") && !name.contains("integration-tests")) return true
         if (name.startsWith(":savedstate")) return true
         if (name == ":internal-testutils-navigation") return true
         if (name == ":internal-testutils-runtime") return true


### PR DESCRIPTION
These are project deps needed for incremental apt integration tests, which were missed because they were not properly included before. See aosp/I0bb053380cbd2ba53589e7adb9f059023fa4bfce.

Test: cd lifecycle && ./gradlew bOS
Change-Id: I09fffe9e3abda3698fb31aae95fc7115a666a84c