### PR TITLE
Fix up core dependencies on annotation

### DIFF
--- a/core/core-graphics-integration-tests/testapp/build.gradle
+++ b/core/core-graphics-integration-tests/testapp/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation(project(":core:core-ktx"))
     implementation(projectOrArtifact(":appcompat:appcompat"))
     implementation projectOrArtifact(":annotation:annotation")
-    compileOnly(projectOrArtifact(":annotation:annotation-sampled"))
+    compileOnly(project(":annotation:annotation-sampled"))
 }
 
 androidx {

--- a/core/core/build.gradle
+++ b/core/core/build.gradle
@@ -12,8 +12,8 @@ dependencies {
         implementation(project(":core:core-ktx"))
     }
 
-    api(project(":annotation:annotation"))
-    api(project(":annotation:annotation-experimental"))
+    api(projectOrArtifact(":annotation:annotation"))
+    api(projectOrArtifact(":annotation:annotation-experimental"))
     api("androidx.lifecycle:lifecycle-runtime:2.3.1")
     api("androidx.versionedparcelable:versionedparcelable:1.1.1")
     implementation("androidx.collection:collection:1.0.0")

--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -16,8 +16,6 @@ playground {
         if (name == ":internal-testutils-fonts") return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true
-        if (name == ":annotation:annotation") return true
-        if (name.startsWith(":annotation:annotation-experimental")) return true
         if (name == ":annotation:annotation-sampled") return true
         if (name == ":test:screenshot:screenshot") return true
         if (name == ":test:screenshot:screenshot-proto") return true


### PR DESCRIPTION
We are inconsistently including parts of annotation as project or snapshot dependencies. There also seems to be a bug with configuration caching and task dependency, which is causing annotations to not get built. This change aligns all annotation deps to be projectOrArtifact, except for annotation-sampled, which is not published.

Test: cd core && ./gradlew bOS
Change-Id: Ie606e42d48a0f88fb8f32fa38357fea28045b74d