### PR TITLE
Remove mismatched androidTest dependency already provided by implementation

### DIFF
--- a/appcompat/appcompat/build.gradle
+++ b/appcompat/appcompat/build.gradle
@@ -48,7 +48,14 @@ dependencies {
     androidTestImplementation(libs.espressoCore, excludes.espresso)
     androidTestImplementation(libs.mockitoCore, excludes.bytebuddy) // DexMaker has it's own MockMaker
     androidTestImplementation(libs.dexmakerMockito, excludes.bytebuddy) // DexMaker has it's own MockMaker
-    androidTestImplementation("androidx.lifecycle:lifecycle-runtime-testing:2.5.1" )
+    androidTestImplementation("androidx.lifecycle:lifecycle-runtime-testing:2.5.1", {
+	    // Needed to ensure that the same version of lifecycle-runtime-ktx
+	    // is pulled into main and androidTest configurations. Otherwise,
+	    // potentially leads to confusing errors about resolution
+	    // ambiguity, especially from playground build which replaces
+	    // project dependency with snapshot artifacts.
+            exclude group: "androidx.lifecycle", module: "lifecycle-runtime-ktx"
+    })
     androidTestImplementation(project(":internal-testutils-runtime"))
     androidTestImplementation(project(":internal-testutils-appcompat"), {
         exclude group: "androidx.appcompat", module: "appcompat"


### PR DESCRIPTION
Fixes a "resolution ambiguity" error with lifecycle-runtime-ktx which  is broken on playground as androidTest resolves a different version of the artifact than the snapshot, but on AOSP both resolve to the project successfully, which works around the problem.

Test: cd appcompat && ./gradlew appcompat:appcompat:compileDebugAndroidTestKotlin
Change-Id: I3c4b8cc388d8a6c38c38f30ae5bbd955f613a755