### PR TITLE
fix - remove width property of bottomSheet modifier

### DIFF
--- a/compose/material/material/src/commonMain/kotlin/androidx/compose/material/BottomSheetScaffold.kt
+++ b/compose/material/material/src/commonMain/kotlin/androidx/compose/material/BottomSheetScaffold.kt
@@ -335,7 +335,6 @@ fun BottomSheetScaffold(
                 bottomSheet = {
                     Surface(
                         swipeable
-                            .fillMaxWidth()
                             .requiredHeightIn(min = sheetPeekHeight)
                             .onGloballyPositioned {
                                 bottomSheetHeight = it.size.height.toFloat()


### PR DESCRIPTION
## Proposed Changes

### Short description

I want the fillMaxWidth() property applied to the Surface that constitutes the BottomSheetScaffold's sheetContent to be removed.

### Long description

The reason is because I want to always show the width of the sheetContent as the width of the content, not the fillMaxWidth in landscape mode.

Currently, to set the width of the sheetContent to a specific dp value in landscape mode, the width of the BottomSheetScaffold itself must be adjusted.

However, in this case, if the UI of the app shows a map such as Google Map, there is an issue that the touch event is not delivered well.

I guess many apps don't want the width of the bottomSheet to always be full in landscape mode.

The ui layer of our app in landscape mode looks like this: (카카오맵 = Map such as Google Map)

<img width="636" alt="스크린샷 2023-01-31 10 02 11" src="https://user-images.githubusercontent.com/51109517/215632435-61ad4db8-1f18-45d6-85c0-1a919dbb895d.png">

## Testing

Test: 
I copied all the BottomSheetScaffold codes and modified only the parts I wanted to test.
The result was successful!
To create the CustomBottomSheetScaffold I also had to copy the Swipeable because of the line of code below.
```kotlin
internal val nestedScrollConnection = this.PreUpPostDownNestedScrollConnection
```
## Issues Fixed

Fixes:
