### PR TITLE
Update repeatable annotation test to test repeatable kotlin annotations

### DIFF
--- a/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/RepeatableKotlinAnnotation.kt
+++ b/room/room-compiler-processing/src/test/java/androidx/room/compiler/processing/testcode/RepeatableKotlinAnnotation.kt
@@ -1,0 +1,5 @@
+package androidx.room.compiler.processing.testcode
+
+@Retention(AnnotationRetention.RUNTIME)
+@Repeatable
+annotation class RepeatableKotlinAnnotation(val value: String)


### PR DESCRIPTION
## Proposed Changes

  - Since https://youtrack.jetbrains.com/issue/KT-12794 is fixed, we can now update the repeatable annotation tests to check that getAllAnnotations method works for repeatable Kotlin annotations as well.
 - Added unit test to check that non repeatable annotation also work with the created repeatable Kotlin annotation.

## Testing

Test: Used 
- ./gradlew :room:room-compiler-processing:test --tests "androidx.room.compiler.processing.XAnnotationTest.repeatableAnnotation[preCompiled_false]"
- ./gradlew :room:room-compiler-processing:test --tests "androidx.room.compiler.processing.XAnnotationTest.kotlinRepeatableAnnotation_notRepeated[preCompiled_false]"
