### PR TITLE
Remove dokkaBuildId from playground as it is no longer needed

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
@@ -111,11 +111,6 @@ const val PLAYGROUND_SNAPSHOT_BUILD_ID = "androidx.playground.snapshotBuildId"
 const val PLAYGROUND_METALAVA_BUILD_ID = "androidx.playground.metalavaBuildId"
 
 /**
- * Build Id used to pull SNAPSHOT version of Dokka for Playground projects
- */
-const val PLAYGROUND_DOKKA_BUILD_ID = "androidx.playground.dokkaBuildId"
-
-/**
  * Filepath to the java agent of YourKit for profiling
  * If this value is set, profiling via YourKit will automatically be enabled
  */
@@ -178,7 +173,6 @@ val ALL_ANDROIDX_PROPERTIES = setOf(
     AffectedModuleDetector.BASE_COMMIT_ARG,
     PLAYGROUND_SNAPSHOT_BUILD_ID,
     PLAYGROUND_METALAVA_BUILD_ID,
-    PLAYGROUND_DOKKA_BUILD_ID,
     PROFILE_YOURKIT_AGENT_PATH,
     KMP_GITHUB_BUILD,
     ENABLED_KMP_TARGET_PLATFORMS,

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -151,20 +151,15 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
                 "/repo/m2repository",
             includeGroupRegex = """com\.android\.tools\.metalava"""
         )
-        val doclava = PlaygroundRepository(
-            "https://androidx.dev/dokka/builds/${props.dokkaBuildId}/artifacts/repository",
-            includeGroupRegex = """org\.jetbrains\.dokka"""
-        )
         val prebuilts = PlaygroundRepository(
             "https://androidx.dev/storage/prebuilts/androidx/internal/repository",
             includeGroupRegex = """androidx\..*"""
         )
-
         val dokka = PlaygroundRepository(
             "https://maven.pkg.jetbrains.space/kotlin/p/dokka/dev",
             includeGroupRegex = """org\.jetbrains\.dokka"""
         )
-        val all = listOf(sonatypeSnapshot, snapshots, metalava, doclava, dokka, prebuilts)
+        val all = listOf(sonatypeSnapshot, snapshots, metalava, dokka, prebuilts)
     }
 
     private data class PlaygroundRepository(
@@ -176,14 +171,12 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
     private data class PlaygroundProperties(
         val snapshotBuildId: String,
         val metalavaBuildId: String,
-        val dokkaBuildId: String
     ) {
         companion object {
             fun load(project: Project): PlaygroundProperties {
                 return PlaygroundProperties(
                     snapshotBuildId = project.requireProperty(PLAYGROUND_SNAPSHOT_BUILD_ID),
                     metalavaBuildId = project.requireProperty(PLAYGROUND_METALAVA_BUILD_ID),
-                    dokkaBuildId = project.requireProperty(PLAYGROUND_DOKKA_BUILD_ID)
                 )
             }
 

--- a/development/update_playground.sh
+++ b/development/update_playground.sh
@@ -20,16 +20,9 @@ function fn_update_metalava {
   fn_sed_inplace "s/androidx.playground.metalavaBuildId=.*/androidx.playground.metalavaBuildId=$BUILDID_METALAVA/g" playground-common/playground.properties
 }
 
-function fn_update_dokka {
-  BUILDID_DOKKA=`curl -s https://androidx.dev/dokka/builds | sed -nr 's|.*dokka/builds/([0-9]*).*|\1|gp' | head -n 1`
-  echo "Updating dokka id: $BUILDID_DOKKA"
-  fn_sed_inplace "s/androidx.playground.dokkaBuildId=.*/androidx.playground.dokkaBuildId=$BUILDID_DOKKA/g" playground-common/playground.properties
-}
-
 if [ "$MODE" == "s" ]; then
   fn_update_snapshot
 elif [ "$MODE" == "a" ]; then
   fn_update_snapshot
   fn_update_metalava
-  fn_update_dokka
 fi

--- a/playground-common/playground-build.gradle
+++ b/playground-common/playground-build.gradle
@@ -25,12 +25,10 @@ buildscript {
     ext.supportRootFolder = playgroundCommonFolder.parentFile
 
     def metalavaBuildId = rootProject.properties["androidx.playground.metalavaBuildId"]
-    def dokkaBuildId = rootProject.properties["androidx.playground.dokkaBuildId"]
-    if (metalavaBuildId == null || dokkaBuildId == null) {
-        throw new GradleException("metalava and or dokka build ids must be defined.")
+    if (metalavaBuildId == null) {
+        throw new GradleException("metalava build id must be defined.")
     }
     def metalavaRepo = "https://androidx.dev/metalava/builds/${metalavaBuildId}/artifacts/repo/m2repository"
-    def dokkaRepo = "https://androidx.dev/dokka/builds/${dokkaBuildId}/artifacts/repository"
     repositories {
         google()
         mavenCentral()
@@ -41,19 +39,11 @@ buildscript {
                 artifact()
             }
         }
-        maven {
-            url dokkaRepo
-            metadataSources {
-                mavenPom()
-                artifact()
-            }
-        }
         gradlePluginPortal().content {
             it.includeModule("gradle.plugin.com.github.johnrengelman", "shadow")
             it.includeModule("me.champeau.gradle", "japicmp-gradle-plugin")
         }
     }
-
     ext.repos = [:]
 }
 

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -27,5 +27,4 @@ kotlin.code.style=official
 androidx.enableDocumentation=false
 androidx.playground.snapshotBuildId=9614968
 androidx.playground.metalavaBuildId=9578585
-androidx.playground.dokkaBuildId=7472101
 androidx.studio.type=playground


### PR DESCRIPTION
Test: None
Change-Id: If5bed4c0dd8935b0a97befae3612339d624dd5ec

## Proposed Changes

Remove dokkaBuildId from playground as it is no longer needed

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
