### PR TITLE
Contract TypedArray.use invocation exactly once

### DIFF
--- a/core/core-ktx/src/androidTest/java/androidx/core/content/res/TypedArrayTest.kt
+++ b/core/core-ktx/src/androidTest/java/androidx/core/content/res/TypedArrayTest.kt
@@ -16,7 +16,11 @@
 
 package androidx.core.content.res
 
+import android.content.Context
+import android.content.res.TypedArray
 import android.graphics.Color
+import android.util.AttributeSet
+import android.view.View
 import androidx.core.getAttributeSet
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.filters.SdkSuppress
@@ -30,7 +34,7 @@ import org.junit.Test
 
 @SmallTest
 class TypedArrayTest {
-    private val context = ApplicationProvider.getApplicationContext() as android.content.Context
+    private val context = ApplicationProvider.getApplicationContext() as Context
 
     @Test fun boolean() {
         val attrs = context.getAttributeSet(R.layout.typed_array)
@@ -214,15 +218,23 @@ class TypedArrayTest {
     @SdkSuppress(minSdkVersion = 21) // No easy way to verify pre-21.
     @Test fun useRecyclesArray() {
         val attrs = context.getAttributeSet(R.layout.typed_array)
-        val array = context.obtainStyledAttributes(attrs, R.styleable.TypedArrayTypes)
+        val customView = CustomView(context, attrs)
 
-        val result = array.use {
-            it.getBoolean(R.styleable.TypedArrayTypes_boolean_present, false)
-        }
-        assertTrue(result)
+        assertTrue(customView.result)
 
         assertThrows<RuntimeException> {
-            array.recycle()
+            customView.array.recycle()
+        }
+    }
+
+    class CustomView(context: Context, attrs: AttributeSet? = null) : View(context, attrs) {
+        val array: TypedArray = context.obtainStyledAttributes(attrs, R.styleable.TypedArrayTypes)
+        val result: Boolean
+
+        init {
+            array.use {
+                result = it.getBoolean(R.styleable.TypedArrayTypes_boolean_present, false)
+            }
         }
     }
 }

--- a/core/core-ktx/src/main/java/androidx/core/content/res/TypedArray.kt
+++ b/core/core-ktx/src/main/java/androidx/core/content/res/TypedArray.kt
@@ -26,6 +26,9 @@ import androidx.annotation.Dimension
 import androidx.annotation.DoNotInline
 import androidx.annotation.RequiresApi
 import androidx.annotation.StyleableRes
+import kotlin.contracts.contract
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
 
 private fun TypedArray.checkAttribute(@StyleableRes index: Int) {
     if (!hasValue(index)) {
@@ -229,7 +232,12 @@ public fun TypedArray.getTextArrayOrThrow(@StyleableRes index: Int): Array<CharS
  *
  * @see kotlin.io.use
  */
+@Suppress("BanInlineOptIn")
+@OptIn(ExperimentalContracts::class)
 public inline fun <R> TypedArray.use(block: (TypedArray) -> R): R {
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
     return block(this).also {
         recycle()
     }


### PR DESCRIPTION
## Proposed Changes

  - If I want to initialize final fields in `TypedArray.use` in a View's constructor, there will be a compiler error: `Captured member values initialization is forbidden due to possible reassignment`, in this case, we should specify the lambda is invoked [EXACTLY_ONCE](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.contracts/-invocation-kind/-e-x-a-c-t-l-y_-o-n-c-e.html).
  - Repro: https://github.com/Goooler/DemoApp/pull/343
  - Ref: https://youtrack.jetbrains.com/issue/KT-42044

## Testing

Test: cd core && ./gradlew core:core-ktx:connectedCheck
