### PR TITLE
Do not expose kotlin stdlib to the consumers

### DIFF
--- a/health/connect/connect-client/build.gradle
+++ b/health/connect/connect-client/build.gradle
@@ -31,7 +31,7 @@ BundleInsideHelper.forInsideAar(
 )
 
 dependencies {
-    api(libs.kotlinStdlib)
+    implementation(libs.kotlinStdlib)
     // Add dependencies here
     api("androidx.activity:activity:1.2.0")
     api("androidx.annotation:annotation:1.2.0")


### PR DESCRIPTION
## Proposed Changes

This PR proposes to declare Kotlin stdlib with `implementation` instead of `api` in the Health Connect SDK's build configuration.

Currently, the Kotlin stdlib that Health Connect SDK depends on appears in the compile classpath of our app. This results in [class duplication](https://d.android.com/r/tools/classpath-sync-errors).

## Testing

Test: Our app using Health Connect SDK works well.

## Issues Fixed

Fixes: N/A
