### PR TITLE
Bump playground metalava build id to 9652637

### DIFF
--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -26,5 +26,5 @@ kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
 androidx.playground.snapshotBuildId=9614968
-androidx.playground.metalavaBuildId=9578585
+androidx.playground.metalavaBuildId=9652637
 androidx.studio.type=playground


### PR DESCRIPTION
Bumped in mainline by https://android-review.git.corp.google.com/c/platform/prebuilts/androidx/external/+/2458290

Test: cd lifecycle && ./gradlew checkApi
Change-Id: I4f8515cd4d057079308a06b41a6eb04f6a75520e