### PR TITLE
Replace usage of TestDispatcher with StandardTestDispatcher in paging-compose

### DIFF
--- a/paging/paging-compose/build.gradle
+++ b/paging/paging-compose/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     androidTestImplementation(libs.testRunner)
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.truth)
-    androidTestImplementation(project(":internal-testutils-ktx"))
 
     samples(projectOrArtifact(":paging:paging-compose:paging-compose-samples"))
 }

--- a/paging/paging-compose/src/androidTest/java/androidx/paging/compose/LazyPagingItemsTest.kt
+++ b/paging/paging-compose/src/androidTest/java/androidx/paging/compose/LazyPagingItemsTest.kt
@@ -47,6 +47,7 @@ import androidx.test.filters.LargeTest
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertFalse
 import org.junit.Ignore
@@ -54,6 +55,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @LargeTest
 @RunWith(AndroidJUnit4::class)
 class LazyPagingItemsTest {

--- a/paging/paging-compose/src/androidTest/java/androidx/paging/compose/LazyPagingItemsTest.kt
+++ b/paging/paging-compose/src/androidTest/java/androidx/paging/compose/LazyPagingItemsTest.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.testutils.TestDispatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertTopPositionInRootIsEqualTo
@@ -48,6 +47,7 @@ import androidx.test.filters.LargeTest
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertFalse
 import org.junit.Ignore
 import org.junit.Rule
@@ -890,10 +890,9 @@ class LazyPagingItemsTest {
             TestPagingSource(items = items, loadDelay = 0)
         }
 
-        val context = TestDispatcher()
+        val context = StandardTestDispatcher()
         lateinit var lazyPagingItems: LazyPagingItems<Int>
         rule.setContent {
-            assertThat(context.queue).isEmpty()
             lazyPagingItems = pager.flow.collectAsLazyPagingItems(context)
         }
 
@@ -904,11 +903,11 @@ class LazyPagingItemsTest {
         }
 
         // start LaunchedEffects
-        context.executeAll()
+        context.scheduler.advanceUntilIdle()
 
         rule.runOnIdle {
             // continue with pagingDataDiffer collections
-            context.executeAll()
+            context.scheduler.advanceUntilIdle()
         }
         rule.waitUntil {
             lazyPagingItems.itemCount == items.size


### PR DESCRIPTION
In Multiplatform Paging, the classes `DirectDispatcher` and `TestDispatcher` in `testutils-ktx` had to be multiplatformized to allow dependent tests in `paging-compose`, `paging-common`, and `paging-runtime` to be moved to the respective `commonTest` folders.

I'm attempting to replace all usages of `DirectDispatcher` and `TestDispatcher` that Multiplatform Paging depends on with those found in `kotlinx.coroutines.test`, so hopefully the `testutils-ktx` dependency no longer has to be multiplatformized in my fork.

I'm starting this effort by doing it with `paging-compose`.

Test: ./gradlew test connectedCheck
Bug: 270612487