### PR TITLE
Replace usage of DirectDispatcher with EmptyCoroutineContext in testutils-paging

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
@@ -2054,7 +2054,7 @@ class PagingDataDifferTest(
                 pagingSourceFactory = {
                     TestPagingSource(
                         loadDelay = 0,
-                        loadDispatcher = loadDispatcher,
+                        loadContext = loadDispatcher,
                     ).also { pagingSources.add(it) }
                 }
             ),

--- a/testutils/testutils-paging/build.gradle
+++ b/testutils/testutils-paging/build.gradle
@@ -25,7 +25,6 @@ plugins {
 dependencies {
     api(libs.kotlinStdlib)
     implementation(project(":paging:paging-common"))
-    implementation(project(":internal-testutils-ktx"))
     implementation(libs.kotlinTest)
 }
 

--- a/testutils/testutils-paging/src/main/java/androidx/paging/TestPagingSource.kt
+++ b/testutils/testutils-paging/src/main/java/androidx/paging/TestPagingSource.kt
@@ -16,8 +16,8 @@
 
 package androidx.paging
 
-import androidx.testutils.DirectDispatcher
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
@@ -33,7 +33,7 @@ class TestPagingSource(
     override val jumpingSupported: Boolean = true,
     val items: List<Int> = ITEMS,
     private val loadDelay: Long = 1000,
-    private val loadDispatcher: CoroutineDispatcher = DirectDispatcher,
+    private val loadContext: CoroutineContext = EmptyCoroutineContext,
     private val placeholdersEnabled: Boolean = true,
 ) : PagingSource<Int, Int>() {
     var errorNextLoad = false
@@ -60,7 +60,7 @@ class TestPagingSource(
         // execution of events.
         delay(loadDelay)
 
-        return withContext(loadDispatcher) { getLoadResult(params) }
+        return withContext(loadContext) { getLoadResult(params) }
     }
 
     private fun getLoadResult(params: LoadParams<Int>): LoadResult<Int, Int> {


### PR DESCRIPTION
The reasoning is the same as https://github.com/androidx/androidx/pull/505, but for `testutils-paging`.

Test: ./gradlew test connectedCheck
Bug: 270612487