### PR TITLE
[Navigation doc] differenciate route vs route pattern

### DIFF
--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -52,9 +52,11 @@ import kotlinx.coroutines.flow.map
  * @sample androidx.navigation.compose.samples.NavScaffold
  *
  * @param navController the navController for this host
- * @param startDestination the route for the start destination
+ * @param startDestination the route (like "topic/{topicId}") for the start destination. route instances
+ * with filled in arguments are not supported. If your start destination requires an argument, you can
+ * set a default value while creating your graph.
  * @param modifier The modifier to be applied to the layout.
- * @param route the route for the graph
+ * @param route the route for the root level of this graph allowing you to use it with [NavHostController.getBackStackEntry]
  * @param builder the builder used to construct the graph
  */
 @Composable

--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -55,6 +55,9 @@ import kotlinx.coroutines.flow.map
  * @param startDestination the route (like "topic/{topicId}") for the start destination. route instances
  * with filled in arguments are not supported. If your start destination requires an argument, you can
  * set a default value while creating your graph.
+ * When a user opens your app via an explicit deep link, the startDestination is added at the bottom of the
+ * stack so that the user goes back to your app's entry point when pressing back.
+ * 
  * @param modifier The modifier to be applied to the layout.
  * @param route the route for the root level of this graph allowing you to use it with [NavHostController.getBackStackEntry]
  * @param builder the builder used to construct the graph

--- a/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
+++ b/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
@@ -497,7 +497,7 @@ public open class NavController(
      * Attempts to pop the controller's back stack back to a specific destination.
      *
      * @param route The route of the topmost destination to retain. Both route patterns
-     * and route instances with filled in arguments are supported.
+     * and routes with filled arguments are supported.
      * @param inclusive Whether the given destination should also be popped.
      * @param saveState Whether the back stack and the state of all destinations between the
      * current destination and the [route] should be saved for later
@@ -582,7 +582,7 @@ public open class NavController(
      * **not** handle calling [dispatchOnDestinationChanged]
      *
      * @param route The route of the topmost destination to retain. Both route patterns
-     * and route instances with filled in arguments are supported.
+     * and routes with filled arguments are supported.
      * @param inclusive Whether the given destination should also be popped.
      * @param saveState Whether the back stack and the state of all destinations between the
      * current destination and the destination with [route] should be saved for later to be
@@ -771,8 +771,8 @@ public open class NavController(
      * via [popBackStack] when using a `saveState` value of `true`.
      *
      * @param route The route of the destination previously used with [popBackStack] with a
-     * `saveState` value of `true`. Both route patterns and route instances with filled in
-     * arguments are supported.
+     * `saveState` value of `true`. Both route patterns and routes with filled arguments
+     * are supported.
      *
      * @return true if the saved state of the stack associated with [route] was cleared.
      */
@@ -1901,7 +1901,7 @@ public open class NavController(
         return if (backStackMap.containsKey(id)) {
             restoreStateInternal(id, null, null, null)
         } else {
-            // if it didn't match, it means the route contains filled in arguments and we need
+            // if it didn't match, it means the route contains filled arguments and we need
             // to find the destination that matches this route's general pattern
             val matchingDestination = findDestination(route)
             check(matchingDestination != null) {
@@ -2144,7 +2144,7 @@ public open class NavController(
      * Navigate to a route in the current NavGraph. If an invalid route is given, an
      * [IllegalArgumentException] will be thrown.
      *
-     * @param route route instance with filled arguments for the desired destination
+     * @param route pattern or route with filled arguments for the destination
      * @param builder DSL for constructing a new [NavOptions]
      *
      * @throws IllegalArgumentException if the given route is invalid
@@ -2158,7 +2158,7 @@ public open class NavController(
      * Navigate to a route in the current NavGraph. If an invalid route is given, an
      * [IllegalArgumentException] will be thrown.
      *
-     * @param route route instance with filled arguments for the desired destination
+     * @param route route pattern or route with filled arguments for the destination
      * @param navOptions special options for this navigation operation
      * @param navigatorExtras extras to pass to the [Navigator]
      *
@@ -2411,7 +2411,7 @@ public open class NavController(
      * destinations are guaranteed to be on the back stack.
      *
      * @param route route of a destination that exists on the back stack. Both route patterns
-     * and route instances with filled in arguments are supported.
+     * and routes with filled arguments are supported.
      * @throws IllegalArgumentException if the destination is not on the back stack
      */
     public fun getBackStackEntry(route: String): NavBackStackEntry {

--- a/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
+++ b/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
@@ -496,8 +496,8 @@ public open class NavController(
     /**
      * Attempts to pop the controller's back stack back to a specific destination.
      *
-     * @param route The topmost destination to retain. May contain filled in arguments as long as
-     * it is exact match with route used to navigate.
+     * @param route The route of the topmost destination to retain. Both route patterns
+     * and route instances with filled in arguments are supported.
      * @param inclusive Whether the given destination should also be popped.
      * @param saveState Whether the back stack and the state of all destinations between the
      * current destination and the [route] should be saved for later
@@ -581,7 +581,8 @@ public open class NavController(
      * Attempts to pop the controller's back stack back to a specific destination. This does
      * **not** handle calling [dispatchOnDestinationChanged]
      *
-     * @param route The topmost destination with this route to retain
+     * @param route The route of the topmost destination to retain. Both route patterns
+     * and route instances with filled in arguments are supported.
      * @param inclusive Whether the given destination should also be popped.
      * @param saveState Whether the back stack and the state of all destinations between the
      * current destination and the destination with [route] should be saved for later to be
@@ -770,8 +771,8 @@ public open class NavController(
      * via [popBackStack] when using a `saveState` value of `true`.
      *
      * @param route The route of the destination previously used with [popBackStack] with a
-     * `saveState` value of `true`. May contain filled in arguments as long as
-     * it is exact match with route used with [popBackStack].
+     * `saveState` value of `true`. Both route patterns and route instances with filled in
+     * arguments are supported.
      *
      * @return true if the saved state of the stack associated with [route] was cleared.
      */
@@ -2143,7 +2144,7 @@ public open class NavController(
      * Navigate to a route in the current NavGraph. If an invalid route is given, an
      * [IllegalArgumentException] will be thrown.
      *
-     * @param route route for the destination
+     * @param route route instance with filled arguments for the desired destination
      * @param builder DSL for constructing a new [NavOptions]
      *
      * @throws IllegalArgumentException if the given route is invalid
@@ -2157,7 +2158,7 @@ public open class NavController(
      * Navigate to a route in the current NavGraph. If an invalid route is given, an
      * [IllegalArgumentException] will be thrown.
      *
-     * @param route route for the destination
+     * @param route route instance with filled arguments for the desired destination
      * @param navOptions special options for this navigation operation
      * @param navigatorExtras extras to pass to the [Navigator]
      *
@@ -2409,8 +2410,8 @@ public open class NavController(
      * [its parent][NavDestination.parent] or grandparent navigation graphs as these
      * destinations are guaranteed to be on the back stack.
      *
-     * @param route route of a destination that exists on the back stack. May contain filled in
-     * arguments as long as it is exact match with route used to navigate.
+     * @param route route of a destination that exists on the back stack. Both route patterns
+     * and route instances with filled in arguments are supported.
      * @throws IllegalArgumentException if the destination is not on the back stack
      */
     public fun getBackStackEntry(route: String): NavBackStackEntry {


### PR DESCRIPTION
_This is a docs-only change_

This PR tries to highlight the difference between :

* "route":  a static String linked to a single destination like `"topic/{topicId}"`
* "route instance": a instance of a route that has arguments filled in like `"topic/42"`

Since changing argument names would be a breaking change, this PR tweaks the KDoc. 

Test: N/A docs change