### PR TITLE
Remove savedstate projects from navigation playground

### DIFF
--- a/navigation/settings.gradle
+++ b/navigation/settings.gradle
@@ -32,7 +32,6 @@ playground {
         if (name.startsWith(":annotation")) return true
         if (name == ":compose:integration-tests:demos:common") return true
         if (name.startsWith(":lifecycle") && !name.contains("integration-tests")) return true
-        if (name.startsWith(":savedstate")) return true
         if (name == ":internal-testutils-navigation") return true
         if (name == ":internal-testutils-runtime") return true
         if (name == ":internal-testutils-truth") return true


### PR DESCRIPTION
This also works around sending an empty test suite to FTL from savedstate-ktx that is currently causing failures.

Test: cd navigation && ./gradlew bOS
Change-Id: I94764a195b488210fd5af5e11079900ae4cc2a47