### PR TITLE
Drop transitive dependency on guava

### DIFF
--- a/wear/wear-remote-interactions/build.gradle
+++ b/wear/wear-remote-interactions/build.gradle
@@ -26,8 +26,7 @@ dependencies {
     api("androidx.annotation:annotation:1.1.0")
     api(libs.kotlinStdlib)
     api(libs.guavaListenableFuture)
-    api("androidx.concurrent:concurrent-futures-ktx:1.0.0")
-    implementation("androidx.concurrent:concurrent-futures:1.0.0")
+    api("androidx.concurrent:concurrent-futures-ktx:1.1.0")
 
     androidTestImplementation(libs.testExtJunit)
     androidTestImplementation(libs.testCore)

--- a/wear/wear-remote-interactions/build.gradle
+++ b/wear/wear-remote-interactions/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api(libs.kotlinStdlib)
     api(libs.guavaListenableFuture)
     api("androidx.concurrent:concurrent-futures-ktx:1.1.0")
+    api(libs.kotlinCoroutinesCore)
 
     androidTestImplementation(libs.testExtJunit)
     androidTestImplementation(libs.testCore)

--- a/wear/wear-remote-interactions/build.gradle
+++ b/wear/wear-remote-interactions/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     api("androidx.annotation:annotation:1.1.0")
     api(libs.kotlinStdlib)
     api(libs.guavaListenableFuture)
-    api(libs.kotlinCoroutinesGuava)
+    api("androidx.concurrent:concurrent-futures-ktx:1.0.0")
     implementation("androidx.concurrent:concurrent-futures:1.0.0")
 
     androidTestImplementation(libs.testExtJunit)


### PR DESCRIPTION
See https://issuetracker.google.com/issues/275580742

## Proposed Changes

  - Don't force the huge and unnecessary Guava dependency
  - Use the dedicated androidx.concurrent-futures-ktx library instead

## Testing

Test: I excluded the kotlinx.coroutines-guava dependency in my project, replaced it with androidx.concurrent-futures-ktx, updated the import where I used the `await()` extension, and it kept working, as expected.

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/275580742
