### PR TITLE
Remove unnecessary dependency on Fragment

### DIFF
--- a/wear/watchface/watchface/build.gradle
+++ b/wear/watchface/watchface/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 dependencies {
     api("androidx.annotation:annotation:1.5.0-alpha01")
-    api("androidx.fragment:fragment:1.2.0")
+    api("androidx.activity:activity:1.7.0")
     api(project(":wear:watchface:watchface-complications-data"))
     api(project(":wear:watchface:watchface-data"))
     api(project(":wear:watchface:watchface-style"))

--- a/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
+++ b/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
@@ -293,6 +293,7 @@ public final class ComplicationHelperActivity extends ComponentActivity
     }
 
     @Override
+    @SuppressWarnings("deprecation") //TODO: Use ActivityResultContract
     public void onRequestPermissionsResult(
             int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
+++ b/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
@@ -319,6 +319,7 @@ public final class ComplicationHelperActivity extends ComponentActivity
     }
 
     @Override
+    @SuppressWarnings("deprecation") //TODO: Use ActivityResultContract
     protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         switch (requestCode) {

--- a/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
+++ b/wear/watchface/watchface/src/main/java/androidx/wear/watchface/ComplicationHelperActivity.java
@@ -26,11 +26,11 @@ import android.os.Bundle;
 import android.support.wearable.complications.ComplicationData;
 import android.support.wearable.complications.ComplicationProviderInfo;
 
+import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.core.app.ActivityCompat;
-import androidx.fragment.app.FragmentActivity;
 import androidx.wear.watchface.complications.ComplicationDataSourceUpdateRequesterConstants;
 import androidx.wear.watchface.complications.data.ComplicationType;
 
@@ -58,7 +58,7 @@ import java.util.Objects;
  *
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-public final class ComplicationHelperActivity extends FragmentActivity
+public final class ComplicationHelperActivity extends ComponentActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback {
 
     /**


### PR DESCRIPTION
## Proposed Changes

  - Make `ComplicationHelperActivity` extend `ComponentActivity` instead of `FragmentActivity`
  - Remove the dependency on Fragment in the androidx watchface library

## Testing

Test: I trust you will do what's necessary in this regard :)

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/275601440
