### PR TITLE
Use projectOrArtifact in paging-compose samples

### DIFF
--- a/paging/paging-compose/samples/build.gradle
+++ b/paging/paging-compose/samples/build.gradle
@@ -27,9 +27,9 @@ dependencies {
     implementation(libs.kotlinStdlib)
 
     compileOnly(projectOrArtifact(":annotation:annotation-sampled"))
-    implementation(project(":compose:foundation:foundation"))
-    implementation(project(":compose:material:material"))
-    implementation(projectOrArtifact(":paging:paging-compose"))
+    implementation(projectOrArtifact(":compose:foundation:foundation"))
+    implementation(projectOrArtifact(":compose:material:material"))
+    implementation(project(":paging:paging-compose"))
     implementation(project(":internal-testutils-paging"))
 }
 


### PR DESCRIPTION
This allows paging playground to resolve compose deps.

Test: cd paging && ./gradlew bOS
Change-Id: I01d3774eefef7fab1380040a00bb840afa245903