### PR TITLE
Add `ComparableSubject#isAtLeast` to Kruth

### DIFF
--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
@@ -37,4 +37,17 @@ open class ComparableSubject<T : Comparable<T>> constructor(actual: T?) : Subjec
             fail("Expected to be less than $other, but was $actual")
         }
     }
+
+    /**
+     * Checks that the subject is greater than or equal to [other].
+     *
+     * @throws NullPointerException if [actual] or [other] is `null`.
+     */
+    fun isAtLeast(other: T?) {
+        if (actual == null || other == null) {
+            throw NullPointerException("Expected to be at least $other, but was $actual")
+        } else if (actual < other) {
+            fail("Expected to be at least $other, but was $actual")
+        }
+    }
 }

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
@@ -44,9 +44,9 @@ open class ComparableSubject<T : Comparable<T>> constructor(actual: T?) : Subjec
      * @throws NullPointerException if [actual] or [other] is `null`.
      */
     fun isAtLeast(other: T?) {
-        if (actual == null || other == null) {
-            throw NullPointerException("Expected to be at least $other, but was $actual")
-        } else if (actual < other) {
+        requireNonNull(actual) { "Expected to be at least $other, but was $actual" }
+        requireNonNull(other) { "Expected to be at least $other, but was $actual" }
+        if (actual < other) {
             fail("Expected to be at least $other, but was $actual")
         }
     }

--- a/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/ComparableSubjectTest.kt
+++ b/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/ComparableSubjectTest.kt
@@ -35,6 +35,9 @@ class ComparableSubjectTest {
         assertFailsWith<NullPointerException> {
             assertThat(6).isLessThan(null)
         }
+        assertFailsWith<NullPointerException> {
+            assertThat(6).isAtLeast(null)
+        }
     }
 
     @Test
@@ -52,16 +55,31 @@ class ComparableSubjectTest {
         }
     }
 
+    @Test
+    fun isAtLeast() {
+        assertThat(4).isAtLeast(3)
+        assertThat(4).isAtLeast(4)
+        assertFailsWith<AssertionError> {
+            assertThat(4).isAtLeast(5)
+        }
+    }
+
     // Brief tests with other comparable types (no negative test cases)
 
     @Test
     fun longs() {
         assertThat(4L).isLessThan(5L)
+
+        assertThat(4L).isAtLeast(4L)
+        assertThat(4L).isAtLeast(3L)
     }
 
     @Test
     fun strings() {
         assertThat("gak").isLessThan("kak")
+
+        assertThat("kak").isAtLeast("kak")
+        assertThat("kak").isAtLeast("gak")
     }
 
     @Test


### PR DESCRIPTION
To migrate the tests in `paging-common` from Truth to Kruth, `isAtLeast` needs to be added to Kruth:

https://github.com/androidx/androidx/blob/72a6b2eeaa0be3fc4a8ff989f72f771d7f109c2e/paging/paging-common/src/test/kotlin/androidx/paging/FlowExtTest.kt#L289-L290

Test: ./gradlew test connectedCheck
Bug: 270612487