### PR TITLE
Remove most usages of TestDispatcher in paging-common tests

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
@@ -27,20 +27,22 @@ import androidx.paging.PagedList.Config
 import androidx.paging.PagingSource.LoadParams.Refresh
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingSource.LoadResult.Page
-import androidx.testutils.TestDispatcher
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 class LegacyPageFetcherTest {
-    private val testDispatcher = TestDispatcher()
+    private val testDispatcher = StandardTestDispatcher()
     private val data = List(9) { "$it" }
 
     inner class ImmediateListDataSource(val data: List<String>) : PagingSource<Int, String>() {
@@ -177,7 +179,7 @@ class LegacyPageFetcherTest {
             consumer.takeStateChanges()
         )
 
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf(Result(APPEND, rangeResult(6, 8))), consumer.takeResults())
         assertEquals(
@@ -204,7 +206,7 @@ class LegacyPageFetcherTest {
             consumer.takeStateChanges()
         )
 
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf(Result(PREPEND, rangeResult(2, 4))),
@@ -227,7 +229,7 @@ class LegacyPageFetcherTest {
         val pager = createPager(consumer, 2, 6)
 
         pager.tryScheduleAppend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf(
@@ -248,7 +250,7 @@ class LegacyPageFetcherTest {
         )
 
         pager.tryScheduleAppend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf(
@@ -275,7 +277,7 @@ class LegacyPageFetcherTest {
         val pager = createPager(consumer, 4, 8)
 
         pager.trySchedulePrepend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf(
@@ -295,7 +297,7 @@ class LegacyPageFetcherTest {
         )
 
         pager.trySchedulePrepend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(
             listOf(
@@ -364,7 +366,7 @@ class LegacyPageFetcherTest {
 
         // try a normal append first
         pager.tryScheduleAppend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(consumer.takeResults()).containsExactly(
             Result(APPEND, rangeResult(3, 5))
@@ -379,7 +381,7 @@ class LegacyPageFetcherTest {
         pagingSource.invalidData = true
 
         pager.tryScheduleAppend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         // the load should return before returning any data
         assertThat(consumer.takeResults()).isEmpty()
@@ -400,7 +402,7 @@ class LegacyPageFetcherTest {
 
         // try a normal prepend first
         pager.trySchedulePrepend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(consumer.takeResults()).containsExactly(
             Result(PREPEND, rangeResult(4, 6))
@@ -415,7 +417,7 @@ class LegacyPageFetcherTest {
         pagingSource.invalidData = true
 
         pager.trySchedulePrepend()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         // the load should return before returning any data
         assertThat(consumer.takeResults()).isEmpty()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
@@ -17,7 +17,6 @@
 package androidx.paging
 
 import androidx.paging.PagingSource.LoadResult.Page
-import androidx.testutils.TestDispatcher
 import com.google.common.truth.Truth.assertThat
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +26,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,7 +35,9 @@ import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 class LegacyPagingSourceTest {
     private val fakePagingState = PagingState(
@@ -357,7 +359,7 @@ class LegacyPagingSourceTest {
             }
         }
 
-        val testDispatcher = TestDispatcher()
+        val testDispatcher = StandardTestDispatcher()
         val pagingSourceFactory = dataSourceFactory.asPagingSourceFactory(
             fetchDispatcher = testDispatcher
         ).let {
@@ -365,14 +367,14 @@ class LegacyPagingSourceTest {
         }
 
         val pagingSource0 = pagingSourceFactory()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
         assertTrue { pagingSource0.dataSource.isInvalid }
         assertTrue { pagingSource0.invalid }
         assertTrue { dataSourceFactory.dataSources[0].isInvalid }
         assertEquals(dataSourceFactory.dataSources[0], pagingSource0.dataSource)
 
         val pagingSource1 = pagingSourceFactory()
-        testDispatcher.executeAll()
+        testDispatcher.scheduler.advanceUntilIdle()
         assertFalse { pagingSource1.dataSource.isInvalid }
         assertFalse { pagingSource1.invalid }
         assertFalse { dataSourceFactory.dataSources[1].isInvalid }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
@@ -16,7 +16,6 @@
 
 package androidx.paging
 
-import androidx.testutils.TestDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,12 +32,11 @@ import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.StandardTestDispatcher
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 class PageKeyedDataSourceTest {
-    private val mainThread = TestDispatcher()
-    private val backgroundThread = TestDispatcher()
-
     internal data class Item(val name: String)
 
     internal data class Page(val prev: String?, val data: List<Item>, val next: String?)
@@ -244,7 +242,7 @@ class PageKeyedDataSourceTest {
         @Suppress("UNCHECKED_CAST", "DEPRECATION")
         val boundaryCallback =
             mock(PagedList.BoundaryCallback::class.java) as PagedList.BoundaryCallback<String>
-        val dispatcher = TestDispatcher()
+        val dispatcher = StandardTestDispatcher()
 
         val testCoroutineScope = CoroutineScope(EmptyCoroutineContext)
         @Suppress("DEPRECATION")
@@ -259,7 +257,7 @@ class PageKeyedDataSourceTest {
 
         verifyNoMoreInteractions(boundaryCallback)
 
-        dispatcher.executeAll()
+        dispatcher.scheduler.advanceUntilIdle()
 
         // verify boundary callbacks are triggered
         verify(boundaryCallback).onItemAtFrontLoaded("A")
@@ -297,7 +295,7 @@ class PageKeyedDataSourceTest {
         @Suppress("UNCHECKED_CAST", "DEPRECATION")
         val boundaryCallback =
             mock(PagedList.BoundaryCallback::class.java) as PagedList.BoundaryCallback<String>
-        val dispatcher = TestDispatcher()
+        val dispatcher = StandardTestDispatcher()
 
         val testCoroutineScope = CoroutineScope(EmptyCoroutineContext)
         @Suppress("DEPRECATION")
@@ -312,7 +310,7 @@ class PageKeyedDataSourceTest {
 
         verifyNoMoreInteractions(boundaryCallback)
 
-        dispatcher.executeAll()
+        dispatcher.scheduler.advanceUntilIdle()
 
         // verify boundary callbacks are triggered
         verify(boundaryCallback).onItemAtFrontLoaded("B")
@@ -510,13 +508,6 @@ class PageKeyedDataSourceTest {
             }
             PAGE_MAP = map
             ITEM_LIST = list
-        }
-    }
-
-    private fun drain() {
-        while (backgroundThread.queue.isNotEmpty() || mainThread.queue.isNotEmpty()) {
-            backgroundThread.executeAll()
-            mainThread.executeAll()
         }
     }
 }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
@@ -22,7 +22,6 @@ import androidx.paging.LoadType.PREPEND
 import androidx.paging.PageEvent.Drop
 import androidx.paging.PagingSource.LoadResult
 import androidx.testutils.MainDispatcherRule
-import androidx.testutils.TestDispatcher
 import com.google.common.truth.Truth.assertThat
 import kotlin.coroutines.ContinuationInterceptor
 import kotlin.test.assertEquals
@@ -47,6 +46,8 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -261,12 +262,12 @@ class PagingDataDifferTest(
     fun refreshOnLatestGenerationReceiver() = runTest { differ, loadDispatcher, _,
         uiReceivers, hintReceivers ->
         // first gen
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
 
         // append a page so we can cache an anchorPosition of [8]
         differ[8]
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
 
@@ -279,7 +280,7 @@ class PagingDataDifferTest(
         differ.refresh()
         assertThat(uiReceivers[0].refreshEvents).hasSize(1)
         assertThat(uiReceivers[1].refreshEvents).hasSize(1)
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(8 until 17)
 
@@ -301,12 +302,12 @@ class PagingDataDifferTest(
         uiReceivers, hintReceivers ->
 
         // first gen
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
 
         // append a page so we can cache an anchorPosition of [8]
         differ[8]
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
 
@@ -317,7 +318,7 @@ class PagingDataDifferTest(
 
         // to recreate a real use-case of retry based on load error
         pagingSources[1].errorNextLoad = true
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
         // differ should still have first gen presenter
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
 
@@ -325,7 +326,7 @@ class PagingDataDifferTest(
         differ.retry()
         assertThat(uiReceivers[0].retryEvents).hasSize(0)
         assertThat(uiReceivers[1].retryEvents).hasSize(1)
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // will retry with the correct cached hint
         assertThat(differ.snapshot()).containsExactlyElementsIn(8 until 17)
@@ -1466,7 +1467,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // execute queued initial REFRESH
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(50 until 59)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1477,7 +1478,7 @@ class PagingDataDifferTest(
         differ.refresh()
 
         // execute second REFRESH load
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // second refresh still loads from initialKey = 50 because anchorPosition/refreshKey is null
         assertThat(pagingSources.size).isEqualTo(2)
@@ -1498,7 +1499,7 @@ class PagingDataDifferTest(
         }
         val collectLoadStates = differ.collectLoadStates()
         // execute initial refresh
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(
@@ -1513,7 +1514,7 @@ class PagingDataDifferTest(
         differ.refresh()
         // after a refresh, make sure the loading event comes in 1 piece w/ the end of pagination
         // reset
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(
                 refreshLocal = Loading,
@@ -1546,7 +1547,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1557,7 +1558,7 @@ class PagingDataDifferTest(
         // normal append
         differ[8]
 
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1572,9 +1573,9 @@ class PagingDataDifferTest(
         differ[11]
         pagingSources[0].nextLoadResult = LoadResult.Invalid()
 
-        // using poll().run() instead of executeAll, otherwise this invalid APPEND + subsequent
+        // using advanceTimeBy instead of advanceUntilIdle, otherwise this invalid APPEND + subsequent
         // REFRESH will auto run consecutively and we won't be able to assert them incrementally
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceTimeBy(1001)
 
         assertThat(pagingSources.size).isEqualTo(2)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1592,7 +1593,7 @@ class PagingDataDifferTest(
         )
 
         // the LoadResult.Invalid from failed APPEND triggers new pagingSource + initial REFRESH
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(11 until 20)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1608,7 +1609,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(50 until 59)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1620,7 +1621,7 @@ class PagingDataDifferTest(
         // normal prepend to ensure LoadStates for Page returns remains the same
         differ[0]
 
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(47 until 59)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1632,7 +1633,7 @@ class PagingDataDifferTest(
         // do an invalid prepend which will return LoadResult.Invalid
         differ[0]
         pagingSources[0].nextLoadResult = LoadResult.Invalid()
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceTimeBy(1001)
 
         assertThat(pagingSources.size).isEqualTo(2)
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1645,7 +1646,7 @@ class PagingDataDifferTest(
         )
 
         // the LoadResult.Invalid from failed PREPEND triggers new pagingSource + initial REFRESH
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // load starts from 0 again because the provided initialKey = 50 is not multi-generational
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
@@ -1663,7 +1664,7 @@ class PagingDataDifferTest(
 
         // execute queued initial REFRESH load which will return LoadResult.Invalid()
         pagingSources[0].nextLoadResult = LoadResult.Invalid()
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceTimeBy(1001)
 
         assertThat(differ.snapshot()).isEmpty()
         assertThat(differ.newCombinedLoadStates()).containsExactly(
@@ -1673,7 +1674,7 @@ class PagingDataDifferTest(
         )
 
         // execute second REFRESH load
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // second refresh still loads from initialKey = 50 because anchorPosition/refreshKey is null
         assertThat(pagingSources.size).isEqualTo(2)
@@ -1692,7 +1693,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(refreshLocal = Loading),
@@ -1705,7 +1706,7 @@ class PagingDataDifferTest(
         val exception = Throwable()
         pagingSources[0].nextLoadResult = LoadResult.Error(exception)
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(
@@ -1721,7 +1722,7 @@ class PagingDataDifferTest(
 
         // retry append
         differ.retry()
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // make sure append success
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 12)
@@ -1743,7 +1744,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(refreshLocal = Loading),
@@ -1757,7 +1758,7 @@ class PagingDataDifferTest(
         val exception = Throwable()
         pagingSources[0].nextLoadResult = LoadResult.Error(exception)
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(prependLocal = Loading),
@@ -1768,7 +1769,7 @@ class PagingDataDifferTest(
         // retry prepend
         differ.retry()
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // make sure prepend success
         assertThat(differ.snapshot()).containsExactlyElementsIn(47 until 59)
@@ -1781,14 +1782,14 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refreshError_retryLoadStates() = runTest() { differ, loadDispatcher, pagingSources, _, _ ->
+    fun refreshError_retryLoadStates() = runTest { differ, loadDispatcher, pagingSources, _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
         // initial load returns LoadResult.Error
         val exception = Throwable()
         pagingSources[0].nextLoadResult = LoadResult.Error(exception)
 
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(refreshLocal = Loading),
@@ -1799,7 +1800,7 @@ class PagingDataDifferTest(
         // retry refresh
         differ.retry()
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // refresh retry does not trigger new gen
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
@@ -1818,7 +1819,7 @@ class PagingDataDifferTest(
         val collectLoadStates = differ.collectLoadStates()
 
         // initial REFRESH
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(refreshLocal = Loading),
@@ -1832,7 +1833,7 @@ class PagingDataDifferTest(
         val exception = Throwable()
         pagingSources[0].nextLoadResult = LoadResult.Error(exception)
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(prependLocal = Loading),
@@ -1841,7 +1842,7 @@ class PagingDataDifferTest(
 
         // refresh() should reset local LoadStates and trigger new REFRESH
         differ.refresh()
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         // Initial load starts from 0 because initialKey is single gen.
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
@@ -1857,7 +1858,7 @@ class PagingDataDifferTest(
     }
 
     @Test
-    fun refreshError_refreshLoadStates() = runTest() { differ, loadDispatcher, pagingSources,
+    fun refreshError_refreshLoadStates() = runTest { differ, loadDispatcher, pagingSources,
         _, _ ->
         val collectLoadStates = differ.collectLoadStates()
 
@@ -1865,7 +1866,7 @@ class PagingDataDifferTest(
         val exception = Throwable()
         pagingSources[0].nextLoadResult = LoadResult.Error(exception)
 
-        loadDispatcher.executeAll()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.newCombinedLoadStates()).containsExactly(
             localLoadStatesOf(refreshLocal = Loading),
@@ -1876,7 +1877,7 @@ class PagingDataDifferTest(
         // refresh should trigger new generation
         differ.refresh()
 
-        loadDispatcher.queue.poll()?.run()
+        loadDispatcher.scheduler.advanceUntilIdle()
 
         assertThat(differ.snapshot()).containsExactlyElementsIn(0 until 9)
         // Goes directly from Error --> Loading without resetting refresh to NotLoading
@@ -2038,7 +2039,7 @@ class PagingDataDifferTest(
     }
 
     private fun runTest(
-        loadDispatcher: TestDispatcher = TestDispatcher(),
+        loadDispatcher: TestDispatcher = StandardTestDispatcher(),
         initialKey: Int? = null,
         pagingSources: MutableList<TestPagingSource> = mutableListOf(),
         pager: Pager<Int, Int> =
@@ -2047,7 +2048,6 @@ class PagingDataDifferTest(
                 initialKey = initialKey,
                 pagingSourceFactory = {
                     TestPagingSource(
-                        loadDelay = 0,
                         loadContext = loadDispatcher,
                     ).also { pagingSources.add(it) }
                 }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingDataDifferTest.kt
@@ -2048,6 +2048,7 @@ class PagingDataDifferTest(
                 initialKey = initialKey,
                 pagingSourceFactory = {
                     TestPagingSource(
+                        loadDelay = 1000,
                         loadContext = loadDispatcher,
                     ).also { pagingSources.add(it) }
                 }


### PR DESCRIPTION
Removes _all_ usages of `TestDispatcher` in the Paging 3 parts of `paging-common` tests, and _some_ usages of `TestDispatcher` in the Paging 2 parts of `paging-common` tests (`PagedListTest.kt` and `ContiguousPagedListTest.kt` are left).

Test: ./gradlew test connectedCheck
Bug: 275416222