### PR TITLE
Turn off GH CI for compose-runtime

### DIFF
--- a/.github/ci-control/ci-config.json
+++ b/.github/ci-control/ci-config.json
@@ -7,7 +7,6 @@
     ],
     "compose" : {
         "include" : [
-            "compose-runtime"
         ],
         "default": false
     },


### PR DESCRIPTION
Seems to be failing due to a bug with version constraints that causes it to fail to resolve androidx.lifecycle:lifecycle-viewmodel-savedstate. Disabling for now since the proper fix seems like it will take some time.

Test: GH workflows
Change-Id: I9d6e1c7d86a4d389d52eefa24ec1d2d45b5ec3b6