### PR TITLE
Pull com.android.tools:r8:8.1.41 from snapshot repo in playground builds

### DIFF
--- a/buildSrc/repos.gradle
+++ b/buildSrc/repos.gradle
@@ -65,6 +65,13 @@ def addMavenRepositories(RepositoryHandler handler) {
                url("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         }
         handler.mavenLocal()
+        // TODO(b/280646217): Remove after official release to gmaven.
+        handler.maven {
+            url("https://storage.googleapis.com/r8-releases/raw")
+            content {
+                includeModule("com.android.tools", "r8")
+            }
+        }
     }
     // Ordering appears to be important: b/229733266
     def androidPluginRepoOverride = System.getenv("GRADLE_PLUGIN_REPO")


### PR DESCRIPTION
androidx depends on this unreleased artifact, so we need to pull it from publicly available snapshot repo.
We don't want to keep this as a repo for buildscript unnecesarily, so filed a bug for tracking its removal once its possible.

Bug: 280646217
Test: cd collection && ./gradlew ktlint