### PR TITLE
Exclude compose-runtime from main GH build properly

### DIFF
--- a/.github/ci-control/ci-config.json
+++ b/.github/ci-control/ci-config.json
@@ -7,11 +7,13 @@
     ],
     "compose" : {
         "include" : [
+            "compose-runtime"
         ],
         "default": false
     },
     "main" : {
         "exclude" : [
+          "compose-runtime",
           "room"
         ],
         "default": true


### PR DESCRIPTION
This seems to have been misconfigured as compose-runtime is still failing ToT. The intention was to disable compose-runtime from androidx-main pipeline, but keep the integration branch running.

Test: GH workflows
Change-Id: If8edfe3b0c2c9b83e3e004d146481373d48e32e8