### PR TITLE
Bump build tools in playground to latest public release

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -38,6 +38,9 @@ runs:
     - name: "Install Cmake"
       shell: bash
       run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1"
+    - name: "Install Android SDK Build-Tools"
+      shell: bash
+      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "build-tools;34.0.0-rc3"
     - name: "Set environment variables"
       shell: bash
       run: |

--- a/buildSrc/public/src/main/kotlin/androidx/build/SupportConfig.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SupportConfig.kt
@@ -25,7 +25,7 @@ object SupportConfig {
     const val DEFAULT_MIN_SDK_VERSION = 14
     const val INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
     private const val INTERNAL_BUILD_TOOLS_VERSION = "34.0.0-rc3"
-    private const val PUBLIC_BUILD_TOOLS_VERSION = "33.0.1"
+    private const val PUBLIC_BUILD_TOOLS_VERSION = "34.0.0-rc3"
     const val NDK_VERSION = "23.1.7779620"
 
     /**


### PR DESCRIPTION
This fixes AIDL failure in core playground

Test: ./gradlew :core:core:checkReleaseAidlApiRelease
Change-Id: I38614339310c8031995f2e412ce6084f43a0614b