### PR TITLE
Fix for broken formatting in Javadocs.

### DIFF
--- a/benchmark/benchmark-macro-junit4/src/main/java/androidx/benchmark/macro/junit4/BaselineProfileRule.kt
+++ b/benchmark/benchmark-macro-junit4/src/main/java/androidx/benchmark/macro/junit4/BaselineProfileRule.kt
@@ -55,6 +55,7 @@ import org.junit.runners.model.Statement
  *         startActivityAndWait()
  *     }
  * }
+ * ```
  *
  * Note that you can filter captured rules, for example, if you're generating rules for a library,
  * and don't want to record profiles from outside that library:


### PR DESCRIPTION
The first code block is not correctly terminated resulting in the rest of the overview section being incorrectly formatted. 

## Proposed Changes

This change correctly terminates the first sample.

## Testing

Test: Manually verify that the document formatting is correct
## Issues Fixed

Fixes: https://issuetracker.google.com/issues/280958687
