### PR TITLE
Replace all occurences of 'org.junit.Assert' with 'kotlin.test' in paging-common

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/ContiguousPagedListTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/ContiguousPagedListTest.kt
@@ -34,12 +34,12 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @RunWith(Parameterized::class)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/FailDispatcher.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/FailDispatcher.kt
@@ -18,8 +18,8 @@ package androidx.paging
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Runnable
-import org.junit.Assert.fail
 import kotlin.coroutines.CoroutineContext
+import kotlin.test.fail
 
 class FailDispatcher(
     val string: String = "Executor expected to be unused"

--- a/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
@@ -21,9 +21,6 @@ import org.mockito.kotlin.capture
 import org.mockito.kotlin.mock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -31,7 +28,10 @@ import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import kotlin.random.Random
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 @Suppress("DEPRECATION")
 @RunWith(JUnit4::class)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
@@ -28,13 +28,13 @@ import androidx.paging.PagingSource.LoadParams.Refresh
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingSource.LoadResult.Page
 import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
-import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -35,6 +34,7 @@ import java.util.concurrent.Executors
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -93,21 +93,21 @@ class LegacyPagingSourceTest {
                 params: LoadInitialParams<Int>,
                 callback: LoadInitialCallback<String>
             ) {
-                Assert.fail("loadInitial not expected")
+                fail("loadInitial not expected")
             }
 
             override fun loadAfter(
                 params: LoadParams<Int>,
                 callback: LoadCallback<String>
             ) {
-                Assert.fail("loadAfter not expected")
+                fail("loadAfter not expected")
             }
 
             override fun loadBefore(
                 params: LoadParams<Int>,
                 callback: LoadCallback<String>
             ) {
-                Assert.fail("loadBefore not expected")
+                fail("loadBefore not expected")
             }
 
             override fun getKey(item: String) = item.hashCode()
@@ -141,21 +141,21 @@ class LegacyPagingSourceTest {
                 params: LoadInitialParams<Int>,
                 callback: LoadInitialCallback<Int, String>
             ) {
-                Assert.fail("loadInitial not expected")
+                fail("loadInitial not expected")
             }
 
             override fun loadBefore(
                 params: LoadParams<Int>,
                 callback: LoadCallback<Int, String>
             ) {
-                Assert.fail("loadBefore not expected")
+                fail("loadBefore not expected")
             }
 
             override fun loadAfter(
                 params: LoadParams<Int>,
                 callback: LoadCallback<Int, String>
             ) {
-                Assert.fail("loadAfter not expected")
+                fail("loadAfter not expected")
             }
         }
         val pagingSource = LegacyPagingSource(
@@ -391,14 +391,14 @@ class LegacyPagingSourceTest {
                 callback: LoadInitialCallback<String>
             ) {
                 if (!expectInitialLoad) {
-                    Assert.fail("loadInitial not expected")
+                    fail("loadInitial not expected")
                 } else {
                     callback.onResult(listOf(), 0)
                 }
             }
 
             override fun loadRange(params: LoadRangeParams, callback: LoadRangeCallback<String>) {
-                Assert.fail("loadRange not expected")
+                fail("loadRange not expected")
             }
         }
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
@@ -20,10 +20,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -31,7 +27,11 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.test.StandardTestDispatcher
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigBuilderTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigBuilderTest.kt
@@ -16,7 +16,7 @@
 
 package androidx.paging
 
-import org.junit.Assert
+import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -29,12 +29,12 @@ class PagedListConfigBuilderTest {
         val config = PagedList.Config.Builder()
             .setPageSize(10)
             .build()
-        Assert.assertEquals(10, config.pageSize)
-        Assert.assertEquals(30, config.initialLoadSizeHint)
-        Assert.assertEquals(true, config.enablePlaceholders)
-        Assert.assertEquals(10, config.prefetchDistance)
+        assertEquals(10, config.pageSize)
+        assertEquals(30, config.initialLoadSizeHint)
+        assertEquals(true, config.enablePlaceholders)
+        assertEquals(10, config.prefetchDistance)
         @Suppress("DEPRECATION")
-        Assert.assertEquals(PagedList.Config.MAX_SIZE_UNBOUNDED, config.maxSize)
+        assertEquals(PagedList.Config.MAX_SIZE_UNBOUNDED, config.maxSize)
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigTest.kt
@@ -16,7 +16,7 @@
 
 package androidx.paging
 
-import org.junit.Assert.assertEquals
+import kotlin.test.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListTest.kt
@@ -24,13 +24,13 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.util.concurrent.Executor
 import kotlin.concurrent.thread
 import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedStorageTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedStorageTest.kt
@@ -17,16 +17,16 @@
 package androidx.paging
 
 import androidx.paging.PagingSource.LoadResult.Page
-import org.junit.Assert.assertArrayEquals
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.test.assertNotNull
 
 @RunWith(JUnit4::class)
@@ -41,7 +41,7 @@ class PagedStorageTest {
     fun construct() {
         val storage = PagedStorage(2, pageOf("a", "b"), 2)
 
-        assertArrayEquals(arrayOf(null, null, "a", "b", null, null), storage.toArray())
+        assertContentEquals(arrayOf(null, null, "a", "b", null, null), storage.toArray())
         assertEquals(6, storage.size)
     }
 
@@ -52,7 +52,7 @@ class PagedStorageTest {
         val storage = PagedStorage(2, pageOf("a", "b"), 2)
         storage.appendPage(pageOf("c", "d"), callback)
 
-        assertArrayEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
+        assertContentEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
         verify(callback).onPageAppended(4, 2, 0)
         verifyNoMoreInteractions(callback)
     }
@@ -64,7 +64,7 @@ class PagedStorageTest {
         val storage = PagedStorage(2, pageOf("a", "b"), 0)
         storage.appendPage(pageOf("c", "d"), callback)
 
-        assertArrayEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
+        assertContentEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
         verify(callback).onPageAppended(4, 0, 2)
         verifyNoMoreInteractions(callback)
     }
@@ -78,14 +78,14 @@ class PagedStorageTest {
         // change 2 nulls into c, d
         storage.appendPage(pageOf("c", "d"), callback)
 
-        assertArrayEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
+        assertContentEquals(arrayOf(null, null, "a", "b", "c", "d"), storage.toArray())
         verify(callback).onPageAppended(4, 2, 0)
         verifyNoMoreInteractions(callback)
 
         // append e, f
         storage.appendPage(pageOf("e", "f"), callback)
 
-        assertArrayEquals(arrayOf(null, null, "a", "b", "c", "d", "e", "f"), storage.toArray())
+        assertContentEquals(arrayOf(null, null, "a", "b", "c", "d", "e", "f"), storage.toArray())
         verify(callback).onPageAppended(6, 0, 2)
         verifyNoMoreInteractions(callback)
     }
@@ -97,7 +97,7 @@ class PagedStorageTest {
         val storage = PagedStorage(2, pageOf("c", "d"), 2)
         storage.prependPage(pageOf("a", "b"), callback)
 
-        assertArrayEquals(arrayOf("a", "b", "c", "d", null, null), storage.toArray())
+        assertContentEquals(arrayOf("a", "b", "c", "d", null, null), storage.toArray())
         verify(callback).onPagePrepended(0, 2, 0)
         verifyNoMoreInteractions(callback)
     }
@@ -109,7 +109,7 @@ class PagedStorageTest {
         val storage = PagedStorage(0, pageOf("c", "d"), 2)
         storage.prependPage(pageOf("a", "b"), callback)
 
-        assertArrayEquals(arrayOf("a", "b", "c", "d", null, null), storage.toArray())
+        assertContentEquals(arrayOf("a", "b", "c", "d", null, null), storage.toArray())
         verify(callback).onPagePrepended(0, 0, 2)
         verifyNoMoreInteractions(callback)
     }
@@ -123,14 +123,14 @@ class PagedStorageTest {
         // change 2 nulls into c, d
         storage.prependPage(pageOf("c", "d"), callback)
 
-        assertArrayEquals(arrayOf("c", "d", "e", "f", null, null), storage.toArray())
+        assertContentEquals(arrayOf("c", "d", "e", "f", null, null), storage.toArray())
         verify(callback).onPagePrepended(0, 2, 0)
         verifyNoMoreInteractions(callback)
 
         // prepend a, b
         storage.prependPage(pageOf("a", "b"), callback)
 
-        assertArrayEquals(arrayOf("a", "b", "c", "d", "e", "f", null, null), storage.toArray())
+        assertContentEquals(arrayOf("a", "b", "c", "d", "e", "f", null, null), storage.toArray())
         verify(callback).onPagePrepended(0, 0, 2)
         verifyNoMoreInteractions(callback)
     }
@@ -141,7 +141,7 @@ class PagedStorageTest {
         val storage = PagedStorage(1, pageOf("a"), 6)
         storage.appendPage(pageOf("b", "c"), callback)
         storage.appendPage(pageOf("d", "e", "f"), callback)
-        assertArrayEquals(arrayOf(null, "a", "b", "c", "d", "e", "f", null), storage.toArray())
+        assertContentEquals(arrayOf(null, "a", "b", "c", "d", "e", "f", null), storage.toArray())
     }
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingConfigTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingConfigTest.kt
@@ -17,10 +17,10 @@
 package androidx.paging
 
 import androidx.paging.PagingConfig.Companion.MAX_SIZE_UNBOUNDED
-import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 @RunWith(JUnit4::class)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingSourceTest.kt
@@ -21,13 +21,13 @@ import androidx.paging.PagingSource.LoadResult
 import androidx.paging.PagingSource.LoadResult.Page.Companion.COUNT_UNDEFINED
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import kotlin.random.Random
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 @RunWith(JUnit4::class)
 class PagingSourceTest {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
@@ -21,9 +21,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
-import org.junit.Assert.fail
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -31,6 +28,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 import java.util.concurrent.Executor
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
 
 @Suppress("DEPRECATION")
 @RunWith(JUnit4::class)


### PR DESCRIPTION
I opted to convert these imports over to `kotlin.test` instead of Truth/Kruth as the `paging-common` tests already mix usage of `kotlin.test` and Truth, and converting to `kotlin.test` results in a smaller diff.

Test: ./gradlew test connectedCheck
Bug: 270612487