### PR TITLE
Add MapSubject#isEmpty to Kruth

### DIFF
--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Kruth.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Kruth.kt
@@ -42,3 +42,6 @@ fun assertThat(actual: String?): StringSubject {
 
 fun <T> assertThat(actual: Iterable<T>?): IterableSubject<T> =
     IterableSubject(actual)
+
+fun <K, V> assertThat(actual: Map<K, V>?): MapSubject<K, V> =
+    MapSubject(actual)

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
@@ -25,7 +25,7 @@ class MapSubject<K, V>(actual: Map<K, V>?) : Subject<Map<K, V>>(actual) {
         requireNonNull(actual) { "Expected to be empty, but was null" }
 
         if (actual.isNotEmpty()) {
-            fail("Expected to be empty")
+            fail("Expected to be empty, but was $actual")
         }
     }
 }

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.kruth
+
+import kotlin.test.fail
+
+class MapSubject<K, V>(actual: Map<K, V>?) : Subject<Map<K, V>>(actual) {
+
+    /** Fails if the map is not empty. */
+    fun isEmpty() {
+        requireNonNull(actual) { "Expected to be empty, but was null" }
+
+        if (actual.isNotEmpty()) {
+            fail("Expected to be empty")
+        }
+    }
+}

--- a/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
+++ b/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.kruth
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class MapSubjectTest {
+
+    @Test
+    fun isEmpty() {
+        assertThat(mapOf<Any, Any>()).isEmpty()
+    }
+
+    @Test
+    fun isEmptyWithFailure() {
+        assertFailsWith<AssertionError> {
+            assertThat(mapOf(1 to 5)).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
I want to convert the `paging-common` tests over to Truth. `PageFetcherSnapshotTest.kt` [requires the assertion function `MapSubject#containsExactlyEntriesIn`](https://github.com/androidx/androidx/blob/0d69980384d87e234c8e61d7164143d0a7c56309/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt#L1656), which doesn't yet exist in Kruth. The implementation of `MapSubject#containsExactlyEntriesIn` [depends on the existence of `MapSubject#isEmpty`](https://github.com/google/truth/blob/c2e624138fcd7e2979ecd5abcb099d345629ae5e/core/src/main/java/com/google/common/truth/MapSubject.java#L234).

As a first step, I've added support for `MapSubject#isEmpty`, as it is useful by itself.

Test: ./gradlew test connectedCheck
Bug: 270612487