### PR TITLE
Bump playground to build-tools;34.0.0-rc4

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -40,7 +40,7 @@ runs:
       run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1"
     - name: "Install Android SDK Build-Tools"
       shell: bash
-      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "build-tools;34.0.0-rc3"
+      run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "build-tools;34.0.0-rc4"
     - name: "Set environment variables"
       shell: bash
       run: |

--- a/buildSrc/public/src/main/kotlin/androidx/build/SupportConfig.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SupportConfig.kt
@@ -25,7 +25,7 @@ object SupportConfig {
     const val DEFAULT_MIN_SDK_VERSION = 14
     const val INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
     private const val INTERNAL_BUILD_TOOLS_VERSION = "34.0.0-rc3"
-    private const val PUBLIC_BUILD_TOOLS_VERSION = "34.0.0-rc3"
+    private const val PUBLIC_BUILD_TOOLS_VERSION = "34.0.0-rc4"
     const val NDK_VERSION = "23.1.7779620"
 
     /**


### PR DESCRIPTION
Seems sdkmanager no longer lists 34.0.0-rc3 as an available version to install even will --list_obsolete or --channel=3 (canary).

The proper fix will be to move the runner to a cached image from gcr, but it requires some work to build. This change temporarily resolves existing failures ToT.

Test: GH workflows
Change-Id: Id9fcfd86ca466fdd18aaaa7a0c7fbf965e8d0830