### PR TITLE
Add assertWithMessage(String) to Kruth

### DIFF
--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/BooleanSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/BooleanSubject.kt
@@ -21,7 +21,10 @@ import kotlin.test.assertTrue
 /**
  * Propositions for boolean subjects.
  */
-class BooleanSubject(actual: Boolean?) : Subject<Boolean>(actual) {
+class BooleanSubject(
+    actual: Boolean?,
+    messageToPrepend: String? = null,
+) : Subject<Boolean>(actual, messageToPrepend) {
 
     /**
      * Fails if the subject is false or `null`.

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ComparableSubject.kt
@@ -16,14 +16,15 @@
 
 package androidx.kruth
 
-import kotlin.test.fail
-
 /**
  * Propositions for [Comparable] typed subjects.
  *
  * @param T the type of the object being tested by this [ComparableSubject]
  */
-open class ComparableSubject<T : Comparable<T>> constructor(actual: T?) : Subject<T>(actual) {
+open class ComparableSubject<T : Comparable<T>> constructor(
+    actual: T?,
+    messageToPrepend: String? = null,
+) : Subject<T>(actual, messageToPrepend) {
 
     /**
      * Checks that the subject is less than [other].

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/FailingOrdered.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/FailingOrdered.kt
@@ -16,16 +16,15 @@
 
 package androidx.kruth
 
-import kotlin.test.fail
-
 /**
  * Always fails with the provided error message.
  */
-internal class FailingOrdered(
+internal class FailingOrdered<T>(
+    private val subject: Subject<T>,
     private val message: () -> String,
 ) : Ordered {
 
     override fun inOrder() {
-        fail(message())
+        subject.fail(message())
     }
 }

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/IterableSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/IterableSubject.kt
@@ -17,7 +17,6 @@
 package androidx.kruth
 
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 /**
  * Propositions for [Iterable] subjects.
@@ -31,7 +30,10 @@ import kotlin.test.fail
  * - Assertions may also require that the elements in the given [Iterable] implement
  * [Any.hashCode] correctly.
  */
-open class IterableSubject<T>(actual: Iterable<T>?) : Subject<Iterable<T>>(actual) {
+open class IterableSubject<T>(
+    actual: Iterable<T>?,
+    messageToPrepend: String? = null,
+) : Subject<Iterable<T>>(actual, messageToPrepend) {
 
     override fun isEqualTo(expected: Any?) {
         // method contract requires testing iterables for equality
@@ -204,7 +206,7 @@ open class IterableSubject<T>(actual: Iterable<T>?) : Subject<Iterable<T>>(actua
             return NoopOrdered
         }
 
-        return FailingOrdered {
+        return FailingOrdered(this) {
             buildString {
                 append("Required elements were all found, but order was wrong.")
                 append("Expected order: $expected.")
@@ -328,7 +330,7 @@ open class IterableSubject<T>(actual: Iterable<T>?) : Subject<Iterable<T>>(actua
                      * so return an object that will fail the test if the user calls inOrder().
                      */
 
-                    return FailingOrdered {
+                    return FailingOrdered(this) {
                         """
                              Contents match. Expected the order to also match, but was not.
                              Expected: $required.

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Kruth.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Kruth.kt
@@ -20,6 +20,9 @@ package androidx.kruth
 // ordering of which Subject type to prioritize from the general `assertThat` factory method. See:
 // https://github.com/google/truth/blob/master/core/src/main/java/com/google/common/truth/Truth.java
 
+fun assertWithMessage(messageToPrepend: String): StandardSubjectBuilder =
+    StandardSubjectBuilder(messageToPrepend)
+
 fun <T : Comparable<T>> assertThat(actual: T?): ComparableSubject<T> {
     return ComparableSubject(actual)
 }

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
@@ -16,9 +16,10 @@
 
 package androidx.kruth
 
-import kotlin.test.fail
-
-class MapSubject<K, V>(actual: Map<K, V>?) : Subject<Map<K, V>>(actual) {
+class MapSubject<K, V>(
+    actual: Map<K, V>?,
+    messageToPrepend: String? = null,
+) : Subject<Map<K, V>>(actual, messageToPrepend) {
 
     /** Fails if the map is not empty. */
     fun isEmpty() {

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/StandardSubjectBuilder.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/StandardSubjectBuilder.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.kruth
+
+class StandardSubjectBuilder(private val messageToPrepend: String) {
+
+    fun <T : Comparable<T>> that(actual: T?): ComparableSubject<T> =
+        ComparableSubject(actual, messageToPrepend)
+
+    fun <T> that(actual: T?): Subject<T> =
+        Subject(actual, messageToPrepend)
+
+    fun <T : Throwable> that(actual: T?): ThrowableSubject<T> =
+        ThrowableSubject(actual, messageToPrepend)
+
+    fun that(actual: Boolean?): BooleanSubject =
+        BooleanSubject(actual, messageToPrepend)
+
+    fun that(actual: String?): StringSubject =
+        StringSubject(actual, messageToPrepend)
+
+    fun <T> that(actual: Iterable<T>?): IterableSubject<T> =
+        IterableSubject(actual, messageToPrepend)
+
+    fun <K, V> that(actual: Map<K, V>?): MapSubject<K, V> =
+        MapSubject(actual, messageToPrepend)
+}

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/StringSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/StringSubject.kt
@@ -18,12 +18,14 @@ package androidx.kruth
 
 import kotlin.test.assertContains
 import kotlin.test.assertNotNull
-import kotlin.test.fail
 
 /**
  * Propositions for string subjects.
  */
-class StringSubject(actual: String?) : ComparableSubject<String>(actual) {
+class StringSubject(
+    actual: String?,
+    messageToPrepend: String? = null,
+) : ComparableSubject<String>(actual, messageToPrepend) {
 
     /**
      * Fails if the string does not contain the given sequence.

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Subject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/Subject.kt
@@ -20,7 +20,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertIsNot
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 // As opposed to Truth, which limits visibility on `actual` and the generic type, we purposely make
 // them visible in Kruth to allow for an easier time extending in Kotlin.
@@ -32,7 +31,7 @@ import kotlin.test.fail
  *
  * To create a [Subject] instance, most users will call an [assertThat] method.
  */
-open class Subject<out T>(val actual: T?) {
+open class Subject<out T>(val actual: T?, private val messageToPrepend: String? = null) {
 
     /**
      *  Fails if the subject is not null.
@@ -131,6 +130,17 @@ open class Subject<out T>(val actual: T?) {
     /** Fails if the subject is equal to any of the given elements.  */
     open fun isNoneOf(first: Any?, second: Any?, vararg rest: Any?) {
         isNotIn(listOf(first, second, *rest))
+    }
+
+    fun fail(message: String) {
+        kotlin.test.fail(
+            buildString {
+                if (messageToPrepend != null) {
+                    appendLine(messageToPrepend)
+                }
+                append(message)
+            }
+        )
     }
 }
 

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ThrowableSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/ThrowableSubject.kt
@@ -19,7 +19,10 @@ package androidx.kruth
 /**
  * Propositions for [Throwable] subjects.
  */
-class ThrowableSubject<T : Throwable>(actual: T?) : Subject<T>(actual) {
+class ThrowableSubject<T : Throwable>(
+    actual: T?,
+    messageToPrepend: String? = null,
+) : Subject<T>(actual, messageToPrepend) {
 
     /**
      * Returns a [StringSubject] to make assertions about the throwable's message.


### PR DESCRIPTION
I know in the Truth implementation that they wrap the failure message in a `FailureMetadata`. I was unsure whether to add that, as I think it's unclear whether Kruth would currently benefit from such a construct.

I wanted to have a `fail` function in `Subject` with a near identical signature to `kotlin.test.fail`, to make it less likely that one would use the `kotlin.test.fail` function directly.

Test: ./gradlew test connectedCheck
Bug: 270612487