### PR TITLE
Add MapSubject#containsExactlyEntriesIn to Kruth

### DIFF
--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
@@ -46,6 +46,29 @@ class MapSubject<K, V> internal constructor(actual: Map<K, V>?) : Subject<Map<K,
             asserter.fail("Expected $expectedMap, but was $actual")
         }
 
-        return NoopOrdered
+        return MapInOrder(expectedMap)
+    }
+
+    private inner class MapInOrder(
+        private val expectedMap: Map<*, *>,
+    ) : Ordered {
+
+        /**
+         * Checks whether the common elements between actual and expected are in the same order.
+         *
+         * This doesn't check whether the keys have the same values or whether all the required keys
+         * are actually present. That was supposed to be done before the "in order" part.
+         */
+        override fun inOrder() {
+            // We're using the fact that Iterable#intersect keeps the order of the first set.
+            checkNotNull(actual)
+            val expectedKeyOrder = (expectedMap.keys intersect actual.keys).toList()
+            val actualKeyOrder = (actual.keys intersect expectedMap.keys).toList()
+            if (actualKeyOrder != expectedKeyOrder) {
+                asserter.fail(
+                    "Entries match, but order was wrong. Expected $expectedMap, but was $actual",
+                )
+            }
+        }
     }
 }

--- a/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
+++ b/testutils/testutils-kmp/src/commonMain/kotlin/androidx/kruth/MapSubject.kt
@@ -35,4 +35,17 @@ class MapSubject<K, V> internal constructor(actual: Map<K, V>?) : Subject<Map<K,
             asserter.fail("Expected to contain $key, but was ${actual.keys}")
         }
     }
+
+    /** Fails if the map does not contain exactly the given set of entries in the given map. */
+    fun containsExactlyEntriesIn(expectedMap: Map<K, V>): Ordered {
+        requireNonNull(actual) { "Expected $expectedMap, but was null" }
+
+        if (expectedMap.isEmpty()) {
+            isEmpty()
+        } else if ((expectedMap.entries - actual.entries).isNotEmpty()) {
+            asserter.fail("Expected $expectedMap, but was $actual")
+        }
+
+        return NoopOrdered
+    }
 }

--- a/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
+++ b/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
@@ -22,6 +22,62 @@ import kotlin.test.assertFailsWith
 class MapSubjectTest {
 
     @Test
+    fun containsExactlyWithNullKey() {
+        val actual = mapOf<String?, String>(null to "value")
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyWithNullValue() {
+        val actual = mapOf<String, String?>("key" to null)
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyEmpty() {
+        val actual = mapOf<String, Int>()
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyEntriesInEmpty_fails() {
+        assertFailsWith<AssertionError> {
+            assertThat(mapOf("jan" to 1)).containsExactlyEntriesIn(emptyMap())
+        }
+    }
+
+    @Test
+    fun containsExactlyOneEntry() {
+        val actual = mapOf("jan" to 1)
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyMultipleEntries() {
+        val actual = mapOf("jan" to 1, "feb" to 2, "march" to 3)
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyNotInOrder() {
+        val actual = mapOf("jan" to 1, "feb" to 2, "march" to 3)
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
+    fun containsExactlyBadNumberOfArgs() {
+        val actual = mapOf("jan" to 1, "feb" to 2, "march" to 3, "april" to 4, "may" to 5)
+        assertThat(actual).containsExactlyEntriesIn(actual)
+        assertThat(actual).containsExactlyEntriesIn(actual).inOrder()
+    }
+
+    @Test
     fun isEmpty() {
         assertThat(mapOf<Any, Any>()).isEmpty()
     }

--- a/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
+++ b/testutils/testutils-kmp/src/commonTest/kotlin/androidx/kruth/MapSubjectTest.kt
@@ -78,6 +78,15 @@ class MapSubjectTest {
     }
 
     @Test
+    fun containsExactlyInOrderWithReversedMap_fails() {
+        assertFailsWith<AssertionError> {
+            assertThat(mutableMapOf("jan" to 1, "feb" to 2, "march" to 3))
+                .containsExactlyEntriesIn(mutableMapOf("march" to 3, "feb" to 2, "jan" to 1))
+                .inOrder()
+        }
+    }
+
+    @Test
     fun isEmpty() {
         assertThat(mapOf<Any, Any>()).isEmpty()
     }


### PR DESCRIPTION
This is the last piece to migrate the `paging-common` tests over to Kruth!

Test: ./gradlew test connectedCheck
Bug: 270612487