### PR TITLE
Fix SBOM Generation in Github and add workaround for the Gradle dependency resolution bug

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/sbom/Sbom.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/sbom/Sbom.kt
@@ -18,11 +18,11 @@ package androidx.build.sbom
 
 import androidx.build.BundleInsideHelper
 import androidx.build.GMavenZipTask
+import androidx.build.ProjectLayoutType
 import androidx.build.addToBuildOnServer
 import androidx.build.getPrebuiltsRoot
 import androidx.build.getSupportRootFolder
 import androidx.build.gitclient.MultiGitClient
-import androidx.build.ProjectLayoutType
 import androidx.inspection.gradle.EXPORT_INSPECTOR_DEPENDENCIES
 import androidx.inspection.gradle.IMPORT_INSPECTOR_DEPENDENCIES
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
@@ -215,7 +215,7 @@ fun Project.configureSbomPublishing() {
     project.apply(plugin = "org.spdx.sbom")
     val repos = if (ProjectLayoutType.isPlayground(this)) {
         emptyMap()
-    }  else {
+    } else {
         getRepoPublicUrls()
     }
     val gitsClient = MultiGitClient.create(project)

--- a/buildSrc/private/src/main/kotlin/androidx/build/sbom/Sbom.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/sbom/Sbom.kt
@@ -22,6 +22,7 @@ import androidx.build.addToBuildOnServer
 import androidx.build.getPrebuiltsRoot
 import androidx.build.getSupportRootFolder
 import androidx.build.gitclient.MultiGitClient
+import androidx.build.ProjectLayoutType
 import androidx.inspection.gradle.EXPORT_INSPECTOR_DEPENDENCIES
 import androidx.inspection.gradle.IMPORT_INSPECTOR_DEPENDENCIES
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
@@ -212,7 +213,11 @@ fun Project.configureSbomPublishing() {
 
     project.configurations.create(sbomEmptyConfiguration)
     project.apply(plugin = "org.spdx.sbom")
-    val repos = getRepoPublicUrls()
+    val repos = if (ProjectLayoutType.isPlayground(this)) {
+        emptyMap()
+    }  else {
+        getRepoPublicUrls()
+    }
     val gitsClient = MultiGitClient.create(project)
     val supportRootDir = getSupportRootFolder()
 

--- a/compose/test-utils/build.gradle
+++ b/compose/test-utils/build.gradle
@@ -40,7 +40,9 @@ androidXMultiplatform {
             }
         }
         androidMain.dependencies {
-            api("androidx.activity:activity:1.2.0")
+            api("androidx.activity:activity:1.7.1")
+            // workaround for https://github.com/gradle/gradle/issues/8489
+            implementation("androidx.lifecycle:lifecycle-common:2.6.1")
             implementation "androidx.activity:activity-compose:1.3.1"
             api(projectOrArtifact(":compose:ui:ui-test-junit4"))
             api(project(":test:screenshot:screenshot"))

--- a/paging/paging-compose/integration-tests/paging-demos/build.gradle
+++ b/paging/paging-compose/integration-tests/paging-demos/build.gradle
@@ -26,6 +26,9 @@ plugins {
 
 dependencies {
     implementation(libs.kotlinStdlib)
+    // workaround for https://github.com/gradle/gradle/issues/8489
+    implementation("androidx.activity:activity:1.7.1")
+    implementation("androidx.lifecycle:lifecycle-common:2.6.1")
 
     implementation(projectOrArtifact(":compose:integration-tests:demos:common"))
     implementation(projectOrArtifact(":compose:foundation:foundation"))

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,6 +25,6 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=10059712
+androidx.playground.snapshotBuildId=10178688
 androidx.playground.metalavaBuildId=10129644
 androidx.studio.type=playground


### PR DESCRIPTION
Add workarounds for gradle resolution bug:
https://github.com/gradle/gradle/issues/8489

Also fixed a problem with sboms in playground since we don't have prebuilt repos there.

Looks like updating the activity and lifecycle dependencies does work around the issue.
It is not great but the only solution i could find.

Bug: n/a
Test: CI
