### PR TITLE
Disable haptics on github

### DIFF
--- a/core/settings.gradle
+++ b/core/settings.gradle
@@ -11,6 +11,7 @@ rootProject.name = "core-playground"
 playground {
     setupPlayground("..")
     selectProjectsFromAndroidX({ name ->
+        if (name.contains("haptics")) return false // b/285039694
         if (name.startsWith(":core")) return true
         if (name == ":internal-testutils-mockito") return true
         if (name == ":internal-testutils-fonts") return true


### PR DESCRIPTION
We are hitting b/285039694 on github. Even though we can workaround it, the workaround is adding a dependency on core-ktx from the samples project, which is not a great solution (it needs prebuilt, not module).

Bug: 285039694
Test: Github CI