### PR TITLE
Remove explicit Unit return when using runTest

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
@@ -452,7 +452,7 @@ class CachingTest {
      * invalidations create new PagingData BUT a new collector only sees the latest one.
      */
     @Test
-    public fun unusedPagingDataIsNeverCollectedByNewDownstream(): Unit = testScope.runTest {
+    public fun unusedPagingDataIsNeverCollectedByNewDownstream() = testScope.runTest {
         val factory = StringPagingSource.VersionedFactory()
         val flow = buildPageFlow(factory).cachedIn(backgroundScope, tracker)
         val collector = ItemCollector(flow)
@@ -517,7 +517,7 @@ class CachingTest {
     }
 
     @Test
-    public fun unusedPagingDataIsNeverCached(): Unit = testScope.runTest {
+    public fun unusedPagingDataIsNeverCached() = testScope.runTest {
         val factory = StringPagingSource.VersionedFactory()
         val flow = buildPageFlow(factory).cachedIn(backgroundScope, tracker)
         val collector = ItemCollector(flow)

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
@@ -453,7 +453,7 @@ class PositionalDataSourceTest {
     private val testScope = TestScope(UnconfinedTestDispatcher())
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun verifyRefreshIsTerminal(counted: Boolean): Unit = testScope.runTest {
+    private fun verifyRefreshIsTerminal(counted: Boolean) = testScope.runTest {
         val dataSource = ListDataSource(list = listOf(0, 1, 2), counted = counted)
         dataSource.load(
             DataSource.Params(


### PR DESCRIPTION
`kotlinx.coroutines.test.runTest` returns a `kotlinx.coroutines.test.TestResult`. Per [its documentation](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-result/), JVM and native just type alias to Unit, but when targeting JS it returns a `Promise`. This explicit return type of `Unit` is therefore incorrect when targeting JS.

Test: ./gradlew test connectedCheck
Bug: 270612487