### PR TITLE
Replace most runBlocking calls with runTest in `paging-common`

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
@@ -21,19 +21,21 @@ import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 /**
  * reproduces b/203594733
  */
+@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(JUnit4::class)
 public class CachedPageEventFlowLeakTest {
     private val gcHelper = GarbageCollectionTestHelper()
@@ -136,17 +138,15 @@ public class CachedPageEventFlowLeakTest {
 
     @Ignore("b/206837348")
     @Test
-    public fun dontLeakCachedPageEventFlows_finished() {
+    public fun dontLeakCachedPageEventFlows_finished() = runTest {
         val scope = CoroutineScope(EmptyCoroutineContext)
         val flow = pager.flow.cachedIn(scope, tracker)
-        runBlocking {
-            collectPages(
-                flow = flow,
-                generationCount = 20,
-                doneInvalidating = null,
-                finishCollecting = true
-            )
-        }
+        collectPages(
+            flow = flow,
+            generationCount = 20,
+            doneInvalidating = null,
+            finishCollecting = true
+        )
         gcHelper.assertLiveObjects(
             // see b/204125064
             // this should ideally be 0 but right now, we keep the previous generation's state
@@ -159,72 +159,66 @@ public class CachedPageEventFlowLeakTest {
     }
 
     @Test
-    public fun dontLeakNonCachedFlow_finished() {
-        runBlocking {
-            collectPages(
-                flow = pager.flow,
-                generationCount = 10,
-                doneInvalidating = null,
-                finishCollecting = true
-            )
-        }
+    public fun dontLeakNonCachedFlow_finished() = runTest {
+        collectPages(
+            flow = pager.flow,
+            generationCount = 10,
+            doneInvalidating = null,
+            finishCollecting = true
+        )
         gcHelper.assertEverythingIsCollected()
     }
 
     @Test
-    public fun dontLeakPreviousPageInfo_stillCollecting() {
+    public fun dontLeakPreviousPageInfo_stillCollecting() = runTest {
         // reproduces b/204125064
-        runBlocking {
-            val doneInvalidating = CompletableDeferred<Unit>()
-            val collection = launch {
-                collectPages(
-                    flow = pager.flow,
-                    generationCount = 10,
-                    doneInvalidating = doneInvalidating,
-                    finishCollecting = false
-                )
-            }
-            // make sure we collected enough generations
-            doneInvalidating.await()
-            gcHelper.assertLiveObjects(
-                // see b/204125064
-                // this should ideally be 0 but right now, we keep the previous generation's state
-                // to be able to find anchor for the new position but we don't clear it yet. It can
-                // only be cleared after the new generation loads a page.
-                Item::class to 20
+        val doneInvalidating = CompletableDeferred<Unit>()
+        val collection = launch {
+            collectPages(
+                flow = pager.flow,
+                generationCount = 10,
+                doneInvalidating = doneInvalidating,
+                finishCollecting = false
             )
-            collection.cancelAndJoin()
         }
+        // make sure we collected enough generations
+        doneInvalidating.await()
+        gcHelper.assertLiveObjects(
+            // see b/204125064
+            // this should ideally be 0 but right now, we keep the previous generation's state
+            // to be able to find anchor for the new position but we don't clear it yet. It can
+            // only be cleared after the new generation loads a page.
+            Item::class to 20
+        )
+        collection.cancelAndJoin()
     }
 
     // Broken: b/206981029
     @Ignore
     @Test
-    public fun dontLeakPreviousPageInfoWithCache_stillCollecting() {
+    public fun dontLeakPreviousPageInfoWithCache_stillCollecting() = runTest {
+        // reproduces b/204125064
         val scope = CoroutineScope(EmptyCoroutineContext)
         val flow = pager.flow.cachedIn(scope, tracker)
-        // reproduces b/204125064
-        runBlocking {
-            val doneInvalidating = CompletableDeferred<Unit>()
-            val collection = launch {
-                collectPages(
-                    flow = flow,
-                    generationCount = 10,
-                    doneInvalidating = doneInvalidating,
-                    finishCollecting = false
-                )
-            }
-            // make sure we collected enough generations
-            doneInvalidating.await()
-            gcHelper.assertLiveObjects(
-                // see b/204125064
-                // this should ideally be 0 but right now, we keep the previous generation's state
-                // to be able to find anchor for the new position but we don't clear it yet. It can
-                // only be cleared after the new generation loads a page.
-                Item::class to 20,
-                CachedPageEventFlow::class to 1
+        val doneInvalidating = CompletableDeferred<Unit>()
+        val collection = launch {
+            collectPages(
+                flow = flow,
+                generationCount = 10,
+                doneInvalidating = doneInvalidating,
+                finishCollecting = false
             )
-            collection.cancelAndJoin()
         }
+        // make sure we collected enough generations
+        doneInvalidating.await()
+        gcHelper.assertLiveObjects(
+            // see b/204125064
+            // this should ideally be 0 but right now, we keep the previous generation's state
+            // to be able to find anchor for the new position but we don't clear it yet. It can
+            // only be cleared after the new generation loads a page.
+            Item::class to 20,
+            CachedPageEventFlow::class to 1
+        )
+        collection.cancelAndJoin()
     }
 }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/FlowExtTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/FlowExtTest.kt
@@ -35,7 +35,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -257,7 +256,7 @@ class FlowExtTest {
     }
 
     @Test
-    fun combineWithoutBatching_stressTest() {
+    fun combineWithoutBatching_stressTest() = testScope.runTest {
         val flow1 = flow {
             repeat(1000) {
                 if (Random.nextBoolean()) {
@@ -276,10 +275,8 @@ class FlowExtTest {
         }
 
         repeat(10) {
-            val result = runBlocking {
-                flow1.combineWithoutBatching(flow2) { first, second, _ -> first to second }
-                    .toList()
-            }
+            val result = flow1.combineWithoutBatching(flow2) { first, second, _ -> first to second }
+                .toList()
 
             // Never emit the same values twice.
             assertThat(result).containsNoDuplicates()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
@@ -24,7 +24,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.ArgumentCaptor
@@ -33,6 +34,7 @@ import org.mockito.Mockito.verifyNoMoreInteractions
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.mock
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("DEPRECATION")
 @RunWith(JUnit4::class)
 class ItemKeyedDataSourceTest {
@@ -51,7 +53,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial() = runBlocking {
+    fun loadInitial() = runTest {
         val dataSource = ItemDataSource()
         val result = loadInitial(dataSource, dataSource.getKey(ITEMS_BY_NAME_ID[49]), 10, true)
 
@@ -61,7 +63,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_keyMatchesSingleItem() = runBlocking {
+    fun loadInitial_keyMatchesSingleItem() = runTest {
         val dataSource = ItemDataSource(items = ITEMS_BY_NAME_ID.subList(0, 1))
 
         // this is tricky, since load after and load before with the passed key will fail
@@ -73,7 +75,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_keyMatchesLastItem() = runBlocking {
+    fun loadInitial_keyMatchesLastItem() = runTest {
         val dataSource = ItemDataSource()
 
         // tricky, because load after key is empty, so another load before and load after required
@@ -86,7 +88,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_nullKey() = runBlocking {
+    fun loadInitial_nullKey() = runTest {
         val dataSource = ItemDataSource()
 
         val result = loadInitial(dataSource, null, 10, true)
@@ -97,7 +99,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_keyPastEndOfList() = runBlocking {
+    fun loadInitial_keyPastEndOfList() = runTest {
         val dataSource = ItemDataSource()
 
         // if key is past entire data set, should return last items in data set
@@ -115,7 +117,7 @@ class ItemKeyedDataSourceTest {
     // ----- UNCOUNTED -----
 
     @Test
-    fun loadInitial_disablePlaceholders() = runBlocking {
+    fun loadInitial_disablePlaceholders() = runTest {
         val dataSource = ItemDataSource()
 
         // dispatchLoadInitial(key, count) == null padding, loadAfter(key, count), null padding
@@ -128,7 +130,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_uncounted() = runBlocking {
+    fun loadInitial_uncounted() = runTest {
         val dataSource = ItemDataSource(counted = false)
 
         // dispatchLoadInitial(key, count) == null padding, loadAfter(key, count), null padding
@@ -141,7 +143,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_nullKey_uncounted() = runBlocking {
+    fun loadInitial_nullKey_uncounted() = runTest {
         val dataSource = ItemDataSource(counted = false)
 
         // dispatchLoadInitial(null, count) == dispatchLoadInitial(count)
@@ -155,7 +157,7 @@ class ItemKeyedDataSourceTest {
     // ----- EMPTY -----
 
     @Test
-    fun loadInitial_empty() = runBlocking {
+    fun loadInitial_empty() = runTest {
         val dataSource = ItemDataSource(items = ArrayList())
 
         // dispatchLoadInitial(key, count) == null padding, loadAfter(key, count), null padding
@@ -168,7 +170,7 @@ class ItemKeyedDataSourceTest {
     }
 
     @Test
-    fun loadInitial_nullKey_empty() = runBlocking {
+    fun loadInitial_nullKey_empty() = runTest {
         val dataSource = ItemDataSource(items = ArrayList())
         val result = loadInitial(dataSource, null, 10, true)
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -57,7 +57,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -3571,7 +3570,7 @@ class PageFetcherSnapshotTest {
 
     @OptIn(DelicateCoroutinesApi::class)
     @Test
-    fun pageEventSentAfterChannelClosed() {
+    fun pageEventSentAfterChannelClosed() = runTest {
         val pager = PageFetcherSnapshot(
             initialKey = 50,
             pagingSource = TestPagingSource(loadDelay = 100),
@@ -3584,7 +3583,7 @@ class PageFetcherSnapshotTest {
         }
         pager.close()
 
-        runBlocking { deferred.await() }
+        deferred.await()
     }
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
@@ -22,7 +22,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.test.fail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -112,7 +111,8 @@ class PositionalDataSourceTest {
         )
     }
 
-    private fun validatePositionOffset(enablePlaceholders: Boolean) = runBlocking {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun validatePositionOffset(enablePlaceholders: Boolean) = testScope.runTest {
         val config = PagedList.Config.Builder()
             .setPageSize(10)
             .setEnablePlaceholders(enablePlaceholders)
@@ -159,11 +159,12 @@ class PositionalDataSourceTest {
         validatePositionOffset(false)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun performLoadInitial(
         enablePlaceholders: Boolean = true,
         invalidateDataSource: Boolean = false,
         callbackInvoker: (callback: PositionalDataSource.LoadInitialCallback<String>) -> Unit
-    ) {
+    ) = testScope.runTest {
         val dataSource = object : PositionalDataSource<String>() {
             override fun loadInitial(
                 params: LoadInitialParams,
@@ -193,7 +194,7 @@ class PositionalDataSourceTest {
             config.enablePlaceholders
         )
 
-        runBlocking { dataSource.loadInitial(params) }
+        dataSource.loadInitial(params)
     }
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/SingleRunnerTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/SingleRunnerTest.kt
@@ -48,7 +48,7 @@ class SingleRunnerTest {
     private val testScope = TestScope()
 
     @Test
-    fun cancelsPreviousRun() = runBlocking {
+    fun cancelsPreviousRun() = testScope.runTest {
         val runner = SingleRunner()
         val job = launch(Dispatchers.Unconfined) {
             runner.runInIsolation {
@@ -65,7 +65,7 @@ class SingleRunnerTest {
     }
 
     @Test
-    fun previousRunCanCancelItself() = runBlocking {
+    fun previousRunCanCancelItself() = testScope.runTest {
         val runner = SingleRunner()
         val job = launch(Dispatchers.Unconfined) {
             runner.runInIsolation {


### PR DESCRIPTION
The below test is the only remaining instance of `runBlocking` in `paging-common`. The rest of the test uses a lot of Java specific stuff, and in Multiplatform Paging, I hadn't attempted to multiplatformize it yet.

https://github.com/androidx/androidx/blob/88877d72f62df51fc9dd040da322c9046aa81f67/paging/paging-common/src/test/kotlin/androidx/paging/SingleRunnerTest.kt#L151-L190

Test: ./gradlew test connectedCheck
Bug: 270612487