### PR TITLE
Fix Javadoc formatting for ConstraintSet.java

### DIFF
--- a/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
+++ b/constraintlayout/constraintlayout/src/main/java/androidx/constraintlayout/widget/ConstraintSet.java
@@ -110,8 +110,8 @@ import java.util.Set;
  *              }
  *          }
  *      }
- *  <pre/>
- * <p/>
+ *  </pre>
+ * </p>
  */
 public class ConstraintSet {
     private static final String TAG = "ConstraintSet";


### PR DESCRIPTION
Fixes badly formed HTML that is causing rendering issues in the generated docs for ConstraintSet.

## Proposed Changes

  - The closing tags for the `<p>` and `<pre>` blocks are incorrectly formed.
  - Change these to be closing tags 

## Testing

Test: N/A docs changes
