### PR TITLE
Replace usage of `java.lang.Class` with `kotlin.reflect.KClass`

### DIFF
--- a/paging/paging-common/src/main/kotlin/androidx/paging/CombinedLoadStates.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/CombinedLoadStates.kt
@@ -70,7 +70,7 @@ public class CombinedLoadStates(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other == null || this::class != other::class) return false
 
         other as CombinedLoadStates
 

--- a/paging/paging-common/src/main/kotlin/androidx/paging/TransformablePage.kt
+++ b/paging/paging-common/src/main/kotlin/androidx/paging/TransformablePage.kt
@@ -91,7 +91,7 @@ internal data class TransformablePage<T : Any>(
     // for IntArray.
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other == null || this::class != other::class) return false
 
         other as TransformablePage<*>
 


### PR DESCRIPTION
When generating an `equals` method from `commonMain` code, Studio suggests the usage of `if (other == null || this::class != other::class) return false` instead of `if (javaClass != other?.javaClass) return false`. I'm just calling this out because of the following line:

https://github.com/androidx/androidx/blob/88877d72f62df51fc9dd040da322c9046aa81f67/paging/paging-common/src/main/kotlin/androidx/paging/TransformablePage.kt#L90-L93

Test: ./gradlew test connectedCheck
Bug: 270612487