### PR TITLE
Remove `RunWith(JUnit4::class)`

### DIFF
--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachedPageEventFlowLeakTest.kt
@@ -29,14 +29,11 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 /**
  * reproduces b/203594733
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 public class CachedPageEventFlowLeakTest {
     private val gcHelper = GarbageCollectionTestHelper()
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/CachingTest.kt
@@ -42,11 +42,8 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class CachingTest {
     private val tracker = ActiveFlowTrackerImpl()
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/DataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/DataSourceTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import androidx.kruth.assertThat
 import kotlin.test.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class DataSourceTest {
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/FlattenedPageEventStorageTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/FlattenedPageEventStorageTest.kt
@@ -26,10 +26,7 @@ import androidx.paging.LoadType.REFRESH
 import androidx.paging.PageEvent.Drop
 import androidx.paging.PageEvent.StaticList
 import kotlin.test.Test
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class FlattenedPageEventStorageTest {
     private val list = FlattenedPageEventStorage<String>()
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/HeaderFooterTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/HeaderFooterTest.kt
@@ -25,8 +25,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 /**
  * Prepend and append are both Done, so that headers will appear
@@ -37,7 +35,6 @@ private val fullLoadStates = loadStates(
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class HeaderFooterTest {
 
     private fun <T : Any> PageEvent<T>.toPagingData() = PagingData(

--- a/paging/paging-common/src/test/kotlin/androidx/paging/HintHandlerTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/HintHandlerTest.kt
@@ -31,10 +31,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 @OptIn(ExperimentalCoroutinesApi::class)
 class HintHandlerTest {
     private val hintHandler = HintHandler()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/ItemKeyedDataSourceTest.kt
@@ -26,8 +26,6 @@ import kotlin.test.fail
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.mockito.ArgumentCaptor
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
@@ -36,7 +34,6 @@ import org.mockito.kotlin.mock
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @Suppress("DEPRECATION")
-@RunWith(JUnit4::class)
 class ItemKeyedDataSourceTest {
 
     // ----- STANDARD -----

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPageFetcherTest.kt
@@ -37,11 +37,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class LegacyPageFetcherTest {
     private val testDispatcher = StandardTestDispatcher()
     private val data = List(9) { "$it" }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/LegacyPagingSourceTest.kt
@@ -34,11 +34,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class LegacyPagingSourceTest {
     private val fakePagingState = PagingState(
         pages = listOf(

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageEventTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageEventTest.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.junit.runners.Parameterized
 
 internal fun <T : Any> adjacentInsertEvent(
@@ -60,7 +59,6 @@ internal fun <T : Any> adjacentInsertEvent(
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class PageEventTest {
     @Test
     fun placeholdersException() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotStateTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotStateTest.kt
@@ -29,11 +29,8 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class PageFetcherSnapshotStateTest {
     val testScope = TestScope()
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherSnapshotTest.kt
@@ -66,11 +66,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalPagingApi::class)
-@RunWith(JUnit4::class)
 class PageFetcherSnapshotTest {
     private val testScope = TestScope(UnconfinedTestDispatcher())
     private val retryBus = ConflatedEventBus<Unit>()

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageFetcherTest.kt
@@ -52,11 +52,8 @@ import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalPagingApi::class)
-@RunWith(JUnit4::class)
 class PageFetcherTest {
     private val testScope = TestScope(UnconfinedTestDispatcher())
     private val pagingSourceFactory = suspend { TestPagingSource() }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PageKeyedDataSourceTest.kt
@@ -28,14 +28,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class PageKeyedDataSourceTest {
     internal data class Item(val name: String)
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagePresenterTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagePresenterTest.kt
@@ -26,8 +26,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.fail
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @Suppress("TestFunctionName")
 internal fun <T : Any> PagePresenter(
@@ -82,7 +80,6 @@ internal fun <T : Any> PagePresenter<T>.dropPages(
 internal fun <T : Any> PagePresenter<T>.asList() = List(size) { get(it) }
 
 @Suppress("SameParameterValue")
-@RunWith(JUnit4::class)
 class PagePresenterTest {
     private fun verifyAppend(
         initialItems: Int,

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigBuilderTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigBuilderTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class PagedListConfigBuilderTest {
     @Test
     fun defaults() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListConfigTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class PagedListConfigTest {
     @Test
     fun defaults() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedListTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedListTest.kt
@@ -33,11 +33,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class PagedListTest {
     companion object {
         private val ITEMS = List(100) { "$it" }

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagedStorageTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagedStorageTest.kt
@@ -23,13 +23,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
-@RunWith(JUnit4::class)
 class PagedStorageTest {
     private fun pageOf(vararg strings: String): Page<Any, String> = Page(
         data = strings.asList(),

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingConfigTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingConfigTest.kt
@@ -20,10 +20,7 @@ import androidx.paging.PagingConfig.Companion.MAX_SIZE_UNBOUNDED
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class PagingConfigTest {
     @Test
     fun defaults() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingSourceTest.kt
@@ -27,11 +27,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class PagingSourceTest {
 
     // ----- STANDARD -----

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PagingStateTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PagingStateTest.kt
@@ -21,10 +21,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class PagingStateTest {
     @Test
     fun closestItemToPosition_withoutPlaceholders() {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/PositionalDataSourceTest.kt
@@ -25,14 +25,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
 
 @Suppress("DEPRECATION")
-@RunWith(JUnit4::class)
 class PositionalDataSourceTest {
     private fun computeInitialLoadPos(
         requestedStartPosition: Int,

--- a/paging/paging-common/src/test/kotlin/androidx/paging/RemoteMediatorAccessorTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/RemoteMediatorAccessorTest.kt
@@ -39,11 +39,8 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalPagingApi::class)
-@RunWith(JUnit4::class)
 class RemoteMediatorAccessorTest {
     private val testScope = TestScope(UnconfinedTestDispatcher())
     private var mockStateId = 0

--- a/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsTest.kt
@@ -30,8 +30,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 private fun <T : Any> List<PageEvent<T>>.getItems() = mapNotNull { event ->
     when (event) {
@@ -55,7 +53,6 @@ private fun <T : Any> assertInsertData(
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class SeparatorsTest {
     @Test
     fun refreshFull() = runTest {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsWithRemoteMediatorTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/SeparatorsWithRemoteMediatorTest.kt
@@ -27,11 +27,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class SeparatorsWithRemoteMediatorTest {
     @Test
     fun prependAfterPrependComplete() = runTest {

--- a/paging/paging-common/src/test/kotlin/androidx/paging/SingleRunnerTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/SingleRunnerTest.kt
@@ -39,11 +39,8 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(JUnit4::class)
 class SingleRunnerTest {
     private val testScope = TestScope()
 

--- a/paging/paging-common/src/test/kotlin/androidx/paging/WrappedItemKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/WrappedItemKeyedDataSourceTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class WrappedItemKeyedDataSourceTest {
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/WrappedPageKeyedDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/WrappedPageKeyedDataSourceTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class WrappedPageKeyedDataSourceTest {
 
     @Test

--- a/paging/paging-common/src/test/kotlin/androidx/paging/WrappedPositionalDataSourceTest.kt
+++ b/paging/paging-common/src/test/kotlin/androidx/paging/WrappedPositionalDataSourceTest.kt
@@ -18,10 +18,7 @@ package androidx.paging
 
 import kotlin.test.Test
 import kotlin.test.assertTrue
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class WrappedPositionalDataSourceTest {
 
     @Test


### PR DESCRIPTION
Omitting `RunWith(JUnit4::class)` will cause JUnit to use its default runner, which is just what `JUnit4` type aliases. See https://github.com/junit-team/junit4/wiki/Test-runners#runwith-annotation.

Test: ./gradlew test connectedCheck
Bug: 270612487