### PR TITLE
Fixes for GitHub playground

### DIFF
--- a/activity/integration-tests/baselineprofile/build.gradle
+++ b/activity/integration-tests/baselineprofile/build.gradle
@@ -40,8 +40,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":benchmark:benchmark-junit4"))
-    implementation(project(":benchmark:benchmark-macro-junit4"))
+    implementation(projectOrArtifact(":benchmark:benchmark-junit4"))
+    implementation(projectOrArtifact(":benchmark:benchmark-macro-junit4"))
     implementation(libs.testRules)
     implementation(libs.testExtJunit)
     implementation(libs.testCore)

--- a/collection/collection/build.gradle
+++ b/collection/collection/build.gradle
@@ -48,7 +48,7 @@ androidXMultiplatform {
         commonMain {
             dependencies {
                 api(libs.kotlinStdlib)
-                api(project(":annotation:annotation"))
+                api(projectOrArtifact(":annotation:annotation"))
             }
         }
 

--- a/fragment/fragment-ktx/build.gradle
+++ b/fragment/fragment-ktx/build.gradle
@@ -25,7 +25,7 @@ plugins {
 
 dependencies {
     api(project(":fragment:fragment"))
-    api(project(":activity:activity-ktx")) {
+    api(projectOrArtifact(":activity:activity-ktx")) {
         because "Mirror fragment dependency graph for -ktx artifacts"
     }
     api("androidx.core:core-ktx:1.2.0") {

--- a/fragment/fragment/build.gradle
+++ b/fragment/fragment/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     api("androidx.collection:collection:1.1.0")
     api("androidx.viewpager:viewpager:1.0.0")
     api("androidx.loader:loader:1.0.0")
-    api(project(":activity:activity"))
+    api(projectOrArtifact(":activity:activity"))
     api("androidx.lifecycle:lifecycle-runtime:2.6.1")
     api("androidx.lifecycle:lifecycle-livedata-core:2.6.1")
     api("androidx.lifecycle:lifecycle-viewmodel:2.6.1")

--- a/playground-common/playground.properties
+++ b/playground-common/playground.properties
@@ -25,6 +25,6 @@
 kotlin.code.style=official
 # Disable docs
 androidx.enableDocumentation=false
-androidx.playground.snapshotBuildId=10295852
+androidx.playground.snapshotBuildId=10339410
 androidx.playground.metalavaBuildId=10338742
 androidx.studio.type=playground


### PR DESCRIPTION
- Activity needs to depends on benchmark via projectOrArtifact
- Fragment needs to depend on activity via projectOrArtifact
- Collection needs to depend on annotation via projectOrArtifact
 - Bump snapshot id to pull in correct version of compose compiler
   
Test: GH CI actions
Change-Id: Id880f4b55a962fb2b568b0cd3cec9353082a5091