### PR TITLE
Fix typo in compose-animation-graphics-documentation.md

### DIFF
--- a/compose/animation/animation-graphics/src/commonMain/kotlin/androidx/compose/animation/graphics/compose-animation-graphics-documentation.md
+++ b/compose/animation/animation-graphics/src/commonMain/kotlin/androidx/compose/animation/graphics/compose-animation-graphics-documentation.md
@@ -2,7 +2,7 @@
 
 Compose Animation Graphics
 
-# Package androidx.compose.anamition.graphics
+# Package androidx.compose.animation.graphics
 
 In this page, you'll find documentation for types, properties, and functions available in the
 `androidx.compose.animation.graphics` package.


### PR DESCRIPTION
Currently due to the typo, generated documentation doesn't contain package description.
See: https://developer.android.com/reference/kotlin/androidx/compose/animation/graphics/res/package-summary

Test: See new generated [documentation page](https://developer.android.com/reference/kotlin/androidx/compose/animation/graphics/res/package-summary)
Fixes: -
