### PR TITLE
Use correct type for Energy kilojoules creation

### DIFF
--- a/health/connect/connect-client/src/main/java/androidx/health/connect/client/units/Energy.kt
+++ b/health/connect/connect-client/src/main/java/androidx/health/connect/client/units/Energy.kt
@@ -90,7 +90,7 @@ private constructor(
         @JvmStatic fun joules(value: Double): Energy = Energy(value, Type.JOULES)
 
         /** Creates [Energy] with the specified value in kilojoules. */
-        @JvmStatic fun kilojoules(value: Double): Energy = Energy(value, Type.KILOCALORIES)
+        @JvmStatic fun kilojoules(value: Double): Energy = Energy(value, Type.KILOJOULES)
     }
 
     private enum class Type {

--- a/health/connect/connect-client/src/test/java/androidx/health/connect/client/units/EnergyTest.kt
+++ b/health/connect/connect-client/src/test/java/androidx/health/connect/client/units/EnergyTest.kt
@@ -31,12 +31,16 @@ class EnergyTest {
     fun equals_sameValues_areEqual() {
         expect.that(Energy.kilocalories(235.0)).isEqualTo(Energy.kilocalories(235.0))
         expect.that(Energy.kilocalories(235.0)).isEqualTo(Energy.calories(235_000.0))
+        expect.that(Energy.kilocalories(235.0)).isEqualTo(Energy.joules(56.1663479835))
+        expect.that(Energy.kilocalories(235.0)).isEqualTo(Energy.kilojoules(56166.3479835))
     }
 
     @Test
     fun equals_differentValues_areNotEqual() {
         expect.that(Energy.kilocalories(235.001)).isNotEqualTo(Energy.kilocalories(235.0))
         expect.that(Energy.kilocalories(235.001)).isNotEqualTo(Energy.calories(235_000.0))
+        expect.that(Energy.kilocalories(235.001)).isNotEqualTo(Energy.joules(56.1663479835))
+        expect.that(Energy.kilocalories(235.001)).isNotEqualTo(Energy.kilojoules(56166.3479835))
     }
 
     @Test
@@ -52,4 +56,5 @@ class EnergyTest {
             .that(Energy.kilocalories(235.001).hashCode())
             .isNotEqualTo(Energy.calories(235_000.0).hashCode())
     }
+    
 }


### PR DESCRIPTION
## Proposed Changes

  - Use `KILOJOULES` type when creating Energy object with kilojoules

## Testing

Test: Unit

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
