### PR TITLE
Adds retryable compose test rule

### DIFF
--- a/compose/ui/ui-test-junit4/src/androidMain/kotlin/androidx/compose/ui/test/junit4/AndroidComposeTestRule.android.kt
+++ b/compose/ui/ui-test-junit4/src/androidMain/kotlin/androidx/compose/ui/test/junit4/AndroidComposeTestRule.android.kt
@@ -340,6 +340,68 @@ class AndroidComposeTestRule<R : TestRule, A : ComponentActivity> private constr
     override fun setContent(composable: @Composable () -> Unit) = composeTest.setContent(composable)
 }
 
+/**
+ * An implementation of [ComposeTestRule] that will correctly reset itself in-between test retries.
+ *
+ * NOTE: In order to function properly this rule should be wrapped by your retry rule.
+ *
+ * This is necessary because there is currently no ability to reset the
+ * [AndroidComposeUiTestEnvironment] in the standard [AndroidComposeTestRule].
+ *
+ * @param ruleProvider Function to create the underlying ComposeTestRule rule, defaults to [createEmptyComposeRule]
+ */
+class RetryableComposeTestRule constructor(
+    private val ruleProvider: () -> ComposeTestRule = ::createEmptyComposeRule
+) :
+    ComposeTestRule {
+    private var rule: ComposeTestRule = ruleProvider.invoke()
+
+    override val density: Density
+        get() = rule.density
+    override val mainClock: MainTestClock
+        get() = rule.mainClock
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                try {
+                    rule.apply(base, description).evaluate()
+                } finally {
+                    rule = ruleProvider.invoke()
+                }
+            }
+        }
+    }
+
+    override suspend fun awaitIdle() = rule.awaitIdle()
+
+    override fun onAllNodes(
+        matcher: SemanticsMatcher,
+        useUnmergedTree: Boolean
+    ): SemanticsNodeInteractionCollection = rule.onAllNodes(matcher, useUnmergedTree)
+
+    override fun onNode(matcher: SemanticsMatcher, useUnmergedTree: Boolean): SemanticsNodeInteraction =
+        rule.onNode(matcher, useUnmergedTree)
+
+    override fun registerIdlingResource(idlingResource: IdlingResource) =
+        rule.registerIdlingResource(idlingResource)
+
+    override fun <T> runOnIdle(action: () -> T): T =
+        rule.runOnIdle(action)
+
+    override fun <T> runOnUiThread(action: () -> T): T =
+        rule.runOnUiThread(action)
+
+    override fun unregisterIdlingResource(idlingResource: IdlingResource) =
+        rule.unregisterIdlingResource(idlingResource)
+
+    override fun waitForIdle() = rule.waitForIdle()
+
+    override fun waitUntil(timeoutMillis: Long, condition: () -> Boolean) =
+        rule.waitUntil(timeoutMillis, condition)
+
+}
+    
 private fun <A : ComponentActivity> getActivityFromTestRule(rule: ActivityScenarioRule<A>): A {
     var activity: A? = null
     rule.scenario.onActivity { activity = it }


### PR DESCRIPTION
## Proposed Changes

- This solves the "Only a single call to `runTest` can be performed during one test." error when you are trying to retry a test that has uses a ComposeRule.
- Achieved by creating a RetryableComposeRule class.
- This is needed because the environment that gets created from a ComposeRule is not supposed to be reused in any other test runs per discussion here: https://github.com/Kotlin/kotlinx.coroutines/issues/3718#issuecomment-1512832250 so this new rule creates a new environment after each test has ran.
- This should help keep people from following the incorrect workaround such as here: https://issuetracker.google.com/issues/235383900 where they re-use the ComposeRule for subsequent retries by ordering their rules specifically to do so.
- This rule should be ordered after any retry rule.

## Testing

Test: I setup an intentionally failing compose jUnit test with a retry rule outside of my RetryableComposeRule and observed that upon the retry there was NO error of "Only a single call to `runTest` can be performed during one test." 

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/235383900 and https://github.com/Kotlin/kotlinx.coroutines/issues/3718#issuecomment-1512832250
