### PR TITLE
Import JVM annotations

### DIFF
--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/Pager.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/Pager.kt
@@ -16,6 +16,7 @@
 
 package androidx.paging
 
+import kotlin.jvm.JvmOverloads
 import kotlinx.coroutines.flow.Flow
 
 /**

--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingConfig.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingConfig.kt
@@ -19,6 +19,8 @@ package androidx.paging
 import androidx.annotation.IntRange
 import androidx.paging.PagingConfig.Companion.MAX_SIZE_UNBOUNDED
 import androidx.paging.PagingSource.LoadResult.Page.Companion.COUNT_UNDEFINED
+import kotlin.jvm.JvmField
+import kotlin.jvm.JvmOverloads
 
 /**
  * An object used to configure loading behavior within a [Pager], as it loads content from a

--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingData.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingData.kt
@@ -16,6 +16,8 @@
 
 package androidx.paging
 
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 

--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingDataDiffer.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingDataDiffer.kt
@@ -30,6 +30,7 @@ import androidx.paging.internal.BUGANIZER_URL
 import androidx.paging.internal.appendMediatorStatesIfNotNull
 import co.touchlab.stately.collections.ConcurrentMutableList
 import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.Volatile
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.flow.Flow

--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingDataTransforms.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/PagingDataTransforms.kt
@@ -21,6 +21,10 @@ package androidx.paging
 
 import androidx.annotation.CheckResult
 import androidx.paging.TerminalSeparatorType.FULLY_COMPLETE
+import kotlin.jvm.JvmMultifileClass
+import kotlin.jvm.JvmName
+import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmSynthetic
 import kotlinx.coroutines.flow.map
 
 internal inline fun <T : Any, R : Any> PagingData<T>.transform(

--- a/paging/paging-common/src/commonMain/kotlin/androidx/paging/RemoteMediator.kt
+++ b/paging/paging-common/src/commonMain/kotlin/androidx/paging/RemoteMediator.kt
@@ -22,6 +22,7 @@ import androidx.paging.LoadType.REFRESH
 import androidx.paging.PagingSource.LoadResult
 import androidx.paging.RemoteMediator.InitializeAction.LAUNCH_INITIAL_REFRESH
 import androidx.paging.RemoteMediator.InitializeAction.SKIP_INITIAL_REFRESH
+import kotlin.jvm.JvmName
 
 /**
  * Defines a set of callbacks used to incrementally load data from a remote source into a local


### PR DESCRIPTION
When running `./gradlew paging:paging-common:allTests`, there are some build errors. Some of these exceptions are just because the JVM annotations need to be explicitly imported when used in `commonMain`. This PR fixes those exceptions only.

Test: ./gradlew test connectedCheck
Bug: 270612487