### PR TITLE
Add GH CODEOWNERS for PR triage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Global owners:
+# Unless a later match takes precedence, global owners will be # requested for
+# review when someone opens a pull request.
+*          @dlam @yigit
+
+# Owners for each library group:
+/activity*          @sanura-njaka @jbw0033 @ianhanniballake
+/appcompat/*        @alanv
+/biometric/*        @dlam
+/collection/*       @dlam
+/compose/compiler/* @jimgoog @lelandrichardson
+/compose/runtime/*  @jimgoog @lelandrichardson
+/core/*             @alanv
+/datastore/*        @rohitsat13 @yigit
+/fragment/*         @sanura-njaka @jbw0033 @ianhanniballake
+/lifecycle/*        @jbw0033 @ianhanniballake
+/navigation/*       @jbw0033 @ianhanniballake @claraf3
+/paging/*           @claraf3 @ianhanniballake
+/room/*             @droid-wan-kenobi @danysantiago @svasilinets
+/work/*             @svasilinets @tikurahul
+
+


### PR DESCRIPTION
This allows GH to automatically assign reviewers to PRs, which should reduce the amount of incoming e-mails by allowing folks on triage to filter out all PR notifications except those they are explicitly tagged or assigned to.

CODEOWNERS requires write permissions on the repo, so we had to relax this permission - but it shouldn't affect anything as we have branch protections on androidx-main in GitHub.

Test: GH lint
Change-Id: I67f6a502943641afbbf04220e25dfdae7f9fa1ff