### PR TITLE
Simplify Android logger

### DIFF
--- a/paging/paging-compose/src/main/java/androidx/paging/compose/LazyPagingItems.kt
+++ b/paging/paging-compose/src/main/java/androidx/paging/compose/LazyPagingItems.kt
@@ -226,11 +226,9 @@ public class LazyPagingItems<T : Any> internal constructor(
                 }
 
                 override fun log(level: Int, message: String, tr: Throwable?) {
-                    when {
-                        tr != null && level == Log.DEBUG -> Log.d(LOG_TAG, message, tr)
-                        tr != null && level == Log.VERBOSE -> Log.v(LOG_TAG, message, tr)
-                        level == Log.DEBUG -> Log.d(LOG_TAG, message)
-                        level == Log.VERBOSE -> Log.v(LOG_TAG, message)
+                    when (level) {
+                        Log.DEBUG -> Log.d(LOG_TAG, message, tr)
+                        Log.VERBOSE -> Log.v(LOG_TAG, message, tr)
                         else -> {
                             throw IllegalArgumentException(
                                 "debug level $level is requested but Paging only supports " +


### PR DESCRIPTION
`paging-compose` counterpart to cd7efa354b35c7e2baa2a815d56e1ddda9c288c0.

Test: ./gradlew paging:paging-compose:test