### PR TITLE
Make jbolinger@ owner for GitHub PRs into androidx/biometric

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 # Owners for each library group:
 /activity*          @sanura-njaka @jbw0033 @ianhanniballake
 /appcompat/*        @alanv
-/biometric/*        @dlam
+/biometric/*        @jbolinger
 /collection/*       @dlam
 /compose/compiler/* @jimgoog @lelandrichardson
 /compose/runtime/*  @jimgoog @lelandrichardson


### PR DESCRIPTION
This allows automatically assigning the correct owner for biometric to PRs on GitHub.

Test: GH CODEOWNERS Lint
Change-Id: Ifaa78b7300a5b523d229e96a05e8ece4e16c2441