### PR TITLE
Remove duplicated text from compiler-metrics.md

### DIFF
--- a/compose/compiler/design/compiler-metrics.md
+++ b/compose/compiler/design/compiler-metrics.md
@@ -12,13 +12,6 @@ level.
 
 In the AndroidX repository `./gradlew` accepts options to enable reports.
 
-To enable compiler metrics for a build target include `-Pandroidx.enableComposeCompilerMetrics=true`
-prior to the build target such as:
-
-```
-.gradlew -Pandroidx.enableComposeCompilerMetrics=true :compose:runtime:runtime:compileKotlin
-```
-
 To enable compiler reports for a build target include `-Pandroidx.enableComposeCompilerReports=true`
 prior to the build target such as:
 


### PR DESCRIPTION
## Proposed Changes

  - Removes duplicated block of text from the markdown document

## Testing

Bug: N/A
Test: local
