### PR TITLE
Make uiautomator an API dependency of benchmark-macro-junit4

### DIFF
--- a/benchmark/benchmark-macro-junit4/build.gradle
+++ b/benchmark/benchmark-macro-junit4/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation(project(":benchmark:benchmark-common"))
     implementation("androidx.test:rules:1.5.0")
     implementation("androidx.test:runner:1.5.0")
-    implementation("androidx.test.uiautomator:uiautomator:2.2.0")
+    api("androidx.test.uiautomator:uiautomator:2.2.0")
 
     androidTestImplementation(project(":internal-testutils-ktx"))
     androidTestImplementation(libs.testExtJunit)


### PR DESCRIPTION
MacrobenchmarkScope exposes uiautomator to downstream dependencies in https://developer.android.com/reference/androidx/benchmark/macro/MacrobenchmarkScope#getDevice()

