### PR TITLE
Fix typo in compose-component-api-guidelines.md

### DIFF
--- a/compose/docs/compose-component-api-guidelines.md
+++ b/compose/docs/compose-component-api-guidelines.md
@@ -1123,7 +1123,7 @@ object ButtonDefaults {
 fun Button(
     onClick: () -> Unit,
     enabled: Boolean = true,
-    buttonColors: ButtonColors = ButtonDefaults.buttonColors(),
+    colors: ButtonColors = ButtonDefaults.buttonColors(),
     content: @Composable RowScope.() -> Unit
 ) {
     val resolvedBackgroundColor = colors.backgroundColor(enabled)


### PR DESCRIPTION
## Proposed Changes
The parameter used to resolve the background colour in the implementation is different than the function parameter.

## Testing

Test: Refer [composable implementation](https://github.com/androidx/androidx/blob/c0a19a1bdbaea5dd59994dd3863c02d54eb9974e/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Button.kt#L110)