### PR TITLE
Turn off core's playground build

### DIFF
--- a/.github/ci-control/ci-config.json
+++ b/.github/ci-control/ci-config.json
@@ -14,6 +14,7 @@
     "main" : {
         "exclude" : [
           "compose-runtime",
+          "core",
           "room"
         ],
         "default": true


### PR DESCRIPTION
Currently hitting aidl failures due to dependency on a publicly unavailable version of build tools.

Test: GH workflows
Change-Id: Ie0473404984cf70236d6eb9c1d68b3c16c8c7515