### PR TITLE
[Compose] Log message correction for SubcomposeLayout

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/SubcomposeLayout.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/SubcomposeLayout.kt
@@ -679,7 +679,7 @@ internal class LayoutNodeSubcompositionsState(
         "layouts is not supported. This includes components that are built on top of " +
         "SubcomposeLayout, such as lazy lists, BoxWithConstraints, TabRow, etc. To mitigate " +
         "this:\n" +
-        "- if intrinsic measurements are used to achieve 'match parent' sizing,, consider " +
+        "- if intrinsic measurements are used to achieve 'match parent' sizing, consider " +
         "replacing the parent of the component with a custom layout which controls the order in " +
         "which children are measured, making intrinsic measurement not needed\n" +
         "- adding a size modifier to the component, in order to fast return the queried " +


### PR DESCRIPTION
_This is a message-string-only change_

This PR tries to highlight the difference between :

Message string for property in `NoIntrinsicsMessage` ( SubcomposeLayout.kt ) has unnecessary double comma.
So reducing comma has been applied.

Test: N/A just message string property change