### PR TITLE
[Compose-Android] Modify Resources for android internal implementation

### DIFF
--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/res/Resources.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/res/Resources.android.kt
@@ -29,6 +29,6 @@ import androidx.compose.ui.platform.LocalContext
 @Composable
 @ReadOnlyComposable
 internal fun resources(): Resources {
-    LocalConfiguration.current
-    return LocalContext.current.resources
+    val configuration = LocalConfiguration.current
+    return configuration.resources
 }


### PR DESCRIPTION
_This is a internal implementation style change_

This PR tries to highlight the difference between :

`resources()` in Resources.android.kt has unusable code block for `LocalConfiguration.current`.
It seems not intuitive implementation which uses just doubling call for `LocalConfiguration.current`.
So catch the value and reuse it for intuitiveness.

Test: N/A expected function result is not different with before one.