### PR TITLE
Do not check @StabilityInferred if class is not public

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
@@ -20,6 +20,7 @@ import androidx.compose.compiler.plugins.kotlin.ComposeFqNames
 import androidx.compose.compiler.plugins.kotlin.lower.annotationClass
 import androidx.compose.compiler.plugins.kotlin.lower.isSyntheticComposableFunction
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
@@ -306,7 +307,8 @@ private fun stabilityOf(
 private fun canInferStability(declaration: IrClass): Boolean {
     val fqName = declaration.fqNameWhenAvailable?.toString() ?: ""
     return KnownStableConstructs.stableTypes.contains(fqName) ||
-        declaration.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB
+        (declaration.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB &&
+            declaration.visibility == DescriptorVisibilities.PUBLIC)
 }
 
 private fun stabilityOf(


### PR DESCRIPTION
## Proposed Changes

I found out that Compose Compiler add @StabilityInferred only for public classes in [ClassStabilityTransformer.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt;drc=4d53400eca9f3ac90c3a3f6cffcbc5bf492ec536;l=89), but that is not checked in stabilityOf and can lead to loosing stability of internal class.

For example:
SimpleClass.kt
```kotlin
internal SimpleClass
```

SimpleComposable.kt
```kotlin
@Composable
internal fun SimpleComposable(clazz: SimpleClass)
``` 

For clean build all things are good, because `canInferStability` returns `false` and stability was checked for class members.
But if we add some change in SimpleComposable.kt. For example:
```kotlin
@Suppress("So experimental")
@Composable
internal fun SimpleComposable(clazz: SimpleClass)
```

We should recompile only SimpleComposable. So SimpleClass will have `IR_EXTERNAL_DECLARATION_STUB` origin and `canInferStability` will returns `true`, but because compiler does not add  @StabilityInferred for internal class SimpleClass will be unstable for second incremental compilation even it does not have any members.


For fix i added checking of class visibility, but may be we should allow to add @StabilityInferred for internal classes?

## Testing

Test: Use simple example above. I do not know how write test for incremental compilation in Compose Compiler :)


