### PR TITLE
Fix lambda and function reference memorization and internal classes loosing stability on incremental compilation. Fix $stable field generation for classes with combined stability

### DIFF
--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/analysis/Stability.kt
@@ -20,6 +20,7 @@ import androidx.compose.compiler.plugins.kotlin.ComposeFqNames
 import androidx.compose.compiler.plugins.kotlin.lower.annotationClass
 import androidx.compose.compiler.plugins.kotlin.lower.isSyntheticComposableFunction
 import org.jetbrains.kotlin.backend.jvm.ir.isInlineClassType
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.declarations.IrAnnotationContainer
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrDeclarationOrigin
@@ -180,7 +181,7 @@ fun Stability.normalize(): Stability {
             }
 
             is Stability.Parameter -> {
-                if (parameters.contains(stability.parameter.symbol)) {
+                if (stability.parameter.symbol !in parameters) {
                     parameters.add(stability.parameter.symbol)
                     parts.add(stability)
                 }
@@ -306,7 +307,8 @@ private fun stabilityOf(
 private fun canInferStability(declaration: IrClass): Boolean {
     val fqName = declaration.fqNameWhenAvailable?.toString() ?: ""
     return KnownStableConstructs.stableTypes.contains(fqName) ||
-        declaration.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB
+        (declaration.origin == IrDeclarationOrigin.IR_EXTERNAL_DECLARATION_STUB &&
+            declaration.visibility == DescriptorVisibilities.PUBLIC)
 }
 
 private fun stabilityOf(

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/AbstractComposeLowering.kt
@@ -343,11 +343,7 @@ abstract class AbstractComposeLowering(
             }
         }
 
-        is Stability.Certain ->
-            if (stable)
-                irConst(StabilityBits.STABLE.bitsForSlot(0))
-            else
-                null
+        is Stability.Certain -> if (stable) irConst(StabilityBits.STABLE.bitsForSlot(0)) else null
 
         is Stability.Parameter -> resolve(parameter)
         is Stability.Runtime -> {

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -21,6 +21,7 @@ import androidx.compose.compiler.plugins.kotlin.ModuleMetrics
 import androidx.compose.compiler.plugins.kotlin.analysis.Stability
 import androidx.compose.compiler.plugins.kotlin.analysis.forEach
 import androidx.compose.compiler.plugins.kotlin.analysis.hasStableMarker
+import androidx.compose.compiler.plugins.kotlin.analysis.knownUnstable
 import androidx.compose.compiler.plugins.kotlin.analysis.normalize
 import androidx.compose.compiler.plugins.kotlin.analysis.stabilityOf
 import org.jetbrains.kotlin.backend.common.ClassLoweringPass
@@ -110,6 +111,9 @@ class ClassStabilityTransformer(
         }
 
         val stability = stabilityOf(declaration.defaultType).normalize()
+
+        // If it is really unstable we do not need to add @StabilityInferred
+        if (stability.knownUnstable()) return cls
 
         // remove type parameters
 

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt
@@ -141,10 +141,11 @@ class ClassStabilityTransformer(
                     }
                 }
             }
-            stableExpr = if (externalParameters)
+            stableExpr = if (externalParameters) {
                 irConst(UNSTABLE)
-            else
+            } else {
                 stability.irStableExpression { irConst(STABLE) } ?: irConst(UNSTABLE)
+            }
         } else {
             stableExpr = stability.irStableExpression() ?: irConst(UNSTABLE)
         }

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -1022,7 +1022,7 @@ class ComposerLambdaMemoization(
         return this
     }
 
-    private fun IrExpression?.isNullOrStable() = this == null || stabilityOf(this).knownStable()
+    private fun IrExpression?.isNullOrStable() = this == null || !stabilityOf(this).knownUnstable()
 }
 
 // This must match the highest value of FunctionXX which is current Function22

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -505,7 +505,7 @@ class ComposerLambdaMemoization(
                         captures
                     )
                 }
-            } else if (dispatchReceiver == null) {
+            } else if (dispatchReceiver == null && extensionReceiver.isNullOrStable()) {
                 return rememberExpression(functionContext, result, emptyList())
             }
         }

--- a/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
+++ b/compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ComposerLambdaMemoization.kt
@@ -19,7 +19,7 @@ package androidx.compose.compiler.plugins.kotlin.lower
 import androidx.compose.compiler.plugins.kotlin.ComposeCallableIds
 import androidx.compose.compiler.plugins.kotlin.ModuleMetrics
 import androidx.compose.compiler.plugins.kotlin.analysis.ComposeWritableSlices
-import androidx.compose.compiler.plugins.kotlin.analysis.knownStable
+import androidx.compose.compiler.plugins.kotlin.analysis.knownUnstable
 import androidx.compose.compiler.plugins.kotlin.analysis.stabilityOf
 import androidx.compose.compiler.plugins.kotlin.irTrace
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
@@ -854,7 +854,7 @@ class ComposerLambdaMemoization(
         // or inlined lambdas.
         if (
             captures.any {
-                it.isVar() || !it.isStable() || it.isInlinedLambda()
+                it.isVar() || it.isUnstable() || it.isInlinedLambda()
             }
         ) {
             metrics.recordLambda(
@@ -946,8 +946,8 @@ class ComposerLambdaMemoization(
     private fun IrValueDeclaration.isVar(): Boolean =
         (this as? IrVariable)?.isVar == true
 
-    private fun IrValueDeclaration.isStable(): Boolean =
-        stabilityOf(type).knownStable()
+    private fun IrValueDeclaration.isUnstable(): Boolean =
+        stabilityOf(type).knownUnstable()
 
     private fun IrValueDeclaration.isInlinedLambda(): Boolean =
         type.isFunctionOrKFunction() &&


### PR DESCRIPTION
## Proposed Changes

I have started to fix bug(https://issuetracker.google.com/issues/298965625) and have founded other incorrect cases

### Lambda memoization for RuntimeStable types
Problem: On incremental compilation lambda was not remember as Stable class was converted to RuntimeStable, because `@StabilityInferred` was added.

Solution: Replaced `!knownStable()` to `knownUnstable` to avoid memoization when type is definitely unstable. This logic is similar to how Compose Compiler adds `skipToGroupEnd` for restartable functions.

### Function reference memoization for RuntimeStable types of dispatch and extension receivers
Solution: Similar to previous one. knownStable() replaced to !knownUnstable()

### Function reference memoization when extension receiver is not Stable
Problem: If function reference does not have dispatch receiver but has extension it will be remember even it is unstable. This is not correct. 

Solution: So i added a check for stability of extension receiver if there is no dispatch

### Unstable class transforms to RuntimeStable on incremental compilation
Problem: Even if class is unstable `@StabilityInferred` is added and on incremental compilation that class stability will be changed to RuntimeStable. And it breaks some things on incremental compilation. 
For example:
1. lambda is memorized (after my fixes previous problems)
2. unused skipToGroupEnd is generated for restartable functions 

Solution: I removed generation of `@StabilityInferred` if class is unstable. 

Why is it necessary to generate `@StabilityInferred` for unstable classes? Why is it not generated for internal classes? (#608)

### Internal classes loose stability on incremental compilation (#608)
Problem: I found out that Compose Compiler add @StabilityInferred only for public classes in [ClassStabilityTransformer.kt](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/compiler/compiler-hosted/src/main/java/androidx/compose/compiler/plugins/kotlin/lower/ClassStabilityTransformer.kt;drc=4d53400eca9f3ac90c3a3f6cffcbc5bf492ec536;l=89), but that is not checked in stabilityOf and can lead to loosing stability of internal class.

For example:

```kotlin
// SimpleClass.kt
internal SimpleClass

// SimpleComposable.kt
@Composable
internal fun SimpleComposable(clazz: SimpleClass)
``` 

For clean build all things are good, because `canInferStability` returns `false` and stability was checked for class members.
But if we add some change in SimpleComposable.kt. For example adding some annotation:
```kotlin
@Suppress("So experimental")
@Composable
internal fun SimpleComposable(clazz: SimpleClass)
```

We should recompile only SimpleComposable. So SimpleClass will have `IR_EXTERNAL_DECLARATION_STUB` origin and `canInferStability` will returns `true`, but because compiler does not add  @StabilityInferred for internal class SimpleClass will be unstable for second incremental compilation even it does not have any members.


Solution: For fix i added checking of class visibility, but may be we should allow to add @StabilityInferred for internal classes?

### $stable is not generated correctly for CombinedStable classes
Problem: There is little problem for check that symbol in parameters. So parameters will never be added to parts
```kotlin
if (parameters.contains(stability.parameter.symbol)) {
     parameters.add(stability.parameter.symbol)
     parts.add(stability)
}
```

Solution: Just replace `parameters.contains(stability.parameter.symbol)` to `stability.parameter.symbol !in parameters`

## Testing
Test:
  1. Make two file with empty class and `@Composable` function 
  2. Add some needed code in function
  3. Compile and check generated IR
  4. Make small changes in file with function
  5. Compile and compare IR with the previous IR

Fixes: 
- https://issuetracker.google.com/issues/298965625
- and improve other cases for incremental compilation like in previous PR for internal classes https://github.com/androidx/androidx/pull/608
