### PR TITLE
Fix typo in the documentation of KeyboardActions

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyboardActions.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/text/KeyboardActions.kt
@@ -94,7 +94,7 @@ class KeyboardActions(
 
     companion object {
         /**
-         * Use this default value if you don't want to specify any action but want to use use the
+         * Use this default value if you don't want to specify any action but want to use the
          * default action implementations.
          */
         @Stable


### PR DESCRIPTION
## Proposed Changes

Fix typo in the documentation for default keyboard actions static value

There is doubled word "use" in the documentation for default keyboard actions instance

## Testing

Test: No need to test
