### PR TITLE
Fix typo in compose-component-api-guidelines.md

### DIFF
--- a/compose/docs/compose-component-api-guidelines.md
+++ b/compose/docs/compose-component-api-guidelines.md
@@ -944,7 +944,7 @@ If in need to make structural changes internally that affect slot composables li
 ```
 @Composable
 fun PreferenceItem(
-    checked: Boolean
+    checked: Boolean,
     content: @Composable () -> Unit
 ) {
     // don't: this logic will dispose and compose again from scratch the content() composable on the `checked` boolean change
@@ -966,10 +966,13 @@ fun PreferenceItem(
 ```
 @Composable
 fun PreferenceItem(
-    checked: Boolean
+    checked: Boolean,
     content: @Composable () -> Unit
 ) {
-    Layout({ Text("Preference item"), content }) {
+    Layout({
+        Text("Preference item")
+        content()
+    }) {
         // custom layout that relayouts the same instance of `content`
         // when `checked` changes
     }


### PR DESCRIPTION
## Proposed Changes

  - add comma in params list to make sample compilable
  - fix samples `Layout` invocation to make it compilable when it's copypasted to IDE
 

## Testing

Test: pasted sample code to IDE to check that code doesn't have compilation errors

