### PR TITLE
Fix typo in CheckResult.kt

### DIFF
--- a/annotation/annotation/src/commonMain/kotlin/androidx/annotation/CheckResult.kt
+++ b/annotation/annotation/src/commonMain/kotlin/androidx/annotation/CheckResult.kt
@@ -24,8 +24,8 @@ package androidx.annotation
  * ```
  * public @CheckResult String trim(String s) { return s.trim(); }
  * ...
- * s.trim(); // this is probably an error
- * s = s.trim(); // ok
+ * trim(s); // this is probably an error
+ * s = trim(s); // ok
  * ```
  */
 @MustBeDocumented


### PR DESCRIPTION
## Proposed Changes

Fix typo in the `@CheckResult` annotation example

In the example a method with a parameter `String s` and annotation was declared, but used default `String.trim()` instead

## Testing

Test: no need to test
