### PR TITLE
Memoize function references with arguments

### DIFF
--- a/compose/compiler/compiler-hosted/integration-tests/src/test/java/androidx/compose/compiler/plugins/kotlin/LambdaMemoizationTransformTests.kt
+++ b/compose/compiler/compiler-hosted/integration-tests/src/test/java/androidx/compose/compiler/plugins/kotlin/LambdaMemoizationTransformTests.kt
@@ -16,9 +16,24 @@
 
 package androidx.compose.compiler.plugins.kotlin
 
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.junit.Test
 
 class LambdaMemoizationTransformTests(useFir: Boolean) : AbstractIrTransformTest(useFir) {
+    override fun CompilerConfiguration.updateConfiguration() {
+        put(ComposeConfiguration.SOURCE_INFORMATION_ENABLED_KEY, true)
+        languageVersionSettings = LanguageVersionSettingsImpl(
+            languageVersion = languageVersionSettings.languageVersion,
+            apiVersion = languageVersionSettings.apiVersion,
+            specificFeatures = mapOf(
+                LanguageFeature.ContextReceivers to LanguageFeature.State.ENABLED
+            )
+        )
+    }
+
     @Test
     fun testCapturedThisFromFieldInitializer() = verifyComposeIrTransform(
         """
@@ -1302,6 +1317,167 @@ class LambdaMemoizationTransformTests(useFir: Boolean) : AbstractIrTransformTest
             fun composed(block: @Composable () -> Unit) { }
 
             fun clickable(onClick: () -> Unit) { }
+            """
+        )
+    }
+
+    @Test
+    fun testNonComposableFunctionReferenceWithNoArgumentsMemoization() {
+        verifyComposeIrTransform(
+            source = """
+                import androidx.compose.runtime.Composable
+                import androidx.compose.runtime.remember
+
+                class Stable { fun qux() {} }
+
+                @Composable
+                fun Something() {
+                    val x = remember { Stable() }
+                    val shouldMemoize = x::qux
+                }
+            """,
+            expectedTransformed = """
+                @StabilityInferred(parameters = 0)
+                class Stable {
+                  fun qux() { }
+                  static val %stable: Int = 0
+                }
+                @Composable
+                fun Something(%composer: Composer?, %changed: Int) {
+                  %composer = %composer.startRestartGroup(<>)
+                  sourceInformation(%composer, "C(Something)<rememb...>,<${if (useFir) "qux" else "x::qux"}>:Test.kt")
+                  if (%changed !== 0 || !%composer.skipping) {
+                    if (isTraceInProgress()) {
+                      traceEventStart(<>, %changed, -1, <>)
+                    }
+                    val x = remember({
+                      Stable()
+                    }, %composer, 0)
+                    val shouldMemoize = <block>{
+                      val tmp0 = x
+                      remember(tmp0, {
+                        tmp0::qux
+                      }, %composer, 0b0110)
+                    }
+                    if (isTraceInProgress()) {
+                      traceEventEnd()
+                    }
+                  } else {
+                    %composer.skipToGroupEnd()
+                  }
+                  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+                    Something(%composer, updateChangedFlags(%changed or 0b0001))
+                  }
+                }
+            """
+        )
+    }
+
+    // Validate fix for b/302680514.
+    @Test
+    fun testNonComposableFunctionReferenceWithArgumentsMemoization() {
+        verifyComposeIrTransform(
+            source = """
+                import androidx.compose.runtime.Composable
+                import androidx.compose.runtime.remember
+
+                class Stable { fun qux(arg1: Any) {} }
+
+                @Composable
+                fun Something() {
+                    val x = remember { Stable() }
+                    val shouldMemoize = x::qux
+                }
+                """,
+                expectedTransformed = """
+                @StabilityInferred(parameters = 0)
+                class Stable {
+                  fun qux(arg1: Any) { }
+                  static val %stable: Int = 0
+                }
+                @Composable
+                fun Something(%composer: Composer?, %changed: Int) {
+                  %composer = %composer.startRestartGroup(<>)
+                  sourceInformation(%composer, "C(Something)<rememb...>,<${if (useFir) "qux" else "x::qux"}>:Test.kt")
+                  if (%changed !== 0 || !%composer.skipping) {
+                    if (isTraceInProgress()) {
+                      traceEventStart(<>, %changed, -1, <>)
+                    }
+                    val x = remember({
+                      Stable()
+                    }, %composer, 0)
+                    val shouldMemoize = <block>{
+                      val tmp0 = x
+                      remember(tmp0, {
+                        tmp0::qux
+                      }, %composer, 0b0110)
+                    }
+                    if (isTraceInProgress()) {
+                      traceEventEnd()
+                    }
+                  } else {
+                    %composer.skipToGroupEnd()
+                  }
+                  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+                    Something(%composer, updateChangedFlags(%changed or 0b0001))
+                  }
+                }
+            """
+        )
+    }
+
+    // Reference to function with context receivers does not currently support memoization.
+    @Test
+    fun testNonComposableFunctionReferenceWithStableContextReceiverNotMemoized() {
+        verifyComposeIrTransform(
+            source = """
+                import androidx.compose.runtime.Composable
+                import androidx.compose.runtime.remember
+
+                class StableReceiver
+                class Stable {
+                    context(StableReceiver)
+                    fun qux() {}
+                }
+
+                @Composable
+                fun Something() {
+                    val x = remember { Stable() }
+                    val shouldNotMemoize = x::qux
+                }
+            """,
+            expectedTransformed = """
+                @StabilityInferred(parameters = 0)
+                class StableReceiver {
+                  static val %stable: Int = 0
+                }
+                @StabilityInferred(parameters = 0)
+                class Stable {
+                  fun qux(%context_receiver_0: StableReceiver) { }
+                  static val %stable: Int = 0
+                }
+                @Composable
+                fun Something(%composer: Composer?, %changed: Int) {
+                  %composer = %composer.startRestartGroup(<>)
+                  sourceInformation(%composer, "C(Something)<rememb...>:Test.kt")
+                  if (%changed !== 0 || !%composer.skipping) {
+                    if (isTraceInProgress()) {
+                      traceEventStart(<>, %changed, -1, <>)
+                    }
+                    val x = remember({
+                      Stable()
+                    }, %composer, 0)
+                    val shouldNotMemoize = x::qux
+                    if (isTraceInProgress()) {
+                      traceEventEnd()
+                    }
+                  } else {
+                    %composer.skipToGroupEnd()
+                  }
+                  %composer.endRestartGroup()?.updateScope { %composer: Composer?, %force: Int ->
+                    Something(%composer, updateChangedFlags(%changed or 0b0001))
+                  }
+                }
             """
         )
     }


### PR DESCRIPTION
## Proposed Changes

`ComposerLambdaMemoization` tried to prematurely prevent potential syntax addition not breaking function reference optimization by checking for amount of value parameters.

This inadvertently broke memoization of function references to methods with more than zero arguments, since `IrFunctionReferenceImpl` currently reflects the amount of value arguments in the referenced function.

Add a check to disable memoization for function references with context receivers. Kotlin doesn't support them yet, and behavior might change in the future.

## Testing

Test: Added new tests to `LambdaMemoizationTransformTests`:
 * `testNonComposableFunctionReferenceWithNoArgumentsMemoization`
 * `testNonComposableFunctionReferenceWithArgumentsMemoization`
 * `testNonComposableFunctionReferenceWithStableContextReceiverNotMemoized`

## Issues Fixed

Fixes: b/302680514
