### PR TITLE
Use projectOrArtifact for fragment playground

### DIFF
--- a/fragment/fragment-testing/build.gradle
+++ b/fragment/fragment-testing/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     api("androidx.test:core:1.5.0")
     api(libs.kotlinStdlib)
     api(project(":fragment:fragment-testing-manifest"))
-    implementation(project(":core:core-ktx"))
+    implementation(projectOrArtifact(":core:core-ktx"))
     androidTestImplementation(libs.kotlinStdlib)
     androidTestImplementation(libs.espressoCore)
     androidTestImplementation(libs.testExtJunit)

--- a/fragment/integration-tests/testapp/build.gradle
+++ b/fragment/integration-tests/testapp/build.gradle
@@ -27,7 +27,7 @@ android {
 dependencies {
     implementation(libs.kotlinStdlib)
     implementation(project(":fragment:fragment-ktx"))
-    implementation(project(":transition:transition"))
+    implementation(projectOrArtifact(":transition:transition"))
     implementation("androidx.recyclerview:recyclerview:1.1.0")
     debugImplementation(project(":fragment:fragment-testing-manifest"))
 


### PR DESCRIPTION
https://github.com/androidx/androidx/actions/runs/6488639790/job/17621489436

Unsupported Playground Project: :core:core
dependency path to :core:core from explicitly requested projects: :fragment:fragment-testing -> :core:core-ktx -> :core:core :fragment:integration-tests:testapp -> :transition:transition -> :core:core

Test: cd fragment && ./gradlew bOS
Change-Id: Ia87330f17ac28ce16a517ae0ee5d2c68db758064