### PR TITLE
Fix paging playground

### DIFF
--- a/paging/integration-tests/testapp/build.gradle
+++ b/paging/integration-tests/testapp/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.1.0")
     implementation(libs.kotlinStdlib)
 
+    // Only needed to ensure version of annotation:annotation matches in impl
+    // and androidTestImpl, for both AOSP and playground builds.
+    implementation(project(":annotation:annotation"))
+
     androidTestImplementation(libs.kotlinTest)
     androidTestImplementation(libs.testCore)
     androidTestImplementation(libs.testExtJunit)


### PR DESCRIPTION
Different version of annotations was being pulled in for the integration test app vs its instrumented tests, which was causing them to fail to build with:

GradleException: Cannot find a version of 'androidx.annotation:annotation' that satisfies the version constraints:...

Test: cd paging && ./gradlew bOS
Change-Id: Ibb3339315975caab0ac5b7734400e8e13602aa36