### PR TITLE
Simple changes to fix AbstractMethodError from issue b/204328129

### DIFF
--- a/text/text/src/main/java/androidx/compose/ui/text/android/CharSequenceCharacterIterator.kt
+++ b/text/text/src/main/java/androidx/compose/ui/text/android/CharSequenceCharacterIterator.kt
@@ -33,7 +33,7 @@ internal class CharSequenceCharacterIterator(
     private val charSequence: CharSequence,
     private val start: Int,
     private val end: Int
-) : CharacterIterator {
+) : Object(), CharacterIterator {
     private var index: Int = start
 
     /**
@@ -173,7 +173,6 @@ internal class CharSequenceCharacterIterator(
      */
     override fun clone(): Any {
         return try {
-            @Suppress("ABSTRACT_SUPER_CALL")
             super.clone()
         } catch (e: CloneNotSupportedException) {
             throw InternalError()


### PR DESCRIPTION
Please see [b/204328129](https://issuetracker.google.com/issues/204328129) for more details on the issue.

## Proposed Changes

Basically this is something necessary to help prevent weird compilation errors that happen with the Buck/Redex build toolchains that Meta uses. Not something meaningful, but since the change is dead simple I guess it shall pass.

## Testing

Test: This has been something that was patched on Meta source and we've been testing it for multiple prod releases of Threads, we're only now porting the change to Google because it seems appropriate.

## Issues Fixed

Fixes: b/204328129