### PR TITLE
Configuration cache should just work for internally run CI scripts

### DIFF
--- a/busytown/androidx_multiplatform_mac.sh
+++ b/busytown/androidx_multiplatform_mac.sh
@@ -15,10 +15,10 @@ export USE_ANDROIDX_REMOTE_BUILD_CACHE=false
 # Setup simulators
 impl/androidx-native-mac-simulator-setup.sh
 
-impl/build.sh buildOnServer listTaskOutputs --no-configuration-cache createAllArchives -Pandroidx.constraints=true
+impl/build.sh buildOnServer listTaskOutputs createAllArchives -Pandroidx.constraints=true
 
 # run a separate createAllArchives task to prepare a repository
 # folder in DIST.
 # This cannot be merged with the buildOnServer run because
 # snapshot version is not a proper release version.
-DIST_DIR=$DIST_DIR/snapshots SNAPSHOT=true impl/build.sh createAllArchives --no-configuration-cache -Pandroidx.constraints=true
+DIST_DIR=$DIST_DIR/snapshots SNAPSHOT=true impl/build.sh createAllArchives -Pandroidx.constraints=true

--- a/busytown/androidx_multiplatform_mac_host_tests.sh
+++ b/busytown/androidx_multiplatform_mac_host_tests.sh
@@ -19,7 +19,6 @@ cd "$(dirname $0)"
 impl/androidx-native-mac-simulator-setup.sh
 
 impl/build.sh darwinBenchmarkResults allHostTests \
-    --no-configuration-cache \
     -Pandroidx.ignoreTestFailures \
     -Pandroidx.displayTestOutput=false \
     "$@"


### PR DESCRIPTION
For context, I talked with @liutikas about this change. While configuration cache doesn't yet have a good way of working on non-ephemeral hosts, it should be fine as long as the internal CI is preserving the cc-keystore directory in Gradle user home and other fingerprinted Gradle dependency/script caches.

## Proposed Changes

  - Remove the `--no-configuration-cache` flag on internal busytown CI scripts.

## Testing

Test: None
