### PR TITLE
Fix incorrect focusedPlaceholderColor

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TextFieldImpl.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TextFieldImpl.kt
@@ -129,13 +129,13 @@ internal fun CommonDecorationBox(
         // Transparent components interfere with Talkback (b/261061240), so if any components below
         // have alpha == 0, we set the component to null instead.
 
+        val placeholderColor = colors.placeholderColor(enabled, isError, interactionSource).value
         val decoratedPlaceholder: @Composable ((Modifier) -> Unit)? =
             if (placeholder != null && transformedText.isEmpty() && placeholderAlphaProgress > 0f) {
                 @Composable { modifier ->
                     Box(modifier.alpha(placeholderAlphaProgress)) {
                         Decoration(
-                            contentColor =
-                                colors.placeholderColor(enabled, isError, interactionSource).value,
+                            contentColor = placeholderColor,
                             typography = MaterialTheme.typography.bodyLarge,
                             content = placeholder
                         )


### PR DESCRIPTION
Given that a user enter and removes text in TextField the composable for placeholder decoration will be recreated, which contains the state of the placeholderColor. When recreating the placeholderColor the focused property will be to reset to default, false, this causes TextField to use the color of an unfocused placeholder when infact the TextField is focused.

## Issues Fixed

Fixes: [b/313669163](https://issuetracker.google.com/issues/313669163)

Tests: none, I'm unable to run the tests suite. Update in manual would be appreciated. 