### PR TITLE
fix: remove duplicate "setContentIntent"

### DIFF
--- a/core/core/src/main/java/androidx/core/app/NotificationCompat.java
+++ b/core/core/src/main/java/androidx/core/app/NotificationCompat.java
@@ -1090,7 +1090,6 @@ public class NotificationCompat {
                     .setSubText(NotificationCompat.getSubText(notification))
                     .setSettingsText(NotificationCompat.getSettingsText(notification))
                     .setStyle(style)
-                    .setContentIntent(notification.contentIntent)
                     .setGroup(NotificationCompat.getGroup(notification))
                     .setGroupSummary(NotificationCompat.isGroupSummary(notification))
                     .setLocusId(NotificationCompat.getLocusId(notification))


### PR DESCRIPTION
I think this line (1093) `.setContentIntent(notification.contentIntent)` is duplicated of line (1110).

## Proposed Changes

  -  Remove duplicate "setContentIntent"

## Testing

Test: None