### PR TITLE
Properly handle ClassCastException in SavedStateHandle when calling get() with the incorrect type

### DIFF
--- a/lifecycle/lifecycle-viewmodel-savedstate/src/androidTest/java/androidx/lifecycle/viewmodel/savedstate/SavedStateHandleTest.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/androidTest/java/androidx/lifecycle/viewmodel/savedstate/SavedStateHandleTest.kt
@@ -101,6 +101,13 @@ class SavedStateHandleTest {
     }
 
     @Test
+    fun testReturnsNullWhenWrongType() {
+        val handle = SavedStateHandle()
+        handle["s"] = "pb"
+        assertThat(handle.get<Int>("s")).isEqualTo(null)
+    }
+
+    @Test
     @UiThreadTest
     fun testRemoveWithLD() {
         val handle = SavedStateHandle()

--- a/lifecycle/lifecycle-viewmodel-savedstate/src/main/java/androidx/lifecycle/SavedStateHandle.kt
+++ b/lifecycle/lifecycle-viewmodel-savedstate/src/main/java/androidx/lifecycle/SavedStateHandle.kt
@@ -268,7 +268,7 @@ class SavedStateHandle {
         } catch (e: ClassCastException) {
             // Instead of failing on ClassCastException, we remove the value from the
             // SavedStateHandle and return null.
-            remove<T>(key)
+            remove<Any?>(key) // Use Any? here to avoid ClassCastException again
             null
         }
     }


### PR DESCRIPTION
When using SavedStateHandle, if you attempt to retrieve a value with the incorrect class type, it is casted to the correct class type and ends up throwing a ClassCastException. But inside `catch` block, we call `remove<T>(key)`, which will throw another ClassCastException, because `remove` method also tries to cast the existing value to the given type. This commit changes `T` to `Any?` to avoid ClassCastException.

## Proposed Changes

  - Change `remove<T>(key)` to `remove<Any?>(key)`.

## Testing

Test: Added `testReturnsNullWhenWrongType` to `lifecycle/lifecycle-viewmodel-savedstate/src/androidTest/java/androidx/lifecycle/viewmodel/savedstate/SavedStateHandleTest.kt`

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
