### PR TITLE
Fix regression in dynamic labels with non-string typed arguments

### DIFF
--- a/navigation/navigation-common/src/main/java/androidx/navigation/NavDestination.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/NavDestination.kt
@@ -635,7 +635,8 @@ public open class NavDestination(
                     val value = context.getString(bundle.getInt(argName))
                     builder.append(value)
                 } else {
-                    builder.append(bundle.getString(argName))
+                    @Suppress("DEPRECATION")
+                    builder.append(bundle[argName].toString())
                 }
             } else {
                 throw IllegalArgumentException(

--- a/navigation/navigation-ui/src/androidTest/java/androidx/navigation/ui/NavigationUITest.kt
+++ b/navigation/navigation-ui/src/androidTest/java/androidx/navigation/ui/NavigationUITest.kt
@@ -193,6 +193,33 @@ class NavigationUITest {
         assertThat(toolbar.title.toString()).isEqualTo(labelString)
     }
 
+    @UiThreadTest
+    @Test
+    fun navigateWithNonStringArg() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val navController = NavHostController(context)
+        navController.navigatorProvider.addNavigator(TestNavigator())
+
+        val startDestination = "start_destination"
+        val endDestination = "end_destination"
+
+        navController.graph = navController.createGraph(startDestination = startDestination) {
+            test(startDestination)
+            test("$endDestination/{test}") {
+                label = "{test}"
+                argument(name = "test") {
+                    type = NavType.LongType
+                }
+            }
+        }
+
+        val toolbar = Toolbar(context).apply { setupWithNavController(navController) }
+        navController.navigate("$endDestination/123")
+
+        val expected = "123"
+        assertThat(toolbar.title.toString()).isEqualTo(expected)
+    }
+    
     private fun createToolbarOnDestinationChangedListener(
         toolbar: Toolbar,
         bundle: Bundle?,

--- a/navigation/navigation-ui/src/androidTest/java/androidx/navigation/ui/NavigationUITest.kt
+++ b/navigation/navigation-ui/src/androidTest/java/androidx/navigation/ui/NavigationUITest.kt
@@ -219,7 +219,7 @@ class NavigationUITest {
         val expected = "123"
         assertThat(toolbar.title.toString()).isEqualTo(expected)
     }
-    
+
     private fun createToolbarOnDestinationChangedListener(
         toolbar: Toolbar,
         bundle: Bundle?,


### PR DESCRIPTION
Regression introduced in https://github.com/androidx/androidx/commit/76f9009e6cfc1cba5314cad87a6f1923203c54fa Reported in https://issuetracker.google.com/issues/316676794

Test: ./gradlew navigation:navigation-ui:cC
Fixes: 316676794

[AndroidX Navigation 2.6.0 broke dynamic app bar title for non String arguments](https://issuetracker.google.com/issues/316676794)
