### PR TITLE
add missing then call in ContextReceiverTests

### DIFF
--- a/compose/runtime/runtime/integration-tests/src/androidInstrumentedTest/kotlin/androidx/compose/runtime/ContextReceiverTests.kt
+++ b/compose/runtime/runtime/integration-tests/src/androidInstrumentedTest/kotlin/androidx/compose/runtime/ContextReceiverTests.kt
@@ -46,7 +46,7 @@ class ContextReceiverTests : BaseComposeTest() {
                     assertEquals(ctxValue, "A")
                 }
             }
-        }
+        }.then {}
     }
 
     context(CtxA)
@@ -69,7 +69,7 @@ class ContextReceiverTests : BaseComposeTest() {
                     assertEquals(ctxValue, "B")
                 }
             }
-        }
+        }.then {}
     }
 
     context(CtxA)


### PR DESCRIPTION
Proposed Changes

  - now compose lambda, does not invoke "assertEquals" calls. You will be able to verify this if you change the expected value to a deliberately incorrect one and run the test.

Testing

Test: ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.tests_regex='ContextReceiverTests*'

 Issues Fixed

It is addition for tests.
