### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 *          @dlam @yigit
 
 # Owners for each library group:
-/activity*          @sanura-njaka @jbw0033 @ianhanniballake
+/activity*          @jbw0033 @ianhanniballake
 /appcompat/*        @alanv
 /biometric/*        @jbolinger
 /collection/*       @dlam
@@ -12,7 +12,7 @@
 /compose/runtime/*  @jimgoog @lelandrichardson
 /core/*             @alanv
 /datastore/*        @rohitsat13 @yigit
-/fragment/*         @sanura-njaka @jbw0033 @ianhanniballake
+/fragment/*         @jbw0033 @ianhanniballake
 /lifecycle/*        @jbw0033 @ianhanniballake
 /navigation/*       @jbw0033 @ianhanniballake @claraf3
 /paging/*           @claraf3 @ianhanniballake


### PR DESCRIPTION
Github is failing to associate the correct reviewer for PRs because it sees the missing user as a syntax error.

Test: N/A