### PR TITLE
Depend on all test tasks in Playground CI

### DIFF
--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXPlaygroundRootImplPlugin.kt
@@ -25,9 +25,8 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.work.DisableCachingByDefault
-import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 /**
  * This plugin is used in Playground projects and adds functionality like resolving to snapshot
@@ -79,7 +78,7 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
             }
         }
         if (project.path in primaryProjectPaths) {
-            project.tasks.withType(Test::class.java).configureEach {
+            project.tasks.withType(AbstractTestTask::class.java).configureEach {
                 PlaygroundCIHostTestsTask.addTask(project, it)
             }
         }
@@ -254,9 +253,10 @@ class AndroidXPlaygroundRootImplPlugin : Plugin<Project> {
             description = "Runs host tests that belong to the projects which were explicitly " +
                 "requested in the playground setup."
         }
+
         companion object {
             private val NAME = "playgroundCIHostTests"
-            fun addTask(project: Project, task: Test) {
+            fun addTask(project: Project, task: AbstractTestTask) {
                 project.rootProject.tasks.named(NAME).configure {
                     it.dependsOn(task)
                 }


### PR DESCRIPTION
Playground CI tries to run the tests only for the explicitly included projects. Previously, we did this using the Test task but KotlinNative test tasks extend AbstractTestTask. This changes moves the code to use it instead so that Github also runs native tests.

Bug: n/a
Test: CI