### PR TITLE
Modify the offset calculation for adding item after the last item.

### DIFF
--- a/leanback/leanback-grid/src/main/java/androidx/leanback/widget/StaggeredGrid.java
+++ b/leanback/leanback-grid/src/main/java/androidx/leanback/widget/StaggeredGrid.java
@@ -212,17 +212,15 @@ abstract class StaggeredGrid extends Grid {
             cachedIndex--;
         }
         if (!foundCachedItemInSameRow) {
+            // Just use the offset of last item.
             cachedIndex = getLastIndex();
+            return getLocation(cachedIndex);
         }
         // Assuming the cachedIndex is next to item on the same row, so the
-        // sum of offset of [cachedIndex + 1, itemIndex] should be size of the
-        // cached item plus spacing.
-        int offset = isReversedFlow() ? -getLocation(cachedIndex).mSize - mSpacing :
-                getLocation(cachedIndex).mSize + mSpacing;
-        for (int i = cachedIndex + 1; i <= getLastIndex(); i++) {
-            offset -= getLocation(i).mOffset;
-        }
-        return offset;
+        // offset of itemIndex should be size of the cached item plus spacing.
+        final Location loc = getLocation(cachedIndex);
+        return isReversedFlow() ? loc.mOffset - loc.mSize - mSpacing :
+                loc.mOffset + loc.mSize + mSpacing;
     }
 
 


### PR DESCRIPTION
When the focus is on the last item and an item is added before the focus item. If the previous item of the same row cannot be found, the offset of the adjacent previous item should be used directly. If found, the offset of the item should be added with the size of the item and space as the current offset.

Test: run locally, no crash

## Proposed Changes

  - Modify the offset calculation for adding item after the last item.

## Testing

Test: Verified through local demo, no crashes. And fixed the issues mentioned below.

## Issues Fixed

Fixes: Fixed the issues mentioned below.

When the number of items is less than one line, when the focus is on the last item, if an item is added before the focus, the focus item will be incorrectly placed in the second line, and in reality, there is still space in the first line above it.
