### PR TITLE
Start using a fixed Gradle encryption key

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -11,6 +11,8 @@ inputs:
     description: "password for gradle cache"
   gradle-enterprise-access-key:
     description: "access key for gradle enterprise"
+  gradle-encryption-key:
+    description: "key for gradle configuration cache encryption"
   gradle-flags:
     description: "flags to pass while invoking gradle"
 runs:
@@ -39,7 +41,7 @@ runs:
         echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
     - name: "Setup Gradle"
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/gradle-build-action@v3
       with:
         # Only save Gradle User Home state for builds on the 'androidx-main' branch.
         # Builds on other branches will only read existing entries from the cache.
@@ -47,6 +49,8 @@ runs:
 
         # Don't reuse cache entries from any other Job.
         gradle-home-cache-strict-match: true
+
+        cache-encryption-key: ${{ inputs.gradle-encryption-key }}
 
         # Limit the size of the cache entry.
         # These directories contain instrumented/transformed dependency jars which can be reconstructed relatively quickly.
@@ -59,6 +63,7 @@ runs:
         JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         GRADLE_BUILD_CACHE_PASSWORD: ${{ inputs.gradle-cache-password }}
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ inputs.gradle-enterprise-access-key }}
+        GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
       working-directory: ${{ inputs.project-root }}
       shell: bash
       run: ./gradlew buildOnServer zipTestConfigsWithApks ${{ inputs.gradle-flags }}
@@ -67,6 +72,7 @@ runs:
         JAVA_HOME: ${{ steps.setup-java.outputs.path }}
         GRADLE_BUILD_CACHE_PASSWORD: ${{ inputs.gradle-cache-password }}
         GRADLE_ENTERPRISE_ACCESS_KEY: ${{ inputs.gradle-enterprise-access-key }}
+        GRADLE_ENCRYPTION_KEY: ${{ inputs.gradle-encryption-key }}
       working-directory: ${{ inputs.project-root }}
       shell: bash
       run: ./gradlew playgroundCIHostTests ${{ inputs.gradle-flags }}

--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -41,7 +41,7 @@ runs:
         echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
     - name: "Setup Gradle"
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/gradle-build-action@v3-beta
       with:
         # Only save Gradle User Home state for builds on the 'androidx-main' branch.
         # Builds on other branches will only read existing entries from the cache.

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -89,7 +89,7 @@ jobs:
           echo "::set-output name=files::$AFFECTED_FILES"
 
       - name: "Setup Gradle"
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/gradle-build-action@v3-beta
         with:
           # Only save Gradle User Home state for builds on the 'androidx-main' branch.
           # Builds on other branches will only read existing entries from the cache.

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       GRADLE_BUILD_CACHE_PASSWORD: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
     steps:
       - name: Pull request format
         uses: 'androidx/check-pr-format-action@main'
@@ -88,7 +89,7 @@ jobs:
           echo "::set-output name=files::$AFFECTED_FILES"
 
       - name: "Setup Gradle"
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           # Only save Gradle User Home state for builds on the 'androidx-main' branch.
           # Builds on other branches will only read existing entries from the cache.
@@ -96,6 +97,8 @@ jobs:
 
           # Don't reuse cache entries from any other Job.
           gradle-home-cache-strict-match: true
+
+          cache-encryption-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
           # Limit the size of the cache entry.
           # These directories contain instrumented/transformed dependency jars which can be reconstructed relatively quickly.
@@ -129,6 +132,7 @@ jobs:
       project-root: playground-projects/${{matrix.project-root || matrix.project}}-playground
       GRADLE_BUILD_CACHE_PASSWORD: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
     steps:
       - name: "Checkout androidx repo"
         uses: actions/checkout@v2
@@ -148,6 +152,7 @@ jobs:
           project-root: ${{ env.project-root }}
           gradle-cache-password: ${{ secrets.GRADLE_BUILD_CACHE_PASSWORD }}
           gradle-enterprise-access-key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          gradle-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
           gradle-flags: ${{ needs.setup.outputs.gradlew_flags }}
       # Upload artifacts task should be in the build-single-project
       # action but they have a tendency to fail and continue-on-error


### PR DESCRIPTION
## Proposed Changes

In Gradle 8.6 support was added for having a fixed Gradle encryption key when encrypting configuration cache entries.

https://docs.gradle.org/8.6-rc-1/userguide/configuration_cache.html#config_cache:secrets:configuring_encryption_key

This allows to reuse configuration cache from previous runs in github actions instead of having to recompute it every time.

## Testing

Test: None
