### PR TITLE
Fix out directory setting for playground

### DIFF
--- a/buildSrc/out.gradle
+++ b/buildSrc/out.gradle
@@ -50,9 +50,10 @@ def chooseBuildSrcBuildDir(subdir = "") {
 
 def chooseOutDir(subdir = "") {
     chooseBuildSrcBuildDir()
+    project.layout.buildDirectory.set(new File(project.ext.outDir, subdir))
     subprojects {
-        // Change buildDir first so that all plugins pick up the new value.
-        project.layout.buildDirectory.set(new File("$project.parent.buildDir/../$project.name/build"))
+        // Expected out directory structure for :foo:bar is out/androidx/foo/bar
+        it.buildDir = new File(outDir, "${subdir}/androidx/${it.path.replace(":", "/")}/build")
     }
 }
 

--- a/playground-common/playground-plugin/settings.gradle
+++ b/playground-common/playground-plugin/settings.gradle
@@ -39,6 +39,10 @@ dependencyResolutionManagement {
     }
 }
 
+System.setProperty(
+        "CHECKOUT_ROOT",
+        buildscript.sourceFile.getParentFile().getParentFile().getParentFile().absolutePath
+)
 System.setProperty("ALLOW_PUBLIC_REPOS", "true")
 rootProject.name = "playground-plugin"
 includeBuild("../../buildSrc") {


### PR DESCRIPTION
## Proposed Changes

before:
:supportBuildSrc:private -> /ssd/out/buildSrc/private/build :collection:collection -> /ssd/ssd5/androidx/out/buildSrc/collection/collection/build

after:
:supportBuildSrc:private -> /ssd/ssd5/androidx/out/buildSrc/private/build :collection:collection -> /ssd/ssd5/androidx/out/collections-playground/androidx/collection/collection/build

## Testing

Test: println(buildDir.absolutePath) in build.gradle files

