### PR TITLE
Bump playground memory

### DIFF
--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -24,7 +24,8 @@
 # This separation is necessary to ensure gradle can read certain properties
 # at configuration time.
 
-org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
+
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true

--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -25,7 +25,6 @@
 # at configuration time.
 
 org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
-
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Update playground properties to bump gradle memory to 8gb (from 4) and kotlin daemon metaspace memory to 1gb (from 512mb).

Looks like GitHub provides bigger machines now so we should be able to bump these values.

Bug: n/a
Test: CI