### PR TITLE
less memory for playground

### DIFF
--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -24,7 +24,7 @@
 # This separation is necessary to ensure gradle can read certain properties
 # at configuration time.
 
-org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Looks like the previous CL dropped the metaspace by mistake.

Adding it back and also setting gradle memory to 6gb.

Bug: n/a
Test: CI