### PR TITLE
Add additional link for information about receiver exporting

### DIFF
--- a/core/core/src/main/java/androidx/core/content/ContextCompat.java
+++ b/core/core/src/main/java/androidx/core/content/ContextCompat.java
@@ -756,11 +756,12 @@ public class ContextCompat {
      * @param filter   Selects the Intent broadcasts to be received.
      * @param flags    If this receiver is listening for broadcasts sent from other apps—even other
      *                 apps that you own—use the {@link #RECEIVER_EXPORTED} flag. If instead this 
-                       receiver is listening only for broadcasts sent by your
-     *                 app, or from the system, use the {@link #RECEIVER_NOT_EXPORTED} flag.
+     *                 receiver is listening only for broadcasts sent by your
+     *                 app, or from the system UID, use the {@link #RECEIVER_NOT_EXPORTED} flag.
      * @return The first sticky intent found that matches <var>filter</var>,
      * or null if there are none.
      * @see Context#registerReceiver(BroadcastReceiver, IntentFilter, int)
+     * @see https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers
      */
     @Nullable
     public static Intent registerReceiver(@NonNull Context context,
@@ -784,10 +785,11 @@ public class ContextCompat {
      *                            apps—even other apps that you own—use the
      *                            {@link #RECEIVER_EXPORTED} flag. If instead this receiver is
      *                            listening only for broadcasts sent by your app, or from the
-     *                            system, use the {@link #RECEIVER_NOT_EXPORTED} flag.
+     *                            system UID, use the {@link #RECEIVER_NOT_EXPORTED} flag.
      * @return The first sticky intent found that matches <var>filter</var>,
      * or null if there are none.
      * @see Context#registerReceiver(BroadcastReceiver, IntentFilter, String, Handler, int)
+     * @see https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers
      */
     @Nullable
     public static Intent registerReceiver(@NonNull Context context,


### PR DESCRIPTION
The Android Developers documentation team has updated their documentation regarding receiver exporting.  This change changes `system` to `system UID` and adds a link to the AD page on this topic.

See https://issuetracker.google.com/issues/323401158 and https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers

## Proposed Changes

- Documentation Update

## Testing

N/A

## Issues Fixed

N/A