### PR TITLE
[Compose][Foundation] Update `TapGestureDetector` documentation

### DIFF
--- a/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
+++ b/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/gestures/TapGestureDetector.kt
@@ -53,7 +53,7 @@ interface PressGestureScope : Density {
     /**
      * Waits for the press to be released before returning. If the press was released,
      * `true` is returned, or if the gesture was canceled by motion being consumed by
-     * another gesture, `false` is returned .
+     * another gesture, `false` is returned.
      */
     suspend fun tryAwaitRelease(): Boolean
 }


### PR DESCRIPTION
This PR updates the documentation of `PressGestureScope.tryAwaitRelease` in `TapGestureDetector`, addressing a small spacing issue.

Test: N/A (documentation update)