### PR TITLE
feat: Allow customizing the Preview's format (e.g. to `ImageFormat.YUV_420_888`)

### DIFF
--- a/camera/camera-core/src/main/java/androidx/camera/core/CameraEffect.java
+++ b/camera/camera-core/src/main/java/androidx/camera/core/CameraEffect.java
@@ -108,7 +108,7 @@ public abstract class CameraEffect {
      */
     @Retention(RetentionPolicy.SOURCE)
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @IntDef(flag = true, value = {INTERNAL_DEFINED_IMAGE_FORMAT_PRIVATE, ImageFormat.JPEG})
+    @IntDef(flag = true, value = {INTERNAL_DEFINED_IMAGE_FORMAT_PRIVATE, ImageFormat.YUV_420_888, ImageFormat.JPEG})
     public @interface Formats {
     }
 

--- a/camera/camera-core/src/main/java/androidx/camera/core/Preview.java
+++ b/camera/camera-core/src/main/java/androidx/camera/core/Preview.java
@@ -229,7 +229,7 @@ public final class Preview extends UseCase {
         CameraInternal camera = requireNonNull(getCamera());
         clearPipeline();
 
-        int format = config.get(OPTION_INPUT_FORMAT);
+        int format = config.getInputFormat();
 
         // Make sure the previously created camera edge is cleared before creating a new one.
         checkState(mCameraEdge == null);

--- a/camera/camera-core/src/main/java/androidx/camera/core/Preview.java
+++ b/camera/camera-core/src/main/java/androidx/camera/core/Preview.java
@@ -229,11 +229,13 @@ public final class Preview extends UseCase {
         CameraInternal camera = requireNonNull(getCamera());
         clearPipeline();
 
+        int format = config.get(OPTION_INPUT_FORMAT);
+
         // Make sure the previously created camera edge is cleared before creating a new one.
         checkState(mCameraEdge == null);
         mCameraEdge = new SurfaceEdge(
                 PREVIEW,
-                INTERNAL_DEFINED_IMAGE_FORMAT_PRIVATE,
+                format,
                 streamSpec,
                 getSensorToBufferTransformMatrix(),
                 camera.getHasTransform(),
@@ -560,9 +562,6 @@ public final class Preview extends UseCase {
     @Override
     protected UseCaseConfig<?> onMergeConfig(@NonNull CameraInfoInternal cameraInfo,
             @NonNull UseCaseConfig.Builder<?, ?, ?> builder) {
-        builder.getMutableConfig().insertOption(OPTION_INPUT_FORMAT,
-                INTERNAL_DEFINED_IMAGE_FORMAT_PRIVATE);
-
         return builder.getUseCaseConfig();
     }
 
@@ -805,7 +804,8 @@ public final class Preview extends UseCase {
                     .setSurfaceOccupancyPriority(DEFAULT_SURFACE_OCCUPANCY_PRIORITY)
                     .setTargetAspectRatio(DEFAULT_ASPECT_RATIO)
                     .setResolutionSelector(DEFAULT_RESOLUTION_SELECTOR)
-                    .setDynamicRange(DEFAULT_DYNAMIC_RANGE);
+                    .setDynamicRange(DEFAULT_DYNAMIC_RANGE)
+                    .setFormat(INTERNAL_DEFINED_IMAGE_FORMAT_PRIVATE);
             DEFAULT_CONFIG = builder.getUseCaseConfig();
         }
 
@@ -1273,6 +1273,23 @@ public final class Preview extends UseCase {
         @NonNull
         public Builder setTargetFrameRate(@NonNull Range<Integer> targetFrameRate) {
             getMutableConfig().insertOption(OPTION_TARGET_FRAME_RATE, targetFrameRate);
+            return this;
+        }
+
+        /**
+         * Sets the buffer format for the associated Preview use case.
+         *
+         * <p>
+         * While {@link ImageFormat.PRiVATE} is the recommended buffer format, applications
+         * may choose a different {@link ImageFormat} such as {@link ImageFormat.YUV_420_888}
+         * when using {@link CameraEffect}s.
+         *
+         * @param format a buffer format.
+         * @return the current Builder.
+         */
+        @NonNull
+        public Builder setFormat(@CameraEffect.Formats int format) {
+            getMutableConfig().insertOption(OPTION_INPUT_FORMAT, format);
             return this;
         }
 


### PR DESCRIPTION
## Proposed Changes

  - Add `setFormat(...)` to `Preview.Builder`
  - Use custom format for `SurfaceEdge` in `Preview::createPipeline(..)`
  - Remove format override in `Preview::onMergeConfig`

The reason for this change is that `CameraEffect`s/`SurfaceProcessor`s are always in a fixed format, and in my case I also have an additional CPU processing step in my `SurfaceProcessor`, which I need `ImageFormat.YUV_420_888` images for (instead of `ImageFormat.PRIVATE`).

I cannot use `ImageAnalysis` for this, since I already have Preview, ImageCapture and VideoCapture use-cases attached.

## Testing

Test: I did not figure out how to test this yet, I'll read the contributing guidelines in a sec and start testing this.

## Issues Fixed

Fixes: A comment in https://issuetracker.google.com/issues/326813037
