### PR TITLE
Re-enable building core:core in playground

### DIFF
--- a/.github/ci-control/ci-config.json
+++ b/.github/ci-control/ci-config.json
@@ -14,7 +14,6 @@
     "main" : {
         "exclude" : [
             "compose-runtime",
-            "core",
             "room"
         ],
         "default": true

--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundExtension.kt
@@ -236,7 +236,6 @@ open class PlaygroundExtension @Inject constructor(
         private val REQUIRED_PROJECTS = listOf(":lint-checks")
         private val UNSUPPORTED_PROJECTS = listOf(
             ":benchmark:benchmark-common", // requires prebuilts
-            ":core:core", // stable aidl, b/270593834
             ":inspection:inspection", // native compilation
         )
     }


### PR DESCRIPTION
We have moved to build-tools that is publicly released

Test: None
