### PR TITLE
Update CODEOWNERS to match subdirectories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,22 @@
 # Global owners:
 # Unless a later match takes precedence, global owners will be # requested for
 # review when someone opens a pull request.
-*          @dlam @yigit
+*                  @dlam @yigit
 
 # Owners for each library group:
-/activity*          @jbw0033 @ianhanniballake
-/appcompat/*        @alanv
-/biometric/*        @jbolinger
-/collection/*       @dlam
-/compose/compiler/* @jimgoog @lelandrichardson
-/compose/runtime/*  @jimgoog @lelandrichardson
-/core/*             @alanv
-/datastore/*        @rohitsat13 @yigit
-/fragment/*         @jbw0033 @ianhanniballake
-/lifecycle/*        @jbw0033 @ianhanniballake
-/navigation/*       @jbw0033 @ianhanniballake @claraf3
-/paging/*           @claraf3 @ianhanniballake
-/room/*             @droid-wan-kenobi @danysantiago @svasilinets
-/work/*             @svasilinets @tikurahul
-
+/activity/         @jbw0033 @ianhanniballake
+/annotation/       @jbw0033 @ianhanniballake
+/appcompat/        @alanv
+/biometric/        @jbolinger
+/collection/       @dlam
+/compose/compiler/ @jimgoog @lelandrichardson
+/compose/runtime/  @jimgoog @lelandrichardson
+/core/             @alanv
+/datastore/        @rohitsat13 @yigit
+/fragment/         @jbw0033 @ianhanniballake
+/lifecycle/        @jbw0033 @ianhanniballake
+/navigation/       @jbw0033 @ianhanniballake @claraf3
+/paging/           @claraf3 @ianhanniballake
+/room/             @droid-wan-kenobi @danysantiago @svasilinets
+/work/             @svasilinets @tikurahul
 


### PR DESCRIPTION
The CODEOWNERS format was updated to only match subdirectories with the /<dir>/ syntax, vs /<dir>/* only matching the first-level down.

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Test: GH CI
Change-Id: I9bcc43629e804db61b0e398fb8c1da20872a6fdb