### PR TITLE
Fix activity playground

### DIFF
--- a/playground-projects/activity-playground/settings.gradle
+++ b/playground-projects/activity-playground/settings.gradle
@@ -27,6 +27,7 @@ rootProject.name = "activity-playground"
 playground {
     setupPlayground("../..")
     selectProjectsFromAndroidX({ name ->
+        if (name == ":activity:integration-tests:macrobenchmark") return false
         if (name.startsWith(":activity")) return true
         return false
     })


### PR DESCRIPTION
Disabling test app which depends on ToT macrobenchmark due to testutils for now.

Bug: 318536542
Test: cd playground-projects/activity-playground && ./gradlew bOS
Change-Id: If94fc7adf71286cc3930a3217f2805c923665cf8