### PR TITLE
align `core-location-altitude` protobuf proguard rule

### DIFF
--- a/core/core-location-altitude/proguard-rules.pro
+++ b/core/core-location-altitude/proguard-rules.pro
@@ -15,5 +15,6 @@
 # libproto uses reflection to deserialize a Proto, which Proguard can't accurately detect.
 # Keep all the class members of any generated messages to ensure we can deserialize properly inside
 # these classes.
--if class * extends androidx.core.location.altitude.impl.proto.GeneratedMessageLite
--keepclasseswithmembers
+-keepclassmembers class * extends androidx.core.location.altitude.impl.proto.GeneratedMessageLite {
+  <fields>;
+}


### PR DESCRIPTION
## Proposed Changes

Current `core-location-altitude:1.0.0-alpha01` proguard rule fails on Gradle release build

This PR fixes the above and aligns with AndroidX proguard rule convention for libproto:
https://github.com/search?q=repo%3Aandroidx%2Fandroidx+generatedMessageLite+language%3AProguard&type=code

## Testing

Changes confirmed working on Gradle 8.4 through 8.7

## Issues Fixed

ProGuard/R8 error: 

\> Task :app:minifyReleaseWithR8 FAILED

AGPBI: {"kind":"error","text":"Expected [!]interface|@interface|class|enum","sources":[{"file":"/nvme2/.gradle/caches/transforms-4/107bba21c7accab0bb3cff9f0df50e5a/transformed/core-location-altitude-1.0.0-alpha01/proguard.txt","position":{"startLine":18,"startColumn":23,"startOffset":926}}],"tool":"R8"}

