### PR TITLE
Fix: webp files corrupted by ExifInterface.saveAttributes

### DIFF
--- a/exifinterface/exifinterface/src/androidTest/java/androidx/exifinterface/media/ExifInterfaceTest.java
+++ b/exifinterface/exifinterface/src/androidTest/java/androidx/exifinterface/media/ExifInterfaceTest.java
@@ -50,7 +50,6 @@ import com.google.common.primitives.Ints;
 import com.google.common.truth.Expect;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -390,7 +389,6 @@ public class ExifInterfaceTest {
 
     // https://issuetracker.google.com/342697059
     @Test
-    @Ignore("Enable as part of merging the fix in https://github.com/androidx/androidx/pull/683")
     @LargeTest
     public void testWebpWithoutExifHeight8192px() throws Throwable {
         File imageFile =

--- a/exifinterface/exifinterface/src/androidTest/java/androidx/exifinterface/media/ExifInterfaceTest.java
+++ b/exifinterface/exifinterface/src/androidTest/java/androidx/exifinterface/media/ExifInterfaceTest.java
@@ -40,6 +40,7 @@ import androidx.annotation.RequiresApi;
 import androidx.exifinterface.test.R;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
+import androidx.test.filters.SdkSuppress;
 import androidx.test.filters.SmallTest;
 import androidx.test.rule.GrantPermissionRule;
 
@@ -390,6 +391,7 @@ public class ExifInterfaceTest {
     // https://issuetracker.google.com/342697059
     @Test
     @LargeTest
+    @SdkSuppress(minSdkVersion = 22)
     public void testWebpWithoutExifHeight8192px() throws Throwable {
         File imageFile =
                 copyFromResourceToFile(

--- a/exifinterface/exifinterface/src/main/java/androidx/exifinterface/media/ExifInterface.java
+++ b/exifinterface/exifinterface/src/main/java/androidx/exifinterface/media/ExifInterface.java
@@ -3093,8 +3093,6 @@ public class ExifInterface {
     private static final int WEBP_CHUNK_TYPE_VP8X_DEFAULT_LENGTH = 10;
     private static final int WEBP_CHUNK_TYPE_BYTE_LENGTH = 4;
     private static final int WEBP_CHUNK_SIZE_BYTE_LENGTH = 4;
-    // maximum width/height allowed (inclusive), in pixels
-    private static final int WEBP_MAX_DIMENSION = 16383
 
     private static SimpleDateFormat sFormatterPrimary;
     private static SimpleDateFormat sFormatterSecondary;
@@ -6776,11 +6774,8 @@ public class ExifInterface {
 
                         // Retrieve image width/height
                         widthAndHeight = totalInputStream.readInt();
-                        int width = widthAndHeight & 0x0000FFFF;
-                        int height = (widthAndHeight & 0xFFFF0000) >> 16;
-                        if (width > WEBP_MAX_DIMENSION || height > WEBP_MAX_DIMENSION) {
-                            throw new IOException("Maximum side allowed is 16383 pixels.");
-                        }
+                        width = widthAndHeight & 0x3FFF;
+                        height = (widthAndHeight >> 16) & 0x3FFF;
                         bytesToRead -= (vp8Frame.length + vp8Signature.length + 4);
                     } else if (Arrays.equals(firstChunkType, WEBP_CHUNK_TYPE_VP8L)) {
                         // Check signature

--- a/exifinterface/exifinterface/src/main/java/androidx/exifinterface/media/ExifInterface.java
+++ b/exifinterface/exifinterface/src/main/java/androidx/exifinterface/media/ExifInterface.java
@@ -3093,6 +3093,8 @@ public class ExifInterface {
     private static final int WEBP_CHUNK_TYPE_VP8X_DEFAULT_LENGTH = 10;
     private static final int WEBP_CHUNK_TYPE_BYTE_LENGTH = 4;
     private static final int WEBP_CHUNK_SIZE_BYTE_LENGTH = 4;
+    // maximum width/height allowed (inclusive), in pixels
+    private static final int WEBP_MAX_DIMENSION = 16383
 
     private static SimpleDateFormat sFormatterPrimary;
     private static SimpleDateFormat sFormatterSecondary;
@@ -6774,8 +6776,11 @@ public class ExifInterface {
 
                         // Retrieve image width/height
                         widthAndHeight = totalInputStream.readInt();
-                        width = (widthAndHeight << 18) >> 18;
-                        height = (widthAndHeight << 2) >> 18;
+                        int width = widthAndHeight & 0x0000FFFF;
+                        int height = (widthAndHeight & 0xFFFF0000) >> 16;
+                        if (width > WEBP_MAX_DIMENSION || height > WEBP_MAX_DIMENSION) {
+                            throw new IOException("Maximum side allowed is 16383 pixels.");
+                        }
                         bytesToRead -= (vp8Frame.length + vp8Signature.length + 4);
                     } else if (Arrays.equals(firstChunkType, WEBP_CHUNK_TYPE_VP8L)) {
                         // Check signature


### PR DESCRIPTION

## Proposed Changes

  - webp file without vp8x header (maybe old format ? )
  - width or height exceeds 8191
  - ExifInterface.saveAttributes

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: The bug on [34269705](https://issuetracker.google.com/issues/342697059) being fixed
