### PR TITLE
Fix: IllegalStateException: AppCompatDialog#addContentView(AbstractComposeView(...), ...)

### DIFF
--- a/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
+++ b/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
@@ -17,6 +17,7 @@
 package androidx.appcompat.app
 
 import android.view.View
+import android.view.ViewGroup
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.test.core.app.ActivityScenario
@@ -69,7 +70,13 @@ class AppCompatDialogTest {
                 view = View(this)
                 AppCompatDialog(this)
             }
-            dialog.addContentView(view)
+            dialog.addContentView(
+                view,
+                ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+            )
 
             val lifecycle = dialog.lifecycle
             assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)

--- a/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
+++ b/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
@@ -64,28 +64,28 @@ class AppCompatDialogTest {
     @Test
     fun testViewTreeLifecycleOwnerWhenAddContentView() {
         withUse(ActivityScenario.launch(AppCompatActivity::class.java)) {
-          lateinit var view: View
-          val dialog = withActivity {
-              view = View(this)
-              AppCompatDialog(this)
-          }
-          dialog.addContentView(view)
+            lateinit var view: View
+            val dialog = withActivity {
+                view = View(this)
+                AppCompatDialog(this)
+            }
+            dialog.addContentView(view)
 
-          val lifecycle = dialog.lifecycle
-          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)
+            val lifecycle = dialog.lifecycle
+            assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)
 
-          onActivity { dialog.show() }
-          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.RESUMED)
+            onActivity { dialog.show() }
+            assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.RESUMED)
 
-          val viewOwner = dialog.window?.decorView?.findViewTreeLifecycleOwner()!!
-          assertThat(viewOwner).isEqualTo(dialog)
+            val viewOwner = dialog.window?.decorView?.findViewTreeLifecycleOwner()!!
+            assertThat(viewOwner).isEqualTo(dialog)
 
-          onActivity { dialog.dismiss() }
-          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+            onActivity { dialog.dismiss() }
+            assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
 
-          assertWithMessage("A new Lifecycle object should be created after destruction")
-              .that(dialog.lifecycle)
-              .isNotSameInstanceAs(lifecycle)
+            assertWithMessage("A new Lifecycle object should be created after destruction")
+                .that(dialog.lifecycle)
+                .isNotSameInstanceAs(lifecycle)
         }
     }
 }

--- a/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
+++ b/appcompat/appcompat/src/androidTest/java/androidx/appcompat/app/AppCompatDialogTest.kt
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith
 class AppCompatDialogTest {
 
     @Test
-    fun testViewTreeLifecycleOwner() {
+    fun testViewTreeLifecycleOwnerWhenSetContentView() {
         withUse(ActivityScenario.launch(AppCompatActivity::class.java)) {
             lateinit var view: View
             val dialog = withActivity {
@@ -58,6 +58,34 @@ class AppCompatDialogTest {
             assertWithMessage("A new Lifecycle object should be created after destruction")
                 .that(dialog.lifecycle)
                 .isNotSameInstanceAs(lifecycle)
+        }
+    }
+
+    @Test
+    fun testViewTreeLifecycleOwnerWhenAddContentView() {
+        withUse(ActivityScenario.launch(AppCompatActivity::class.java)) {
+          lateinit var view: View
+          val dialog = withActivity {
+              view = View(this)
+              AppCompatDialog(this)
+          }
+          dialog.addContentView(view)
+
+          val lifecycle = dialog.lifecycle
+          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.INITIALIZED)
+
+          onActivity { dialog.show() }
+          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.RESUMED)
+
+          val viewOwner = dialog.window?.decorView?.findViewTreeLifecycleOwner()!!
+          assertThat(viewOwner).isEqualTo(dialog)
+
+          onActivity { dialog.dismiss() }
+          assertThat(lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+
+          assertWithMessage("A new Lifecycle object should be created after destruction")
+              .that(dialog.lifecycle)
+              .isNotSameInstanceAs(lifecycle)
         }
     }
 }

--- a/appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDialog.java
+++ b/appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDialog.java
@@ -111,6 +111,12 @@ public class AppCompatDialog extends ComponentDialog implements AppCompatCallbac
         getDelegate().setContentView(view, params);
     }
 
+    @Override
+    public void addContentView(@NonNull View view, ViewGroup.LayoutParams params) {
+        initViewTreeOwners();
+        getDelegate().addContentView(view, params);
+    }
+
     private void initViewTreeOwners() {
         // Set the view tree owners before setting the content view so that the inflation process
         // and attach listeners will see them already present

--- a/appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDialog.java
+++ b/appcompat/appcompat/src/main/java/androidx/appcompat/app/AppCompatDialog.java
@@ -111,12 +111,6 @@ public class AppCompatDialog extends ComponentDialog implements AppCompatCallbac
         getDelegate().setContentView(view, params);
     }
 
-    @Override
-    public void addContentView(@NonNull View view, ViewGroup.LayoutParams params) {
-        initViewTreeOwners();
-        getDelegate().addContentView(view, params);
-    }
-
     private void initViewTreeOwners() {
         // Set the view tree owners before setting the content view so that the inflation process
         // and attach listeners will see them already present
@@ -146,6 +140,7 @@ public class AppCompatDialog extends ComponentDialog implements AppCompatCallbac
 
     @Override
     public void addContentView(@NonNull View view, ViewGroup.LayoutParams params) {
+        initViewTreeOwners();
         getDelegate().addContentView(view, params);
     }
 


### PR DESCRIPTION
## Issues Fixed

Fixes: 349502140
Relnote: "Fixed an `IllegalStateException` when attempting to use `ComposeView` in an `AppCompatDialog` when using `addContentView`"

## Description

In the `AppCompatDialog`, `initViewTreeOwners()` is called inside all of `setContentView` but no `addContentView`. While in `ComponentDialog`, `initializeViewTreeOwners()` is called inside all of `setContentView` and `addContentView`, so `AppCompatDialog` has no complete solution for the `IllegalStateException`.