### PR TITLE
Update .github flows to use ENV files over set-output

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -16,7 +16,7 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
       - name: "set output directory"
-        run: echo "::set-output name=output-dir::$(readlink -f .)/outputs"
+        run: echo "output-dir=$(readlink -f .)/outputs" >> $GITHUB_OUTPUT
         id: dirs
       - id: run_tests
         uses: androidX/androidx-ci-action@dist-latest
@@ -48,9 +48,9 @@ jobs:
           if [ "${{ needs.run_integration_tests.result }}" == "success" ]                  && \
             [ "${{ github.event.workflow_run.conclusion }}" == "success" ]
           then
-            echo "::set-output name=result::true"
+            echo "result=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=result::false"
+            echo "result=false" >> GITHUB_OUTPUT
           fi
 
       - name: Result WebHook

--- a/.github/workflows/jbpresubmit.yml
+++ b/.github/workflows/jbpresubmit.yml
@@ -42,20 +42,20 @@ jobs:
             -Dorg.gradle.internal.repository.initial.backoff=500            \
             -Dorg.gradle.jvmargs=-XX:MaxMetaspaceSize=512m                  \
             --stacktrace"
-          echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
+          echo "gradlew_flags=GRADLEW_FLAGS" >> $GITHUB_OUTPUT
       - name: "Compute actions/checkout arguments"
         id: checkout-args
         env:
           REF: ${{ github.event.pull_request.head.ref || github.event.ref}}
         run: |
           set -x
-          echo "::set-output name=ref::$REF"
+          echo "ref=$REF" >> $GITHUB_OUTPUT
 
           REPOSITORY=${{ github.event.pull_request.head.repo.full_name }}
           if [ -z "$REPOSITORY" ]; then
             REPOSITORY=${{ github.repository }}
           fi
-          echo "::set-output name=repository::$REPOSITORY"
+          echo "repository=$REPOSITORY" >> $GITHUB_OUTPUT
 
   lint:
     runs-on: ubuntu-latest
@@ -110,14 +110,14 @@ jobs:
         run: |
           set -x
           KTFMT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=../&|g' | grep -v "*.txt"`
-          echo "::set-output name=ktfmt-file-args::$KTFMT_FILES"
+          echo "ktfmt-file-args=KTFMT_FILES" >> $GITHUB_OUTPUT
 
       - name: "Parse changed-files as affected files args"
         id: affected-file-args
         run: |
           set -x
           AFFECTED_FILES=`echo "${{ steps.changed-files.outputs.files_including_removals }}" | sed 's|\([^ ]\+\)|--changedFilePath=\1|g'`
-          echo "::set-output name=files::$AFFECTED_FILES"
+          echo "files=AFFECTED_FILES" >> $GITHUB_OUTPUT
       - name: "warm up gradle"
         id: warm-up-gradle-cache
         uses: gradle/gradle-command-action@v1

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -23,7 +23,7 @@ jobs:
             -Dorg.gradle.internal.repository.max.retries=20                 \
             -Dorg.gradle.internal.repository.initial.backoff=500            \
             --stacktrace"
-          echo "::set-output name=gradlew_flags::$GRADLEW_FLAGS"
+          echo "gradlew_flags=$GRADLEW_FLAGS" >> $GITHUB_OUTPUT
       - name: Publish build scans link
         # No scans are produced for PRs from forked repos, so omit this notice for forked PRs.
         if: ${{ !(github.event.pull_request && github.event.pull_request.head.repo.fork) }}
@@ -80,14 +80,14 @@ jobs:
         run: |
           set -x
           KTFMT_FILES=`echo "${{ steps.changed-files.outputs.files }}" | sed 's|[^ ]* *|--file=../&|g' | grep -v "*.txt"`
-          echo "::set-output name=ktfmt-file-args::$KTFMT_FILES"
+          echo "ktfmt-file-args=$KTFMT_FILES" >> $GITHUB_OUTPUT
 
       - name: "Parse changed-files as affected files args"
         id: affected-file-args
         run: |
           set -x
           AFFECTED_FILES=`echo "${{ steps.changed-files.outputs.files_including_removals }}" | sed 's|\([^ ]\+\)|--changedFilePath=\1|g'`
-          echo "::set-output name=files::$AFFECTED_FILES"
+          echo "files=$AFFECTED_FILES" >> $GITHUB_OUTPUT
 
       - name: "Setup Gradle"
         uses: gradle/gradle-build-action@v3-beta
@@ -146,7 +146,7 @@ jobs:
         run: |
           set -x
           RESULT=`.github/ci-control/should_run_project.py --project ${{ matrix.project }} --branch "$BRANCH_REF"`
-          echo "::set-output name=enabled::$RESULT"
+          echo "enabled=$RESULT" >> $GITHUB_OUTPUT
       - name: "Run build"
         uses: ./.github/actions/build-single-project
         if: ${{ steps.check-ci-config.outputs.enabled == 'true' }}

--- a/.github/workflows/update_prebuilts.yml
+++ b/.github/workflows/update_prebuilts.yml
@@ -33,7 +33,7 @@ jobs:
           set -x
           git status
           HAS_CHANGES=`git status --porcelain|grep playground\.properties|wc -l`
-          echo "::set-output name=has_changes::$HAS_CHANGES"
+          echo "has_changes=HAS_CHANGES" >> $GITHUB_OUTPUT
       - name: "Create a PR"
         shell: bash
         id: "create-pr"


### PR DESCRIPTION
set-output is now deprecated. See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Test: GH Workflows