### PR TITLE
Enable set -x when installing NDK on GH runner

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -32,8 +32,10 @@ runs:
       shell: bash
       run: echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "cmake;3.22.1"
     - name: "Install NDK"
+      working-directory: ${{ github.workspace }}
       shell: bash
       run: |
+        set -x
         NDK_VERSION=$(grep "ndkVersion" settings.gradle | awk -F "=" '{gsub(/"| /, ""); print $2}')
         echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;$NDK_VERSION"
     - name: "Install Android SDK Build-Tools"


### PR DESCRIPTION
Test: GH workflows
Change-Id: I424b6753a3421281a4bc429287b0b517dc68ae0d