### PR TITLE
Move ndkVersion setting into a shared .gradle file

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         set -x
-        NDK_VERSION=$(grep "ndkVersion" settings.gradle | awk -F "=" '{gsub(/"| /, ""); print $2}')
+        NDK_VERSION=$(grep "ndkVersion" buildSrc/ndk.gradle | awk -F "=" '{gsub(/"| /, ""); print $2}')
         echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;$NDK_VERSION"
     - name: "Install Android SDK Build-Tools"
       shell: bash

--- a/buildSrc/ndk.gradle
+++ b/buildSrc/ndk.gradle
@@ -1,0 +1,3 @@
+android {
+    ndkVersion = "27.0.12077973"
+}

--- a/playground-projects/activity-playground/settings.gradle
+++ b/playground-projects/activity-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply ../../buildSrc/ndk.gradle
 
 rootProject.name = "activity-playground"
 

--- a/playground-projects/appcompat-playground/settings.gradle
+++ b/playground-projects/appcompat-playground/settings.gradle
@@ -4,7 +4,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply ../../buildSrc/ndk.gradle
 
 rootProject.name = "appcompat-playground"
 

--- a/playground-projects/biometric-playground/settings.gradle
+++ b/playground-projects/biometric-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply ../../buildSrc/ndk.gradle
 
 rootProject.name = "biometric-playground"
 

--- a/playground-projects/collection-playground/settings.gradle
+++ b/playground-projects/collection-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply ../../buildSrc/ndk.gradle
 
 rootProject.name = "collections-playground"
 

--- a/playground-projects/compose/runtime-playground/settings.gradle
+++ b/playground-projects/compose/runtime-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply ../../buildSrc/ndk.gradle
 
 rootProject.name = "compose-runtime"
 

--- a/playground-projects/core-playground/settings.gradle
+++ b/playground-projects/core-playground/settings.gradle
@@ -4,7 +4,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "core-playground"
 

--- a/playground-projects/datastore-playground/settings.gradle
+++ b/playground-projects/datastore-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "datastore-playground"
 

--- a/playground-projects/fragment-playground/settings.gradle
+++ b/playground-projects/fragment-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "fragment-playground"
 

--- a/playground-projects/ktfmt-playground/settings.gradle
+++ b/playground-projects/ktfmt-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 playground {
     setupPlayground("../..")

--- a/playground-projects/lifecycle-playground/settings.gradle
+++ b/playground-projects/lifecycle-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "lifecycle-playground"
 

--- a/playground-projects/navigation-playground/settings.gradle
+++ b/playground-projects/navigation-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "navigation-playground"
 

--- a/playground-projects/paging-playground/settings.gradle
+++ b/playground-projects/paging-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "paging-playground"
 

--- a/playground-projects/room-playground/settings.gradle
+++ b/playground-projects/room-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "room-playground"
 

--- a/playground-projects/sqlite-playground/settings.gradle
+++ b/playground-projects/sqlite-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "sqlite-playground"
 

--- a/playground-projects/work-playground/settings.gradle
+++ b/playground-projects/work-playground/settings.gradle
@@ -20,7 +20,10 @@ pluginManagement {
 }
 plugins {
     id "playground"
+    id "com.android.settings" version "8.7.0-alpha02"
 }
+
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "work-playground"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -83,9 +83,7 @@ apply(plugin: "com.gradle.common-custom-user-data-gradle-plugin")
 apply(plugin: "androidx.build.gradle.gcpbuildcache")
 apply(plugin: "com.android.settings")
 
-android {
-    ndkVersion = "27.0.12077973"
-}
+apply(from: "buildSrc/ndk.gradle")
 
 def BUILD_NUMBER = System.getenv("BUILD_NUMBER")
 develocity {


### PR DESCRIPTION
Playground builds were overriding the installed ndk version due to agp default and lack of ndkVersion declaration in settings.gradle.

Test: ./gradlew datastore:datastore-core:tasks
Change-Id: Id6d8d9cff46ba3aa3e929e4a7df4912672a12f3a