### PR TITLE
Github workflow fixes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ jobs:
           device-specs: Pixel2.arm:30
           use-test-config-files: true
           test-suite-tags: androidx_unit_tests
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: outputs

--- a/.github/workflows/jbpresubmit.yml
+++ b/.github/workflows/jbpresubmit.yml
@@ -86,7 +86,7 @@ jobs:
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
       - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.setup.outputs.checkout_ref }}
           repository: ${{ needs.setup.outputs.checkout_repo }}

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -62,7 +62,7 @@ jobs:
           echo "DIST_DIR=$HOME/dist" >> $GITHUB_ENV
 
       - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Get changed files in push or pull_request"
         id: changed-files
@@ -138,7 +138,7 @@ jobs:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
     steps:
       - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Check if the project should be built"
         id: check-ci-config
         env:
@@ -164,14 +164,14 @@ jobs:
       - name: "Upload build artifacts"
         continue-on-error: true
         if: ${{ steps.check-ci-config.outputs.enabled == 'true' }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts_${{ matrix.project }}
           path: ~/dist
       - name: "Upload daemon logs"
         continue-on-error: true
         if: failure()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: gradle-daemon-logs_${{ matrix.project }}
           path: ~/.gradle/daemon

--- a/.github/workflows/update_prebuilts.yml
+++ b/.github/workflows/update_prebuilts.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout androidx repo"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: "Run update prebuilt snapshot ids script"
         shell: bash
         # this does not update metalava because it needs to match the

--- a/playground-projects/activity-playground/settings.gradle
+++ b/playground-projects/activity-playground/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.android.settings" version "8.7.0-alpha02"
 }
 
-apply ../../buildSrc/ndk.gradle
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "activity-playground"
 

--- a/playground-projects/appcompat-playground/settings.gradle
+++ b/playground-projects/appcompat-playground/settings.gradle
@@ -7,7 +7,7 @@ plugins {
     id "com.android.settings" version "8.7.0-alpha02"
 }
 
-apply ../../buildSrc/ndk.gradle
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "appcompat-playground"
 

--- a/playground-projects/biometric-playground/settings.gradle
+++ b/playground-projects/biometric-playground/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.android.settings" version "8.7.0-alpha02"
 }
 
-apply ../../buildSrc/ndk.gradle
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "biometric-playground"
 

--- a/playground-projects/collection-playground/settings.gradle
+++ b/playground-projects/collection-playground/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.android.settings" version "8.7.0-alpha02"
 }
 
-apply ../../buildSrc/ndk.gradle
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "collections-playground"
 

--- a/playground-projects/compose/runtime-playground/settings.gradle
+++ b/playground-projects/compose/runtime-playground/settings.gradle
@@ -23,7 +23,7 @@ plugins {
     id "com.android.settings" version "8.7.0-alpha02"
 }
 
-apply ../../buildSrc/ndk.gradle
+apply from: "../../buildSrc/ndk.gradle"
 
 rootProject.name = "compose-runtime"
 


### PR DESCRIPTION
Fix incorrect syntax and migrate to actions v4

- The existing version we use (v2) now automatically fails builds / workflows, so we are being forced to migrate.
- A few playground settings.gradle files were applying the ndk.gradle file incorrectly.

Test: GH workflows (tested on dlam/androidx)