### PR TITLE
Use sequences for lazy evaluation

### DIFF
--- a/activity/activity-compose-lint/src/main/java/androidx/activity/compose/lint/CollectProgressDetector.kt
+++ b/activity/activity-compose-lint/src/main/java/androidx/activity/compose/lint/CollectProgressDetector.kt
@@ -50,8 +50,7 @@ class CollectProgressDetector : Detector(), SourceCodeScanner {
                     .orEmpty()
                     .asSequence()
                     .filter { (_, parameter) -> parameter.name == "onBack" }
-                    .keys
-                    .filterIsInstance<ULambdaExpression>()
+                    .mapNotNull { (key, _) -> key as? ULambdaExpression }
                     .firstOrNull() ?: return
 
             // If the parameter is not referenced, immediately trigger the warning

--- a/activity/activity-compose-lint/src/main/java/androidx/activity/compose/lint/CollectProgressDetector.kt
+++ b/activity/activity-compose-lint/src/main/java/androidx/activity/compose/lint/CollectProgressDetector.kt
@@ -48,6 +48,7 @@ class CollectProgressDetector : Detector(), SourceCodeScanner {
             val backLambda =
                 computeKotlinArgumentMapping(node, method)
                     .orEmpty()
+                    .asSequence()
                     .filter { (_, parameter) -> parameter.name == "onBack" }
                     .keys
                     .filterIsInstance<ULambdaExpression>()


### PR DESCRIPTION
## Proposed Changes

Use of Sequences: By converting the collection to a sequence using asSequence(), we enable lazy evaluation, which can improve performance when dealing with large collections by avoiding unnecessary intermediate collections.

Map Not Null: Instead of filtering and then casting, we use mapNotNull to both filter and cast in one step, making the code cleaner.

## Testing

Manually

## Issues Fixed

Use sequences for lazy evaluation
