### PR TITLE
fix: room common js target

### DIFF
--- a/annotation/annotation/build.gradle
+++ b/annotation/annotation/build.gradle
@@ -25,6 +25,7 @@ androidXMultiplatform {
     watchosDeviceArm64()
     watchos()
     tvos()
+    js()
     wasmJs()
 
     defaultPlatform(PlatformIdentifier.JVM)

--- a/room/room-common/build.gradle
+++ b/room/room-common/build.gradle
@@ -36,6 +36,7 @@ androidXMultiplatform {
     mac()
     linux()
     ios()
+    js()
 
     defaultPlatform(PlatformIdentifier.JVM)
 


### PR DESCRIPTION
## Proposed Changes

  - Add Kotlin `js` target to `annotation/annotations`
  - Add Kotlin `js` target to `room/room-common`

## Testing

Test: This modifies the build only, by adding a new Kotlin target; since room-common is just annotations, the build passing is itself the test.



## Issues Fixed

Fixes: _[No JavaScript variant published for Room Common](https://issuetracker.google.com/issues/359296625)_
