### PR TITLE
[AppCompatAutoCompleteTextView] incorrect filtering is not applied after rotating device

### DIFF
--- a/appcompat/appcompat/src/main/java/androidx/appcompat/widget/AppCompatAutoCompleteTextView.java
+++ b/appcompat/appcompat/src/main/java/androidx/appcompat/widget/AppCompatAutoCompleteTextView.java
@@ -374,4 +374,12 @@ public class AppCompatAutoCompleteTextView extends AutoCompleteTextView implemen
         mTextHelper.setCompoundDrawableTintMode(tintMode);
         mTextHelper.applyCompoundDrawablesTints();
     }
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        int threshold = getThreshold();
+        setThreshold(Integer.MAX_VALUE);
+        super.onRestoreInstanceState(state);
+        setThreshold(threshold);
+    }
 }


### PR DESCRIPTION
## Proposed Changes

By this change, the incorrect filtering is not applied to the exposed dropdown menu (AppCompatAutoCompleteTextView) after rotating the device (for details, please see https://github.com/material-components/material-components-android/issues/1464#issue-651036047, https://github.com/material-components/material-components-android/issues/1464#issuecomment-1829309736).

## Testing

Test: Exposed Dropdown Menu Demo in Text Field Demo in Material Components Catalog App (https://github.com/material-components/material-components-android/issues/1464#issue-651036047, https://github.com/material-components/material-components-android/tree/master/catalog)

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/322066510

## See Also

https://android-review.googlesource.com/c/platform/frameworks/support/+/2101234
https://android-review.googlesource.com/c/platform/frameworks/base/+/1965319