### PR TITLE
fix: use `projectOrArtifact` for `benchmark-common` dependency

### DIFF
--- a/benchmark/benchmark-junit4/build.gradle
+++ b/benchmark/benchmark-junit4/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    api(project(":benchmark:benchmark-common"))
+    api(projectOrArtifact(":benchmark:benchmark-common"))
 
     api(libs.junit)
     api(libs.kotlinStdlib)


### PR DESCRIPTION
## Proposed Changes

  - I was following the steps outlined in the [CONTRIBUTING.md](https://github.com/androidx/androidx/blob/androidx-main/CONTRIBUTING.md#checkout-and-importing-a-project) to set up my environment, but I encountered a recurring error after running the following commands:

```shell
cd playground-projects/room-playground
./gradlew studio
```

Error stacktrace: 
```
FAILURE: Build failed with an exception.

* Where:
Settings file 'androidx/playground-projects/room-playground/settings.gradle' line: 32

* What went wrong:
A problem occurred evaluating settings 'room-playground'.
> There are unsupported builds in the project. You can break one of the
  following dependencies by using projectOrArtifact instead of project
  when declaring the dependency.
  ----
  Unsupported Playground Project: :benchmark:benchmark-common
  dependency path to :benchmark:benchmark-common from explicitly requested projects:
  :room:room-benchmark -> :benchmark:benchmark-junit4 -> :benchmark:benchmark-common
  dependency path to :benchmark:benchmark-common from implicitly added projects. If the following list is
  not empty, please file a bug on AndroidX/Github component.
  :benchmark:benchmark-junit4 -> :benchmark:benchmark-common
  :benchmark:benchmark-common
  ----
```

## Testing

Test: The setup was completed successfully after I applied this change, and the environment now runs without errors.

## Issues Fixed

Fixes: fixed setup for `room-playground` project