### PR TITLE
Fix some of playground build issues

### DIFF
--- a/buildSrc/shared-dependencies.gradle
+++ b/buildSrc/shared-dependencies.gradle
@@ -47,7 +47,7 @@ dependencies {
     implementation(libs.protobufGradlePlugin) // needed to compile inspection plugin
     implementation(libs.kotlinPoet) // needed to compile glance-layout-generator
 
-    implementation(libs.protobuf) // needed to compile baseline-profile gradle plugins
+    implementation("com.google.protobuf:protobuf-java:3.22.3") // needed to compile baseline-profile gradle plugins
     implementation(libs.agpTestingPlatformCoreProto) // needed to compile baseline-profile gradle plugins
 
     // dependencies that aren't used by buildSrc directly but that we resolve here so that the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ agpTestingPlatformCoreProto =  { module = "com.google.testing.platform:core-prot
 androidAccessibilityFramework = { module = "com.google.android.apps.common.testing.accessibility.framework:accessibility-test-framework", version = { strictly = "2.1" } }
 androidGradlePluginApi = { module = "com.android.tools.build:gradle-api", version.ref = "androidGradlePlugin" }
 androidGradlePluginz = { module = "com.android.tools.build:gradle", version.ref = "androidGradlePlugin" }
+androidGradleSettingsPlugin = { module = "com.android.tools.build:gradle-settings", version.ref = "androidGradlePlugin" }
 androidLayoutlibApi = { module = "com.android.tools.layoutlib:layoutlib-api", version.ref = "androidLint" }
 androidLint = { module = "com.android.tools.lint:lint", version.ref = "androidLint" }
 androidLintMin = { module = "com.android.tools.lint:lint", version.ref = "androidLintMin" }

--- a/playground-common/playground-plugin/build.gradle
+++ b/playground-common/playground-plugin/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation("supportBuildSrc:private")
     implementation("supportBuildSrc:public")
     implementation("supportBuildSrc:plugins")
+    implementation(libs.androidGradleSettingsPlugin)
     testImplementation(libs.junit)
     testImplementation(libs.truth)
 }

--- a/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundPlugin.kt
+++ b/playground-common/playground-plugin/src/main/kotlin/androidx/playground/PlaygroundPlugin.kt
@@ -22,6 +22,7 @@ import org.gradle.api.initialization.Settings
 class PlaygroundPlugin : Plugin<Settings> {
     override fun apply(settings: Settings) {
         settings.apply(mapOf("plugin" to "playground-develocity-conventions"))
+        settings.apply(mapOf("plugin" to "com.android.settings"))
         settings.extensions.create("playground", PlaygroundExtension::class.java, settings)
         validateJvm(settings)
     }

--- a/playground-projects/activity-playground/settings.gradle
+++ b/playground-projects/activity-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/appcompat-playground/settings.gradle
+++ b/playground-projects/appcompat-playground/settings.gradle
@@ -4,7 +4,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/biometric-playground/settings.gradle
+++ b/playground-projects/biometric-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/collection-playground/settings.gradle
+++ b/playground-projects/collection-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/compose/runtime-playground/settings.gradle
+++ b/playground-projects/compose/runtime-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/core-playground/settings.gradle
+++ b/playground-projects/core-playground/settings.gradle
@@ -4,7 +4,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/datastore-playground/settings.gradle
+++ b/playground-projects/datastore-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/fragment-playground/settings.gradle
+++ b/playground-projects/fragment-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/ktfmt-playground/settings.gradle
+++ b/playground-projects/ktfmt-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/lifecycle-playground/settings.gradle
+++ b/playground-projects/lifecycle-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/navigation-playground/settings.gradle
+++ b/playground-projects/navigation-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/paging-playground/settings.gradle
+++ b/playground-projects/paging-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/room-playground/settings.gradle
+++ b/playground-projects/room-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/sqlite-playground/settings.gradle
+++ b/playground-projects/sqlite-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"

--- a/playground-projects/work-playground/settings.gradle
+++ b/playground-projects/work-playground/settings.gradle
@@ -20,7 +20,6 @@ pluginManagement {
 }
 plugins {
     id "playground"
-    id "com.android.settings" version "8.7.0-alpha02"
 }
 
 apply from: "../../buildSrc/ndk.gradle"


### PR DESCRIPTION
## Proposed Changes

- Move to PlaygroundPlugin for applying com.android.settings plugin this allows us to use the same version without it being spread to many files
- Pick a protobuf-java version (3.22.3) that works with AGP in shared-dependnecies.gradle

## Testing

Test: ./gradlew bOS
