### PR TITLE
Avoid double-traversal to find root coordinates in the `boundsInWindow` method

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/LayoutCoordinates.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/layout/LayoutCoordinates.kt
@@ -195,7 +195,7 @@ fun LayoutCoordinates.boundsInWindow(): Rect {
     val rootWidth = root.size.width.toFloat()
     val rootHeight = root.size.height.toFloat()
 
-    val bounds = boundsInRoot()
+    val bounds = root.localBoundingBoxOf(this)
     val boundsLeft = bounds.left.fastCoerceIn(0f, rootWidth)
     val boundsTop = bounds.top.fastCoerceIn(0f, rootHeight)
     val boundsRight = bounds.right.fastCoerceIn(0f, rootWidth)


### PR DESCRIPTION
## Proposed Changes

- Replace `boundsInRoot()` with `root.localBoundingBoxOf(this)`, because `boundsInRoot()` does yet another `findRootCoordinates()` pass which is redundant at this point, since we've just found the root coordinates a few lines above

## Testing

Test: I tested it manually in my local fork of this method, plus, existing tests should cover it.

## Issues Fixed

...
