### PR TITLE
Add support for List<Enum> arguments in typesafe navigation

### DIFF
--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/serialization/RouteDecoderTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/serialization/RouteDecoderTest.kt
@@ -212,6 +212,46 @@ abstract class RouteDecoderTest(val source: ArgumentSource) {
     }
 
     @Test
+    fun decodeEnumList() {
+        @Serializable class TestClass(val arg: List<TestEnum>)
+
+        val map = mapOf("arg" to listOf(TestEnum.TWO, TestEnum.TWO))
+        val result =
+            decode<TestClass>(
+                map,
+                listOf(
+                    navArgument("arg") { type = InternalNavType.EnumListType(TestEnum::class.java) }
+                )
+            )
+        assertThat(result.arg).isEqualTo(listOf(TestEnum.TWO, TestEnum.TWO))
+    }
+
+    @Test
+    fun decodeEnumListNullable() {
+        @Serializable class TestClass(val arg: List<TestEnum>?)
+
+        val values = mapOf("arg" to listOf(TestEnum.TWO, TestEnum.TWO))
+        val result =
+            decode<TestClass>(
+                values,
+                listOf(
+                    navArgument("arg") { type = InternalNavType.EnumListType(TestEnum::class.java) }
+                )
+            )
+        assertThat(result.arg).isEqualTo(listOf(TestEnum.TWO, TestEnum.TWO))
+
+        val values2 = mapOf("arg" to null)
+        val result2 =
+            decode<TestClass>(
+                values2,
+                listOf(
+                    navArgument("arg") { type = InternalNavType.EnumListType(TestEnum::class.java) }
+                )
+            )
+        assertThat(result2.arg).isNull()
+    }
+
+    @Test
     fun decodeIntString() {
         @Serializable @SerialName(PATH_SERIAL_NAME) class TestClass(val arg: Int, val arg2: String)
 
@@ -403,6 +443,12 @@ abstract class RouteDecoderTest(val source: ArgumentSource) {
     }
 
     @Serializable private class CustomType(val nestedArg: Int)
+
+    @Serializable
+    private enum class TestEnum {
+        ONE,
+        TWO
+    }
 
     private val customNavType =
         navArgument("arg") {

--- a/navigation/navigation-common/src/androidTest/java/androidx/navigation/serialization/RouteFilledTest.kt
+++ b/navigation/navigation-common/src/androidTest/java/androidx/navigation/serialization/RouteFilledTest.kt
@@ -841,6 +841,32 @@ class RouteFilledTest {
             }
         assertThatRouteFilledFrom(clazz, listOf(arg)).isEqualTo("$PATH_SERIAL_NAME")
     }
+
+    @Test
+    fun encodeEnumList() {
+        @Serializable @SerialName(PATH_SERIAL_NAME) class TestClass(val arg: List<TestEnum>)
+
+        val clazz = TestClass(listOf(TestEnum.ONE, TestEnum.TWO))
+        val arg =
+            navArgument("arg") {
+                type = InternalNavType.EnumListType(TestEnum::class.java)
+                nullable = false
+            }
+        assertThatRouteFilledFrom(clazz, listOf(arg)).isEqualTo("$PATH_SERIAL_NAME?arg=ONE&arg=TWO")
+    }
+
+    @Test
+    fun encodeEnumListNullable() {
+        @Serializable @SerialName(PATH_SERIAL_NAME) class TestClass(val arg: List<TestEnum>?)
+
+        val clazz = TestClass(null)
+        val arg =
+            navArgument("arg") {
+                type = InternalNavType.EnumListType(TestEnum::class.java)
+                nullable = true
+            }
+        assertThatRouteFilledFrom(clazz, listOf(arg)).isEqualTo(PATH_SERIAL_NAME)
+    }
 }
 
 private fun <T : Any> assertThatRouteFilledFrom(

--- a/navigation/navigation-common/src/main/java/androidx/navigation/serialization/NavTypeConverter.kt
+++ b/navigation/navigation-common/src/main/java/androidx/navigation/serialization/NavTypeConverter.kt
@@ -101,6 +101,11 @@ internal fun SerialDescriptor.getNavType(): NavType<*> {
                     InternalType.LONG -> NavType.LongListType
                     InternalType.STRING -> NavType.StringListType
                     InternalType.STRING_NULLABLE -> InternalNavType.StringNullableListType
+                    InternalType.ENUM ->
+                        @Suppress("UNCHECKED_CAST")
+                        InternalNavType.EnumListType(
+                            getElementDescriptor(0).getClass() as Class<Enum<*>>
+                        )
                     else -> UNKNOWN
                 }
             }
@@ -470,6 +475,46 @@ internal object InternalNavType {
 
             override fun emptyCollection(): List<Double> = emptyList()
         }
+
+    class EnumListType<D : Enum<*>>(type: Class<D>) : CollectionNavType<List<D>?>(true) {
+        private val enumNavType = EnumType(type)
+
+        override val name: String
+            get() = "List<${enumNavType.name}}>"
+
+        override fun put(bundle: Bundle, key: String, value: List<D>?) {
+            bundle.putSerializable(key, value?.let { ArrayList(value) })
+        }
+
+        @Suppress("DEPRECATION", "UNCHECKED_CAST")
+        override fun get(bundle: Bundle, key: String): List<D>? = (bundle[key] as? List<D>?)
+
+        override fun parseValue(value: String): List<D> = listOf(enumNavType.parseValue(value))
+
+        override fun parseValue(value: String, previousValue: List<D>?): List<D>? =
+            previousValue?.plus(parseValue(value)) ?: parseValue(value)
+
+        override fun valueEquals(value: List<D>?, other: List<D>?): Boolean {
+            val valueArrayList = value?.let { ArrayList(value) }
+            val otherArrayList = other?.let { ArrayList(other) }
+            return valueArrayList == otherArrayList
+        }
+
+        override fun serializeAsValues(value: List<D>?): List<String> =
+            value?.map { it.toString() } ?: emptyList()
+
+        override fun emptyCollection(): List<D> = emptyList()
+
+        public override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is EnumListType<*>) return false
+            return enumNavType == other.enumNavType
+        }
+
+        public override fun hashCode(): Int {
+            return enumNavType.hashCode()
+        }
+    }
 
     class EnumNullableType<D : Enum<*>?>(type: Class<D?>) : SerializableNullableType<D?>(type) {
         private val type: Class<D?>

--- a/navigation/navigation-common/src/test/java/androidx/navigation/serialization/NavArgumentGeneratorTest.kt
+++ b/navigation/navigation-common/src/test/java/androidx/navigation/serialization/NavArgumentGeneratorTest.kt
@@ -653,6 +653,34 @@ class NavArgumentGeneratorTest {
     }
 
     @Test
+    fun convertToEnumList() {
+        @Serializable class TestClass(val arg: List<TestEnum>)
+
+        val converted = serializer<TestClass>().generateNavArguments()
+        val expected =
+            navArgument("arg") {
+                type = InternalNavType.EnumListType(TestEnum::class.java)
+                nullable = false
+            }
+        assertThat(converted).containsExactlyInOrder(expected)
+        assertThat(converted[0].argument.isDefaultValueUnknown).isFalse()
+    }
+
+    @Test
+    fun convertToEnumListNullable() {
+        @Serializable class TestClass(val arg: List<TestEnum>?)
+
+        val converted = serializer<TestClass>().generateNavArguments()
+        val expected =
+            navArgument("arg") {
+                type = InternalNavType.EnumListType(TestEnum::class.java)
+                nullable = true
+            }
+        assertThat(converted).containsExactlyInOrder(expected)
+        assertThat(converted[0].argument.isDefaultValueUnknown).isFalse()
+    }
+
+    @Test
     fun convertToParcelable() {
         @Serializable
         class TestParcelable : Parcelable {

--- a/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerRouteTest.kt
+++ b/navigation/navigation-runtime/src/androidTest/java/androidx/navigation/NavControllerRouteTest.kt
@@ -5252,6 +5252,42 @@ class NavControllerRouteTest {
 
     @UiThreadTest
     @Test
+    fun testNavigateWithObjectEnumList() {
+        @Serializable @SerialName("test") class TestClass(val arg: List<TestEnum>)
+
+        val navController = createNavController()
+        navController.graph =
+            navController.createGraph(
+                startDestination = TestClass(listOf(TestEnum.ONE, TestEnum.TWO))
+            ) {
+                test<TestClass>()
+            }
+        assertThat(navController.currentDestination?.route).isEqualTo("test?arg={arg}")
+        val route = navController.currentBackStackEntry?.toRoute<TestClass>()
+        assertThat(route!!.arg).containsExactly(TestEnum.ONE, TestEnum.TWO)
+    }
+
+    @UiThreadTest
+    @Test
+    fun testNavigateWithObjectNullEnumList() {
+        @Serializable @SerialName("test") class TestClass(val arg: List<TestEnum>? = null)
+
+        val navController = createNavController()
+        navController.graph =
+            navController.createGraph(startDestination = TestClass(null)) { test<TestClass>() }
+
+        assertThat(navController.currentDestination?.route).isEqualTo("test?arg={arg}")
+        val route = navController.currentBackStackEntry?.toRoute<TestClass>()
+        assertThat(route!!.arg).isNull()
+
+        navController.navigate(TestClass(listOf(TestEnum.ONE, TestEnum.TWO)))
+        assertThat(navController.currentDestination?.route).isEqualTo("test?arg={arg}")
+        val route2 = navController.currentBackStackEntry?.toRoute<TestClass>()
+        assertThat(route2!!.arg).containsExactly(TestEnum.ONE, TestEnum.TWO)
+    }
+
+    @UiThreadTest
+    @Test
     fun testNavigateWithObjectValueClass() {
         @Serializable @SerialName("test") class TestClass(val arg: TestValueClass)
         val navType =


### PR DESCRIPTION
## Proposed Changes

Add support for List<Enum> arguments in typesafe navigation

## Testing

Test: ./gradlew navigation:navigation-common:test
Test: ./gradlew navigation:navigation-common:cC
Test: ./gradlew navigation:navigation-runtime:cC

## Issues Fixed

Fixes: 375559962
