### PR TITLE
Fix compose runtime playground contributing build failed

### DIFF
--- a/playground-projects/compose/runtime-playground/settings.gradle
+++ b/playground-projects/compose/runtime-playground/settings.gradle
@@ -22,7 +22,7 @@ plugins {
     id "playground"
 }
 
-apply from: "../../buildSrc/ndk.gradle"
+apply from: "../../../buildSrc/ndk.gradle"
 
 rootProject.name = "compose-runtime"
 


### PR DESCRIPTION
## Proposed Changes

  - Fixed an issue with the NDK script path by updating the relative path to ndk.gradle. The previous path caused a build error as the file location was incorrect. This change ensures the build script correctly locates ndk.gradle, resolving the 'file does not exist' error.

## Testing

Test: `None`

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/378121123
