### PR TITLE
Fix Unsupported Playground Project :benchmark:benchmark-common

### DIFF
--- a/compose/benchmark-utils/build.gradle
+++ b/compose/benchmark-utils/build.gradle
@@ -33,7 +33,7 @@ plugins {
 dependencies {
     api("androidx.activity:activity:1.2.0")
     api(project(":compose:test-utils"))
-    api(project(":benchmark:benchmark-junit4"))
+    api(projectOrArtifact(":benchmark:benchmark-junit4"))
 
     implementation(libs.kotlinStdlibCommon)
     implementation(project(":compose:runtime:runtime"))

--- a/compose/runtime/runtime/compose-runtime-benchmark/build.gradle
+++ b/compose/runtime/runtime/compose-runtime-benchmark/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     androidTestImplementation(libs.kotlinStdlib)
     androidTestImplementation(libs.kotlinReflect)
     androidTestImplementation(libs.kotlinCoroutinesTest)
-    androidTestImplementation(project(":benchmark:benchmark-junit4"))
+    androidTestImplementation(projectOrArtifact(":benchmark:benchmark-junit4"))
     androidTestImplementation("androidx.activity:activity:1.2.0")
     androidTestImplementation(project(":activity:activity-compose"))
     // old version of common-java8 conflicts with newer version, because both have

--- a/navigation/navigation-benchmark/build.gradle
+++ b/navigation/navigation-benchmark/build.gradle
@@ -31,8 +31,8 @@ plugins {
 }
 
 dependencies {
-    androidTestImplementation(project(":benchmark:benchmark-common"))
-    androidTestImplementation(project(":benchmark:benchmark-junit4"))
+    androidTestImplementation(projectOrArtifact(":benchmark:benchmark-common"))
+    androidTestImplementation(projectOrArtifact(":benchmark:benchmark-junit4"))
     androidTestImplementation(project(":internal-testutils-navigation"))
     androidTestImplementation(project(":navigation:navigation-common"))
     androidTestImplementation(project(":navigation:navigation-runtime"))


### PR DESCRIPTION
## Proposed Changes

  - This update fixes build issues by switching from `project` to `projectOrArtifact` for the `:benchmark:benchmark-junit4` and `:benchmark:benchmark-common` dependencies.

## Testing

Test: `none`

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/377642759
