### PR TITLE
Update Java Version in Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ creating a fork of the [androidx/androidx](https://github.com/androidx/androidx)
 
   ```bash
   # You could also add this to your .{bash|zsh}rc file.
-  export JAVA_HOME="location of JDK 17 directory"
+  export JAVA_HOME="location of JDK 21 directory"
   export ANDROID_SDK_ROOT="location of the Android SDK directory"
   ```
 


### PR DESCRIPTION
## Proposed Changes

  - Update Java Version in Contribution Guide

## Testing

Test: `none`

## Issues Fixed

Fixes: 
```
FAILURE: Build failed with an exception.

* Where:
Settings file '/Users/h.kahloun/Documents/GitHub/androidx/playground-projects/room-playground/settings.gradle' line: 22

* What went wrong:
An exception occurred applying plugin request [id: 'playground']
> Failed to apply plugin 'playground'.
   > AndroidX build must be invoked with JDK 21.
     Make sure your JAVA_HOME environment variable points to Java 21 JDK.
     Current version: 17
     Current JAVA HOME: /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Get more help at https://help.gradle.org.
```
