### PR TITLE
[262773946] Fix getThumbnailUri method to return the COLUMN_THUMBNAIL…

### DIFF
--- a/tvprovider/tvprovider/src/main/java/androidx/tvprovider/media/tv/BaseProgram.java
+++ b/tvprovider/tvprovider/src/main/java/androidx/tvprovider/media/tv/BaseProgram.java
@@ -199,7 +199,7 @@ public abstract class BaseProgram {
      * @see androidx.tvprovider.media.tv.TvContractCompat.Programs#COLUMN_THUMBNAIL_URI
      */
     public Uri getThumbnailUri() {
-        String uri = mValues.getAsString(Programs.COLUMN_POSTER_ART_URI);
+        String uri = mValues.getAsString(Programs.COLUMN_THUMBNAIL_URI);
         return uri == null ? null : Uri.parse(uri);
     }
 


### PR DESCRIPTION
Fix `getThumbnailUri` method to return the COLUMN_THUMBNAIL_URI column instead of COLUMN_POSTER_ART_URI.

Android TVProvider is library to support sending recommendation to the TV launcher. It provides adding a thumbnail and poster uri to the recommendation. However the `getThumbnailUri` [method](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/tvprovider/tvprovider/src/main/java/androidx/tvprovider/media/tv/BaseProgram.java#201) looks at the same column as the `getPosterArtUri` [method](https://android.googlesource.com/platform/frameworks/support/+/refs/heads/androidx-main/tvprovider/tvprovider/src/main/java/androidx/tvprovider/media/tv/BaseProgram.java#192). This PR fixes the issue by making `getThumbnailUri` the look at the right column.

Fixes: [b/262773946](https://issuetracker.google.com/issues/262773946)