### PR TITLE
Add enabled param to PullToRefreshBox

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/pulltorefresh/PullToRefresh.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/pulltorefresh/PullToRefresh.kt
@@ -145,10 +145,11 @@ fun PullToRefreshBox(
             state = state
         )
     },
+    enabled: Boolean = true,
     content: @Composable BoxScope.() -> Unit
 ) {
     Box(
-        modifier.pullToRefresh(state = state, isRefreshing = isRefreshing, onRefresh = onRefresh),
+        modifier.pullToRefresh(state = state, isRefreshing = isRefreshing, onRefresh = onRefresh, enabled = enabled),
         contentAlignment = contentAlignment
     ) {
         content()


### PR DESCRIPTION
## Proposed Changes

`PullToRefreshBox` doesn't have the option to enalbe/disable `PullToRefresh`. Added this param to handle this behaviour.

## Testing

Test: Manually

