### PR TITLE
Make the `libs.kotlinCoroutinesCore` dependency in the Compose Runtime module an `api` module dependency in the `commonMain` source set

### DIFF
--- a/compose/runtime/runtime/build.gradle
+++ b/compose/runtime/runtime/build.gradle
@@ -44,7 +44,7 @@ androidXMultiplatform {
         commonMain {
             dependencies {
                 implementation(libs.kotlinStdlibCommon)
-                implementation(libs.kotlinCoroutinesCore)
+                api(libs.kotlinCoroutinesCore)
                 implementation(project(":collection:collection"))
             }
         }
@@ -78,7 +78,6 @@ androidXMultiplatform {
             dependsOn(nonEmulatorJvmMain)
             dependencies {
                 implementation(libs.kotlinStdlib)
-                api(libs.kotlinCoroutinesCore)
             }
         }
 


### PR DESCRIPTION
## Proposed Changes

- Make the `libs.kotlinCoroutinesCore` dependency in the Compose Runtime module an `api` module dependency in the `commonMain` source set

  Coroutines is an `api` module dependency on the JVM and Android targets, but not on the other targets. I discovered this while working on a Compose Multiplatform project and realized that I had to manually add the Coroutines dependency to use `launchedEffect`. I think this inconsistency should be fixed unless it's intended.

## Testing

Test: Run `./gradlew test connectedCheck` in "playground-projects/compose/runtime-playground"
