### PR TITLE
Simplify `NavController.currentBackStackEntryAsState` with an expression body

### DIFF
--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHostController.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHostController.kt
@@ -38,9 +38,8 @@ import androidx.navigation.Navigator
  * @return a mutable state of the current back stack entry
  */
 @Composable
-public fun NavController.currentBackStackEntryAsState(): State<NavBackStackEntry?> {
-    return currentBackStackEntryFlow.collectAsState(null)
-}
+public fun NavController.currentBackStackEntryAsState(): State<NavBackStackEntry?> =
+    currentBackStackEntryFlow.collectAsState(null)
 
 /**
  * Creates a NavHostController that handles the adding of the [ComposeNavigator] and


### PR DESCRIPTION
## Proposed Changes

- Simplify `NavController.currentBackStackEntryAsState` with an expression body

  This change stems from the work done in #740.

## Testing

Test: Run `./gradlew :navigation:navigation-compose:connectedCheck` in "playground-projects/navigation-playground"