### PR TITLE
Simplify and improve `previousBackStackEntry` in `NavController`

### DIFF
--- a/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
+++ b/navigation/navigation-runtime/src/main/java/androidx/navigation/NavController.kt
@@ -2963,14 +2963,10 @@ public open class NavController(
      *   two visible entries
      */
     public open val previousBackStackEntry: NavBackStackEntry?
-        get() {
-            val iterator = backQueue.reversed().iterator()
+        get() = backQueue.asReversed().asSequence()
             // throw the topmost destination away.
-            if (iterator.hasNext()) {
-                iterator.next()
-            }
-            return iterator.asSequence().firstOrNull { entry -> entry.destination !is NavGraph }
-        }
+            .drop(1)
+            .firstOrNull { entry -> entry.destination !is NavGraph }
 
     public companion object {
         private const val TAG = "NavController"


### PR DESCRIPTION
## Proposed Changes

- Simplify and improve `previousBackStackEntry` in `NavController`

  `asReversed` is used instead of `reversed` to reduce the cost of copying a list. The reversed list is converted to a `Sequence` earlier and `drop(1)` is used instead of the iterator to simplify the code.

  This change stems from the work done in #740. This change should also conflict with that PR. I can rebase/merge from that PR here, or rebase/merge from this PR in that PR if either of them is merged into the main branch first.

## Testing

Test: Run `./gradlew :navigation:navigation-runtime:connectedCheck` in "playground-projects/navigation-playground"