### PR TITLE
Fix a possible typo `inPredictiveBack` in local variable names, replacing it with `isPredictiveBack`

### DIFF
--- a/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
+++ b/navigation/navigation-compose/src/main/java/androidx/navigation/compose/NavHost.kt
@@ -510,7 +510,7 @@ public fun NavHost(
     val currentBackStack by composeNavigator.backStack.collectAsState()
 
     var progress by remember { mutableFloatStateOf(0f) }
-    var inPredictiveBack by remember { mutableStateOf(false) }
+    var isPredictiveBack by remember { mutableStateOf(false) }
     PredictiveBackHandler(currentBackStack.size > 1) { backEvent ->
         var currentBackStackEntry: NavBackStackEntry? = null
         if (currentBackStack.size > 1) {
@@ -523,17 +523,17 @@ public fun NavHost(
         try {
             backEvent.collect {
                 if (currentBackStack.size > 1) {
-                    inPredictiveBack = true
+                    isPredictiveBack = true
                     progress = it.progress
                 }
             }
             if (currentBackStack.size > 1) {
-                inPredictiveBack = false
+                isPredictiveBack = false
                 composeNavigator.popBackStack(currentBackStackEntry!!, false)
             }
         } catch (e: CancellationException) {
             if (currentBackStack.size > 1) {
-                inPredictiveBack = false
+                isPredictiveBack = false
             }
         }
     }
@@ -565,7 +565,7 @@ public fun NavHost(
         val finalEnter: AnimatedContentTransitionScope<NavBackStackEntry>.() -> EnterTransition = {
             val targetDestination = targetState.destination as ComposeNavigator.Destination
 
-            if (composeNavigator.isPop.value || inPredictiveBack) {
+            if (composeNavigator.isPop.value || isPredictiveBack) {
                 targetDestination.hierarchy.firstNotNullOfOrNull { destination ->
                     destination.createPopEnterTransition(this)
                 } ?: popEnterTransition.invoke(this)
@@ -579,7 +579,7 @@ public fun NavHost(
         val finalExit: AnimatedContentTransitionScope<NavBackStackEntry>.() -> ExitTransition = {
             val initialDestination = initialState.destination as ComposeNavigator.Destination
 
-            if (composeNavigator.isPop.value || inPredictiveBack) {
+            if (composeNavigator.isPop.value || isPredictiveBack) {
                 initialDestination.hierarchy.firstNotNullOfOrNull { destination ->
                     destination.createPopExitTransition(this)
                 } ?: popExitTransition.invoke(this)
@@ -615,7 +615,7 @@ public fun NavHost(
 
         val transition = rememberTransition(transitionState, label = "entry")
 
-        if (inPredictiveBack) {
+        if (isPredictiveBack) {
             LaunchedEffect(progress) {
                 val previousEntry = currentBackStack[currentBackStack.size - 2]
                 transitionState.seekTo(progress, previousEntry)
@@ -664,7 +664,7 @@ public fun NavHost(
                     val targetZIndex =
                         when {
                             targetState.id == initialState.id -> initialZIndex
-                            composeNavigator.isPop.value || inPredictiveBack -> initialZIndex - 1f
+                            composeNavigator.isPop.value || isPredictiveBack -> initialZIndex - 1f
                             else -> initialZIndex + 1f
                         }.also { zIndices[targetState.id] = it }
 
@@ -688,7 +688,7 @@ public fun NavHost(
             // AnimatedContent will just skip attempting to transition the old entry.
             // See https://issuetracker.google.com/238686802
             val currentEntry =
-                if (inPredictiveBack) {
+                if (isPredictiveBack) {
                     // We have to do this because the previous entry does not show up in
                     // visibleEntries
                     // even if we prepare it above as part of onBackStackChangeStarted

--- a/wear/compose/compose-navigation/src/main/java/androidx/wear/compose/navigation/PredictiveBackNavHost.kt
+++ b/wear/compose/compose-navigation/src/main/java/androidx/wear/compose/navigation/PredictiveBackNavHost.kt
@@ -138,25 +138,25 @@ internal fun PredictiveBackNavHost(
 
     // Use PredictiveBackHandler instead of BackHandler on API >= 35
     var progress by remember { mutableFloatStateOf(0f) }
-    var inPredictiveBack by remember { mutableStateOf(false) }
+    var isPredictiveBack by remember { mutableStateOf(false) }
     val transitionState = remember { SeekableTransitionState(current) }
     PredictiveBackHandler(userSwipeEnabled && backStack.size > 1) { backEvent ->
-        inPredictiveBack = true
+        isPredictiveBack = true
         progress = 0f
         try {
             backEvent.collect { progress = it.progress }
             Animatable(progress).animateTo(1f, TRANSITION_ANIMATION_SPEC) { progress = value }
-            inPredictiveBack = false
+            isPredictiveBack = false
             navigateBack()
         } catch (e: CancellationException) {
-            inPredictiveBack = false
+            isPredictiveBack = false
         }
     }
 
     val zIndices = remember { mutableObjectFloatMapOf<String>() }
     val transition = rememberTransition(transitionState, label = "entry")
 
-    if (inPredictiveBack && previous != null) {
+    if (isPredictiveBack && previous != null) {
         LaunchedEffect(progress) { transitionState.seekTo(progress, previous) }
     } else {
         LaunchedEffect(current) {
@@ -188,17 +188,17 @@ internal fun PredictiveBackNavHost(
             val targetZIndex =
                 when {
                     targetState.id == initialState.id -> initialZIndex
-                    wearNavigator.isPop.value || inPredictiveBack ->
+                    wearNavigator.isPop.value || isPredictiveBack ->
                         initialZIndex - 1f // Going to the previous page, so zIndex - 1
                     else -> initialZIndex + 1f // Going to the next page, so zIndex + 1
                 }.also { zIndices[targetState.id] = it }
 
             ContentTransform(
                 targetContentEnter =
-                    if (wearNavigator.isPop.value || inPredictiveBack) POP_ENTER_TRANSITION
+                    if (wearNavigator.isPop.value || isPredictiveBack) POP_ENTER_TRANSITION
                     else ENTER_TRANSITION,
                 initialContentExit =
-                    if (wearNavigator.isPop.value || inPredictiveBack) POP_EXIT_TRANSITION
+                    if (wearNavigator.isPop.value || isPredictiveBack) POP_EXIT_TRANSITION
                     else EXIT_TRANSITION,
                 targetContentZIndex = targetZIndex,
                 sizeTransform = null
@@ -212,7 +212,7 @@ internal fun PredictiveBackNavHost(
         // part of visible entries since it was cleared from the back stack and is not
         // animating.
         val currentEntry =
-            if (wearNavigator.isPop.value || inPredictiveBack) {
+            if (wearNavigator.isPop.value || isPredictiveBack) {
                 // We have to do this because the previous entry might not show up in backStack
                 it
             } else {


### PR DESCRIPTION
## Proposed Changes

- Fix a possible typo `inPredictiveBack` in local variable names, replacing it with `isPredictiveBack`
  The variable names `isPredictiveBack` and `isPredictiveBackInProgress` are used elsewhere, so I think this should be a typo. `inPredictiveBack` also doesn't make sense by itself.

## Testing

Test: Run `./gradlew :navigation:connectedCheck` in "playground-projects/navigation-playground".