### PR TITLE
Update outdated documentation link to semantics traversal order

### DIFF
--- a/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/semantics/SemanticsProperties.kt
+++ b/compose/ui/ui/src/commonMain/kotlin/androidx/compose/ui/semantics/SemanticsProperties.kt
@@ -871,7 +871,7 @@ var SemanticsPropertyReceiver.isContainer by SemanticsProperties.IsContainer
 /**
  * Whether this semantics node is a traversal group.
  *
- * See https://developer.android.com/jetpack/compose/accessibility#modify-traversal-order
+ * See https://developer.android.com/develop/ui/compose/accessibility/traversal
  *
  * @see SemanticsProperties.IsTraversalGroup
  */


### PR DESCRIPTION
## Proposed Changes

- Update a link in `SematicsProperties`'s `IsTraversalGroup` documentation block that leads to a non-existent page

## Testing

N/A

## Issues Fixed

N/A


