### PR TITLE
Remove unused kotlin-reflect dependency from glance-appwidget-preview

### DIFF
--- a/glance/glance-appwidget-preview/build.gradle
+++ b/glance/glance-appwidget-preview/build.gradle
@@ -33,7 +33,6 @@ plugins {
 dependencies {
 
     api(libs.kotlinStdlib)
-    api(libs.kotlinReflect)
     api(libs.kotlinCoroutinesAndroid)
 
     implementation("androidx.core:core:1.1.0")


### PR DESCRIPTION
## Proposed Changes
Aside from being unused, this imposes significant downstream effects on consumers, including changes to how kotlinc generates KClass references and `typeOf()` implementations.

## Testing

Test: Its existing tests should pass

## Issues Fixed
