### PR TITLE
room-paging refresh initial load fix

### DIFF
--- a/room/room-paging/src/commonMain/kotlin/androidx/room/paging/util/RoomPagingUtil.kt
+++ b/room/room-paging/src/commonMain/kotlin/androidx/room/paging/util/RoomPagingUtil.kt
@@ -83,7 +83,7 @@ public fun getOffset(params: LoadParams<Int>, key: Int, itemCount: Int): Int {
             }
         is Append -> key
         is Refresh ->
-            if (key >= itemCount) {
+            if (key >= itemCount - params.loadSize) {
                 maxOf(0, itemCount - params.loadSize)
             } else {
                 key


### PR DESCRIPTION
## Proposed Changes

If items are removed then the initial key for a refresh may be close enough to the end of the list that fewer than a screens-worth of items may be loaded causing the UI to jump. Changed to handle similarly to the case where the initial key larger than itemCount and load loadSize items from the end.

## Testing

Test: ./gradlew test connectedCheck

## Issues Fixed

Fixes: b/389729367
