### PR TITLE
Backport request orientation cache

### DIFF
--- a/core/core/src/main/java/androidx/core/app/ComponentActivity.kt
+++ b/core/core/src/main/java/androidx/core/app/ComponentActivity.kt
@@ -50,6 +50,8 @@ public open class ComponentActivity : Activity(), LifecycleOwner, KeyEventDispat
      */
     @Suppress("LeakingThis") private val lifecycleRegistry = LifecycleRegistry(this)
 
+    private var lastRequestedOrientation: Int = SCREEN_ORIENTATION_UNSET
+
     /**
      * Store an instance of [ExtraData] for later retrieval by class name via [getExtraData].
      *
@@ -110,6 +112,27 @@ public open class ComponentActivity : Activity(), LifecycleOwner, KeyEventDispat
         } else KeyEventDispatcher.dispatchKeyEvent(this, decor, this, event)
     }
 
+    override fun setRequestedOrientation(orientation: Int) {
+        // Sets this Activity's orientation, only if the orientation value has changed or if a
+        // value hasn't been previously set. This avoids unnecessary Binder calls, which
+        // can be expensive. This caching was added to Activity.java in API level 35.
+        if (Build.VERSION.SDK_INT >= 35) {
+            super.setRequestedOrientation(orientation)
+        } else if (orientation != lastRequestedOrientation) {
+            lastRequestedOrientation = orientation
+            super.setRequestedOrientation(orientation)
+        }
+    }
+
+    override fun getRequestedOrientation(): Int {
+        // See setRequestedOrientation() above.
+        if (Build.VERSION.SDK_INT >= 35 || lastRequestedOrientation == SCREEN_ORIENTATION_UNSET) {
+            return super.getRequestedOrientation()
+        } else {
+            return lastRequestedOrientation
+        }
+    }
+
     /**
      * Checks if the internal state should be dump, as some special args are handled by [Activity]
      * itself.
@@ -155,4 +178,11 @@ public open class ComponentActivity : Activity(), LifecycleOwner, KeyEventDispat
       {@link View#setTag(int, Object)} with the window's decor view."""
     )
     public open class ExtraData
+
+    private companion object {
+        /**
+         * Value copied from ActivityInfo.SCREEN_ORIENTATION_UNSET (internal field)
+         */
+        private const val SCREEN_ORIENTATION_UNSET = -2
+    }
 }


### PR DESCRIPTION
API 35 / Android 15 added a field cache to `Activity.setRequestedOrientation()` because every call would lead to an IPC call, which can be expensive and hammer the system.

https://cs.android.com/android/_/android/platform/frameworks/base/+/14b59e53b82dbeb93ca1c8ac612c13d62c8672e9

## Proposed Changes

This change backports the API 35 behavior.

Note: I made the change in `androidx.core.app.ComponentActivity` as that's the top level base activity class. Let me know if you'd like me to move it somewhere else instead (or feel free to just edit).

## Testing

Test: we tested this change in our own base activity class in the Square Point of Sale app.

## Issues Fixed

Fixes: 265021810 (not public, I couldn't read it, but it's referenced in the Android 15 change)
