### PR TITLE
Coerce slider range when dragging to avoid overlap

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
@@ -2323,7 +2323,6 @@ private val ThumbSize = DpSize(ThumbWidth, ThumbHeight)
 private val VerticalThumbSize = DpSize(ThumbHeight, ThumbWidth)
 private val ThumbTrackGapSize: Dp = SliderTokens.ActiveHandleLeadingSpace
 private val TrackInsideCornerSize: Dp = 2.dp
-private const val SliderRangeTolerance = 0.0001
 
 private enum class SliderComponents {
     THUMB,
@@ -2684,14 +2683,14 @@ class RangeSliderState(
                 val offsetEnd = rawOffsetEnd
                 var offsetStart = rawOffsetStart.coerceIn(minPx, offsetEnd)
                 offsetStart = snapValueToTick(offsetStart, tickFractions, minPx, maxPx)
-                SliderRange(offsetStart, offsetEnd)
+                SliderRange(offsetStart.coerceAtMost(offsetEnd), offsetEnd)
             } else {
                 rawOffsetEnd = (rawOffsetEnd + offset)
                 rawOffsetStart = scaleToOffset(minPx, maxPx, activeRangeStart)
                 val offsetStart = rawOffsetStart
                 var offsetEnd = rawOffsetEnd.coerceIn(offsetStart, maxPx)
                 offsetEnd = snapValueToTick(offsetEnd, tickFractions, minPx, maxPx)
-                SliderRange(offsetStart, offsetEnd)
+                SliderRange(offsetStart, offsetEnd.coerceAtLeast(offsetStart))
             }
         val scaledUserValue = scaleToUserValue(minPx, maxPx, offsetRange)
         if (scaledUserValue != SliderRange(activeRangeStart, activeRangeEnd)) {
@@ -2861,7 +2860,7 @@ internal value class SliderRange(val packedValue: Long) {
 internal fun SliderRange(start: Float, endInclusive: Float): SliderRange {
     val isUnspecified = start.isNaN() && endInclusive.isNaN()
 
-    require(isUnspecified || start <= endInclusive + SliderRangeTolerance) {
+    require(isUnspecified || start <= endInclusive) {
         "start($start) must be <= endInclusive($endInclusive)"
     }
     return SliderRange(packFloats(start, endInclusive))
@@ -2878,7 +2877,7 @@ internal fun SliderRange(range: ClosedFloatingPointRange<Float>): SliderRange {
     val start = range.start
     val endInclusive = range.endInclusive
     val isUnspecified = start.isNaN() && endInclusive.isNaN()
-    require(isUnspecified || start <= endInclusive + SliderRangeTolerance) {
+    require(isUnspecified || start <= endInclusive) {
         "ClosedFloatingPointRange<Float>.start($start) must be <= " +
             "ClosedFloatingPoint.endInclusive($endInclusive)"
     }

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt
@@ -1891,8 +1891,16 @@ private fun scale(a1: Float, b1: Float, x1: Float, a2: Float, b2: Float) =
     lerp(a2, b2, calcFraction(a1, b1, x1))
 
 // Scale x.start, x.endInclusive from a1..b1 range to a2..b2 range
-private fun scale(a1: Float, b1: Float, x: SliderRange, a2: Float, b2: Float) =
-    SliderRange(scale(a1, b1, x.start, a2, b2), scale(a1, b1, x.endInclusive, a2, b2))
+private fun scale(isStart: Boolean, a1: Float, b1: Float, x: SliderRange, a2: Float, b2: Float): SliderRange {
+    val start = scale(a1, b1, x.start, a2, b2)
+    val end = scale(a1, b1, x.endInclusive, a2, b2)
+
+    return if (isStart) {
+        SliderRange(start.coerceAtMost(end), end)
+    } else {
+        SliderRange(start, end.coerceAtLeast(start))
+    }
+}
 
 // Calculate the 0..1 fraction that `pos` value represents between `a` and `b`
 private fun calcFraction(a: Float, b: Float, pos: Float) =
@@ -2692,7 +2700,7 @@ class RangeSliderState(
                 offsetEnd = snapValueToTick(offsetEnd, tickFractions, minPx, maxPx)
                 SliderRange(offsetStart, offsetEnd.coerceAtLeast(offsetStart))
             }
-        val scaledUserValue = scaleToUserValue(minPx, maxPx, offsetRange)
+        val scaledUserValue = scaleToUserValue(isStart, minPx, maxPx, offsetRange)
         if (scaledUserValue != SliderRange(activeRangeStart, activeRangeEnd)) {
             if (onValueChange != null) {
                 onValueChange?.let { it(scaledUserValue) }
@@ -2716,8 +2724,8 @@ class RangeSliderState(
         get() = floor(steps * (1f - coercedActiveRangeStartAsFraction)).toInt()
 
     // scales range offset from within minPx..maxPx to within valueRange.start..valueRange.end
-    private fun scaleToUserValue(minPx: Float, maxPx: Float, offset: SliderRange) =
-        scale(minPx, maxPx, offset, valueRange.start, valueRange.endInclusive)
+    private fun scaleToUserValue(isStart: Boolean, minPx: Float, maxPx: Float, offset: SliderRange) =
+        scale(isStart, minPx, maxPx, offset, valueRange.start, valueRange.endInclusive)
 
     // scales float userValue within valueRange.start..valueRange.end to within minPx..maxPx
     private fun scaleToOffset(minPx: Float, maxPx: Float, userValue: Float) =


### PR DESCRIPTION
The material3 [RangeSlider implementation](https://github.com/androidx/androidx/blob/2786b9ec613c6dd14a72914c2213626f24b2cac3/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt#L4) can crash for large float values when you try to drag one handle beyond the other one as there can be rounding errors for large float values. Details for this crash can be found [here](https://issuetracker.google.com/issues/324934900).  In a first attempt to fix it, a tolerance was introduced in [this PR](https://android-review.googlesource.com/c/platform/frameworks/support/+/2974112/3/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/Slider.kt#2085) to mitigate this crash. 
However, the crash can still occur when you are using large enough numbers (in my testing 5 digits). Instead of using a tolerance, I propose to cap the values to be non overlapping in the first place. This works for all scenarios (very small to very big float values) in my manual testing.

## Proposed Changes

  - Remove the tolerance for comparison
  - Instead coerce the new range values to be non overlapping: 
    - when dragging the start handle, the value is forced to be <= the end value 
    - when dragging the end handle, the value is force to be >= the start value


## Testing

Test: Manual testing on different devices

## Issues Fixed

Fixes: 324934900
Fixes: 368982579
