### PR TITLE
Demote FunctionKeyMeta and FunctionKeyMetaClass to binary retention

### DIFF
--- a/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/FunctionKeyMeta.kt
+++ b/compose/runtime/runtime/src/commonMain/kotlin/androidx/compose/runtime/internal/FunctionKeyMeta.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.ComposeCompilerApi
  */
 @ComposeCompilerApi
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.BINARY)
 @Repeatable
 annotation class FunctionKeyMeta(val key: Int, val startOffset: Int, val endOffset: Int)
 
@@ -42,5 +42,5 @@ annotation class FunctionKeyMeta(val key: Int, val startOffset: Int, val endOffs
  */
 @ComposeCompilerApi
 @Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
+@Retention(AnnotationRetention.BINARY)
 annotation class FunctionKeyMetaClass(val file: String)


### PR DESCRIPTION
We are proposing to change the default behaviour of the `generateFunctionKeyMetaAnnotations` option of the Compose Compiler. Currently it defaults to `false`, we are proposing changing it to `true`. Motivation: [Compose Hot Reload](https://github.com/JetBrains/compose-hot-reload/issues/131) project requires `generateFunctionKeyMetaAnnotations` enabled for Desktop targets to work correctly. 

As a part of this change, we propose demoting `FunctionKeyMeta` and `FunctionKeyMetaClass` annotations to binary retention and enabling `generateFunctionKeyMetaAnnotations` by default for all targets.

## Proposed Changes

  - Demote `FunctionKeyMeta` and `FunctionKeyMetaClass` annotations to binary retention 

## Testing

Test: checked with `./gradlew test connectedCheck`

