### PR TITLE
[MediaRouter] Remove redundant SDK check in `DeviceUtils`

### DIFF
--- a/mediarouter/mediarouter/lint-baseline.xml
+++ b/mediarouter/mediarouter/lint-baseline.xml
@@ -46,13 +46,4 @@
             file="src/main/java/androidx/mediarouter/media/RemotePlaybackClient.java"/>
     </issue>
 
-    <issue
-        id="ObsoleteSdkInt"
-        message="Unnecessary; `SDK_INT` is always >= 21"
-        errorLine1="                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH"
-        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/androidx/mediarouter/app/DeviceUtils.java"/>
-    </issue>
-
 </issues>

--- a/mediarouter/mediarouter/src/main/java/androidx/mediarouter/app/DeviceUtils.java
+++ b/mediarouter/mediarouter/src/main/java/androidx/mediarouter/app/DeviceUtils.java
@@ -184,9 +184,7 @@ final class DeviceUtils {
      */
     private static boolean isWearable(@NonNull PackageManager packageManager) {
         if (sIsWearable == null) {
-            sIsWearable =
-                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT_WATCH
-                            && packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH);
+            sIsWearable = packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH);
         }
         return sIsWearable;
     }


### PR DESCRIPTION
## Proposed Changes

  - Remove unnecessary KitKat version check, since the min SDK version is now Lollipop.
  - Remove the corresponding issue from Lint's baseline file.

## Testing

Test: tested in a custom project. The check being always true, it is safe to remove it.

## Issues Fixed

Fixes: N/A