### PR TITLE
Bump MaxMetaspaceSize in GitHub actions

### DIFF
--- a/playground-common/androidx-shared.properties
+++ b/playground-common/androidx-shared.properties
@@ -24,7 +24,7 @@
 # This separation is necessary to ensure gradle can read certain properties
 # at configuration time.
 
-org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
+org.gradle.jvmargs=-Xmx6g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true  -Dlint.nullness.ignore-deprecated=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
## Proposed Changes

Bump MaxMetaspaceSize in GitHub actions as we are hitting the limit in the runners causing Gradle to OOM.
 
## Testing

Test: https://github.com/androidx/androidx/actions/workflows/gradle-release-nightly-integration.yml latest run uses higher metaspace limit

## Issues Fixed


