### PR TITLE
[MediaRouter] Enable running `mediarouter-playground`

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -120,7 +120,7 @@ jobs:
         os: [ubuntu-latest]
         # If you would like to remove some projects temporarily, use .github/ci-control/ci-config.json instead.
         # Keep these in alphabetical order.
-        project: ["activity", "appcompat", "biometric", "collection", "compose-runtime", "core", "datastore", "fragment", "lifecycle", "lint", "navigation", "paging", "room", "sqlite", "work"]
+        project: ["activity", "appcompat", "biometric", "collection", "compose-runtime", "core", "datastore", "fragment", "lifecycle", "lint", "mediarouter", "navigation", "paging", "room", "sqlite", "work"]
         include:
           - project: "compose-runtime"
             project-root: "compose/runtime"


### PR DESCRIPTION
## Proposed Changes

  - Make the `mediarouter-playground` project build on GitHub Actions. This follows up on 35416a187e115fd4351009448363128cd37bf362.

## Testing

Test: check the corresponding workflow result on GitHub Actions.

## Issues Fixed

Fixes: N/A