### PR TITLE
Do not ignore key events from remotes using HDMI-CEC

### DIFF
--- a/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldFocusModifier.android.kt
+++ b/compose/foundation/foundation/src/androidMain/kotlin/androidx/compose/foundation/text/TextFieldFocusModifier.android.kt
@@ -57,7 +57,7 @@ internal actual fun Modifier.interceptDPadAndMoveFocus(
             !device.supportsSource(SOURCE_DPAD) -> false
 
             // Ignore key events from virtual keyboards
-            device.isVirtual -> false
+            device.isVirtual && keyEvent.nativeKeyEvent.source != InputDevice.SOURCE_HDMI -> false
 
             // Ignore key release events
             keyEvent.type != KeyDown -> false


### PR DESCRIPTION
## Proposed Changes

  - This change updates the focus behavior in BasicTextField (The variants using CoreTextField) to allow focus change on devices using HDMI-CEC passthrough controllers.

## Issues Fixed


Fixes: https://issuetracker.google.com/issues/420743932
