### PR TITLE
Adapt build scan publication message parsing

### DIFF
--- a/development/build_log_simplifier/message-flakes.ignore
+++ b/development/build_log_simplifier/message-flakes.ignore
@@ -143,6 +143,7 @@ Using custom version .* of AGP due to GRADLE_PLUGIN_VERSION being set\.
 Using custom version .* of Lint due to LINT_VERSION being set\.
 Using custom version .* of metalava due to METALAVA_VERSION being set\.
 Publishing build scan\.\.\.
+Publishing Build Scan\.\.\.
 https://ge\.androidx\.dev/s/.*
 # androidx-demos:compileReleaseJavaWithJavac
 Note: \$SUPPORT/samples/AndroidXDemos/src/main/java/com/example/androidx/util/DiffUtilActivity\.java uses unchecked or unsafe operations\.


### PR DESCRIPTION
## Proposed Changes

  - Develocity Gradle Plugin version 4.0.2 outputs a slightly different Build Scan publication log message: `Publishing Build Scan...` instead of `Publishing build scan...`. This PRs adds the new message to the ignore list.

## Testing

Test: Ran `development/build_log_simplifier.py --validate /tmp/gradle.log` with `gradle.log` containing `Publishing Build Scan...` and checked that it's properly stripped.
