### PR TITLE
Update LayoutSample.kt replaced maxIntrinsicHeight with maxIntrinsicW…

### DIFF
--- a/compose/ui/ui/samples/src/main/java/androidx/compose/ui/samples/LayoutSample.kt
+++ b/compose/ui/ui/samples/src/main/java/androidx/compose/ui/samples/LayoutSample.kt
@@ -142,7 +142,7 @@ fun LayoutWithProvidedIntrinsicsUsage(content: @Composable () -> Unit) {
             override fun IntrinsicMeasureScope.maxIntrinsicWidth(
                 measurables: List<IntrinsicMeasurable>,
                 height: Int,
-            ) = (measurables.map { it.maxIntrinsicHeight(height / 2) }.maxByOrNull { it } ?: 0) * 2
+            ) = (measurables.map { it.maxIntrinsicWidth(height / 2) }.maxByOrNull { it } ?: 0) * 2
 
             override fun IntrinsicMeasureScope.maxIntrinsicHeight(
                 measurables: List<IntrinsicMeasurable>,


### PR DESCRIPTION
Update LayoutSample.kt replaced maxIntrinsicHeight with maxIntrinsicWidth

## Proposed Changes

  - There was most likely a mistaken use of maxIntrinsicHeight, it should be replaced with maxIntrinsicWidth

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

One liner didn't test anything to be honest. Will test if anyone provides guidance.
