### PR TITLE
New `DoubleDoublePair`

### DIFF
--- a/collection/collection/api/current.ignore
+++ b/collection/collection/api/current.ignore
@@ -1,4 +1,8 @@
 // Baseline format: 1.0
+AddedClass: androidx.collection.DoubleDoublePair:
+    Added class androidx.collection.DoubleDoublePair
+
+
 AddedMethod: androidx.collection.FloatFloatPair#box-impl(long):
     Added method androidx.collection.FloatFloatPair.box-impl(long)
 AddedMethod: androidx.collection.FloatFloatPair#component1-impl(long):

--- a/collection/collection/api/current.txt
+++ b/collection/collection/api/current.txt
@@ -95,6 +95,16 @@ package androidx.collection {
     property public int last;
   }
 
+  public final class DoubleDoublePair {
+    ctor public DoubleDoublePair(double first, double second);
+    method public inline operator double component1();
+    method public inline operator double component2();
+    method public double getFirst();
+    method public double getSecond();
+    property public double first;
+    property public double second;
+  }
+
   public abstract sealed class DoubleList {
     method public final inline boolean any();
     method public final inline boolean any(kotlin.jvm.functions.Function1<? super java.lang.Double,java.lang.Boolean> predicate);

--- a/collection/collection/api/restricted_current.ignore
+++ b/collection/collection/api/restricted_current.ignore
@@ -1,4 +1,8 @@
 // Baseline format: 1.0
+AddedClass: androidx.collection.DoubleDoublePair:
+    Added class androidx.collection.DoubleDoublePair
+
+
 AddedMethod: androidx.collection.FloatFloatPair#box-impl(long):
     Added method androidx.collection.FloatFloatPair.box-impl(long)
 AddedMethod: androidx.collection.FloatFloatPair#component1-impl(long):

--- a/collection/collection/api/restricted_current.txt
+++ b/collection/collection/api/restricted_current.txt
@@ -95,6 +95,16 @@ package androidx.collection {
     property public int last;
   }
 
+  public final class DoubleDoublePair {
+    ctor public DoubleDoublePair(double first, double second);
+    method public inline operator double component1();
+    method public inline operator double component2();
+    method public double getFirst();
+    method public double getSecond();
+    property public double first;
+    property public double second;
+  }
+
   public abstract sealed class DoubleList {
     method public final inline boolean any();
     method public final inline boolean any(kotlin.jvm.functions.Function1<? super java.lang.Double,java.lang.Boolean> predicate);

--- a/collection/collection/bcv/native/current.txt
+++ b/collection/collection/bcv/native/current.txt
@@ -446,6 +446,21 @@ final class androidx.collection/CircularIntArray { // androidx.collection/Circul
     final fun size(): kotlin/Int // androidx.collection/CircularIntArray.size|size(){}[0]
 }
 
+final class androidx.collection/DoubleDoublePair { // androidx.collection/DoubleDoublePair|null[0]
+    constructor <init>(kotlin/Double, kotlin/Double) // androidx.collection/DoubleDoublePair.<init>|<init>(kotlin.Double;kotlin.Double){}[0]
+
+    final val first // androidx.collection/DoubleDoublePair.first|{}first[0]
+        final fun <get-first>(): kotlin/Double // androidx.collection/DoubleDoublePair.first.<get-first>|<get-first>(){}[0]
+    final val second // androidx.collection/DoubleDoublePair.second|{}second[0]
+        final fun <get-second>(): kotlin/Double // androidx.collection/DoubleDoublePair.second.<get-second>|<get-second>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // androidx.collection/DoubleDoublePair.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // androidx.collection/DoubleDoublePair.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // androidx.collection/DoubleDoublePair.toString|toString(){}[0]
+    final inline fun component1(): kotlin/Double // androidx.collection/DoubleDoublePair.component1|component1(){}[0]
+    final inline fun component2(): kotlin/Double // androidx.collection/DoubleDoublePair.component2|component2(){}[0]
+}
+
 final class androidx.collection/LongLongPair { // androidx.collection/LongLongPair|null[0]
     constructor <init>(kotlin/Long, kotlin/Long) // androidx.collection/LongLongPair.<init>|<init>(kotlin.Long;kotlin.Long){}[0]
 

--- a/collection/collection/src/commonMain/kotlin/androidx/collection/DoubleDoublePair.kt
+++ b/collection/collection/src/commonMain/kotlin/androidx/collection/DoubleDoublePair.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Android Open Source Project
+ * Copyright 2025 The Android Open Source Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,42 +18,42 @@
 package androidx.collection
 
 /**
- * Container to ease passing around a tuple of two [Long] values.
+ * Container to ease passing around a tuple of two [Double] values.
  *
  * @param first the first value in the pair
  * @param second the second value in the pair
  */
-public class LongLongPair public constructor(public val first: Long, public val second: Long) {
+public class DoubleDoublePair public constructor(public val first: Double, public val second: Double) {
     /**
      * Returns the [first] component of the pair. For instance, the first component of
-     * `LongLongPair(3, 4)` is `3`.
+     * `DoubleDoublePair(3.1, 4.6)` is `3.1`.
      *
      * This method allows to use destructuring declarations when working with pairs, for example:
      * ```
      * val (first, second) = myPair
      * ```
      */
-    public inline operator fun component1(): Long = first
+    public inline operator fun component1(): Double = first
 
     /**
      * Returns the [second] component of the pair. For instance, the second component of
-     * `LongLongPair(3, 4)` is `4`.
+     * `DoubleDoublePair(3.1, 4.6)` is `4.6`.
      *
      * This method allows to use destructuring declarations when working with pairs, for example:
      * ```
      * val (first, second) = myPair
      * ```
      */
-    public inline operator fun component2(): Long = second
+    public inline operator fun component2(): Double = second
 
     /**
      * Checks the two values for equality.
      *
-     * @param other the [LongLongPair] to which this one is to be checked for equality
-     * @return true if the underlying values of the [LongLongPair] are both considered equal
+     * @param other the [DoubleDoublePair] to which this one is to be checked for equality
+     * @return true if the underlying values of the [DoubleDoublePair] are both considered equal
      */
     override fun equals(other: Any?): Boolean {
-        if (other !is LongLongPair) {
+        if (other !is DoubleDoublePair) {
             return false
         }
         return other.first == first && other.second == second
@@ -62,7 +62,7 @@ public class LongLongPair public constructor(public val first: Long, public val 
     /**
      * Compute a hash code using the hash codes of the underlying values
      *
-     * @return a hashcode of the [LongLongPair]
+     * @return a hashcode of the [DoubleDoublePair]
      */
     override fun hashCode(): Int {
         return first.hashCode() xor second.hashCode()

--- a/collection/collection/src/commonTest/kotlin/androidx/collection/PairTest.kt
+++ b/collection/collection/src/commonTest/kotlin/androidx/collection/PairTest.kt
@@ -125,4 +125,33 @@ class PairTest {
         assertEquals(3L, first)
         assertEquals(5L, second)
     }
+
+    @Test
+    fun doubleCreation() {
+        val pair = DoubleDoublePair(3.1, 4.6)
+        assertEquals(3.1, pair.first)
+        assertEquals(4.6, pair.second)
+    }
+
+    @Test
+    fun doubleEquality() {
+        val pair = DoubleDoublePair(3.1, 4.6)
+        val pairEqual = DoubleDoublePair(3.1, 4.6)
+        val pairUnequal1 = DoubleDoublePair(3.1, 5.0)
+        val pairUnequal2 = DoubleDoublePair(3.0, 4.6)
+        val pairUnequal3 = DoubleDoublePair(3.101, 4.601)
+
+        assertEquals(pair, pairEqual)
+        assertNotEquals(pair, pairUnequal1)
+        assertNotEquals(pair, pairUnequal2)
+        assertNotEquals(pair, pairUnequal3)
+    }
+
+    @Test
+    fun doubleDestructing() {
+        val pair = DoubleDoublePair(3.1, 4.6)
+        val (first, second) = pair
+        assertEquals(3.1, first)
+        assertEquals(4.6, second)
+    }
 }


### PR DESCRIPTION
The `androidx.collection` library has a `Pair` for `Int`, `Float`, `Long`, but there is no `Double`, and sometimes it is necessary, so I add it.

Test: ./gradlew test