### PR TITLE
Fix formatting issues in KDoc of `Arrangement.kt`

### DIFF
--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Arrangement.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Arrangement.kt
@@ -31,11 +31,11 @@ import kotlin.math.min
  * Used to specify the arrangement of the layout's children in layouts like [Row] or [Column] in the
  * main axis direction (horizontal and vertical, respectively).
  *
- * Below is an illustration of different horizontal arrangements in [Row]s: ![Row
- * arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/row_arrangement_visualization.gif)
+ * Below is an illustration of different horizontal arrangements in [Row]s:
+ * ![Row arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/row_arrangement_visualization.gif)
  *
- * Different vertical arrangements in [Column]s: ![Column
- * arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/column_arrangement_visualization.gif)
+ * Different vertical arrangements in [Column]s:
+ * ![Column arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/column_arrangement_visualization.gif)
  */
 @Immutable
 object Arrangement {

--- a/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Arrangement.kt
+++ b/compose/foundation/foundation-layout/src/commonMain/kotlin/androidx/compose/foundation/layout/Arrangement.kt
@@ -32,10 +32,10 @@ import kotlin.math.min
  * main axis direction (horizontal and vertical, respectively).
  *
  * Below is an illustration of different horizontal arrangements in [Row]s:
- * ![Row arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/row_arrangement_visualization.gif)
+ * ![Row arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/row_arrangement_visualization.gif)
  *
  * Different vertical arrangements in [Column]s:
- * ![Column arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/column_arrangement_visualization.gif)
+ * ![Column arrangements](https://developer.android.com/images/reference/androidx/compose/foundation/layout/column_arrangement_visualization.gif)
  */
 @Immutable
 object Arrangement {


### PR DESCRIPTION
## Proposed Changes

Fix the broken markdown link in KDoc that was incorrectly formatted on 2 lines.

| Info tooltip | In-editor rendering |
|---|---|
| <img width="447" height="504" alt="image" src="https://github.com/user-attachments/assets/739aba03-ebd4-4743-80e8-d0c4df5ad1e1" /> | <img width="699" height="299" alt="image" src="https://github.com/user-attachments/assets/1c87095b-0424-4633-9c06-05553b2b2234" /> |



## Testing

Test: not applicable

