### PR TITLE
Fix broken `teardown` job in `integration_tests.yml` workflow

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -50,7 +50,7 @@ jobs:
           then
             echo "result=true" >> $GITHUB_OUTPUT
           else
-            echo "result=false" >> GITHUB_OUTPUT
+            echo "result=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Result WebHook


### PR DESCRIPTION
## Proposed Changes

Add missing `$` character when setting the result variable in the `workflow-status` step.
This bug is the main reason for all these failures: https://github.com/androidx/androidx/actions/workflows/integration_tests.yml

## Testing

Test: Run the new workflow and check that the following error is no longer present:

```
Error: Unable to deliver Web Hook SyntaxError: Unexpected token ',', ..."success": , "src" : "... is not valid JSON
```
