### PR TITLE
[MediaRouter] Remove outdated SDK checks

### DIFF
--- a/mediarouter/mediarouter/lint-baseline.xml
+++ b/mediarouter/mediarouter/lint-baseline.xml
@@ -46,22 +46,4 @@
             file="src/main/java/androidx/mediarouter/media/RemotePlaybackClient.java"/>
     </issue>
 
-    <issue
-        id="ObsoleteSdkInt"
-        message="Unnecessary; `SDK_INT` is always >= 23"
-        errorLine1="        if (Build.VERSION.SDK_INT >= 23) {"
-        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/androidx/mediarouter/app/SystemOutputSwitcherDialogController.java"/>
-    </issue>
-
-    <issue
-        id="ObsoleteSdkInt"
-        message="Unnecessary; `SDK_INT` is always >= 23"
-        errorLine1="    @RequiresApi(23)"
-        errorLine2="    ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/androidx/mediarouter/app/SystemOutputSwitcherDialogController.java"/>
-    </issue>
-
 </issues>

--- a/mediarouter/mediarouter/src/main/java/androidx/mediarouter/app/SystemOutputSwitcherDialogController.java
+++ b/mediarouter/mediarouter/src/main/java/androidx/mediarouter/app/SystemOutputSwitcherDialogController.java
@@ -203,10 +203,26 @@ public final class SystemOutputSwitcherDialogController {
 
     private static boolean isSuitableDeviceAlreadyConnectedAsAudioOutput(
             @NonNull Context context) {
-        if (Build.VERSION.SDK_INT >= 23) {
-            return Api23Impl.isSuitableDeviceAlreadyConnectedAsAudioOutput(context);
+        AudioManager audioManager = context.getSystemService(AudioManager.class);
+        AudioDeviceInfo[] audioDeviceInfos = audioManager.getDevices(
+                AudioManager.GET_DEVICES_OUTPUTS);
+        for (AudioDeviceInfo device : audioDeviceInfos) {
+            switch (device.getType()) {
+                case AudioDeviceInfo.TYPE_BLE_BROADCAST:
+                case AudioDeviceInfo.TYPE_BLE_HEADSET:
+                case AudioDeviceInfo.TYPE_BLE_SPEAKER:
+                case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
+                case AudioDeviceInfo.TYPE_HEARING_AID:
+                case AudioDeviceInfo.TYPE_LINE_ANALOG:
+                case AudioDeviceInfo.TYPE_LINE_DIGITAL:
+                case AudioDeviceInfo.TYPE_USB_DEVICE:
+                case AudioDeviceInfo.TYPE_USB_HEADSET:
+                case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
+                case AudioDeviceInfo.TYPE_WIRED_HEADSET:
+                    return true;
+            }
         }
-        return true;
+        return false;
     }
 
     @RequiresApi(30)
@@ -228,35 +244,6 @@ public final class SystemOutputSwitcherDialogController {
 
         static boolean showSystemOutputSwitcher(MediaRouter2 mediaRouter2) {
             return mediaRouter2.showSystemOutputSwitcher();
-        }
-    }
-
-    @RequiresApi(23)
-    static final class Api23Impl {
-        private Api23Impl() {
-        }
-
-        public static boolean isSuitableDeviceAlreadyConnectedAsAudioOutput(Context context) {
-            AudioManager audioManager = context.getSystemService(AudioManager.class);
-            AudioDeviceInfo[] audioDeviceInfos = audioManager.getDevices(
-                    AudioManager.GET_DEVICES_OUTPUTS);
-            for (AudioDeviceInfo device : audioDeviceInfos) {
-                switch (device.getType()) {
-                    case AudioDeviceInfo.TYPE_BLE_BROADCAST:
-                    case AudioDeviceInfo.TYPE_BLE_HEADSET:
-                    case AudioDeviceInfo.TYPE_BLE_SPEAKER:
-                    case AudioDeviceInfo.TYPE_BLUETOOTH_A2DP:
-                    case AudioDeviceInfo.TYPE_HEARING_AID:
-                    case AudioDeviceInfo.TYPE_LINE_ANALOG:
-                    case AudioDeviceInfo.TYPE_LINE_DIGITAL:
-                    case AudioDeviceInfo.TYPE_USB_DEVICE:
-                    case AudioDeviceInfo.TYPE_USB_HEADSET:
-                    case AudioDeviceInfo.TYPE_WIRED_HEADPHONES:
-                    case AudioDeviceInfo.TYPE_WIRED_HEADSET:
-                        return true;
-                }
-            }
-            return false;
         }
     }
 }

--- a/mediarouter/mediarouter/src/test/java/androidx/mediarouter/app/SystemOutputSwitcherDialogControllerTest.java
+++ b/mediarouter/mediarouter/src/test/java/androidx/mediarouter/app/SystemOutputSwitcherDialogControllerTest.java
@@ -35,7 +35,6 @@ import android.os.Build;
 import android.provider.Settings;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.google.common.collect.ImmutableList;
@@ -96,7 +95,6 @@ public class SystemOutputSwitcherDialogControllerTest {
         }
     }
 
-    @RequiresApi(23)
     private static void setupConnectedAudioOutput(int... deviceTypes) {
         ShadowAudioManager shadowAudioManager = shadowOf(
                 ApplicationProvider.getApplicationContext().getSystemService(AudioManager.class));


### PR DESCRIPTION
## Proposed Changes

This PR removes outdated SDK checks in MediaRouter.

## Testing

Test: the GitHub check for `MediaRouter` is green.