### PR TITLE
[Core] Deprecate proxy methods

### DIFF
--- a/core/core/api/current.txt
+++ b/core/core/api/current.txt
@@ -43,12 +43,12 @@ package androidx.core.app {
 
   public class ActivityCompat extends androidx.core.content.ContextCompat {
     ctor protected ActivityCompat();
-    method public static void finishAffinity(android.app.Activity);
-    method public static void finishAfterTransition(android.app.Activity);
-    method public static android.net.Uri? getReferrer(android.app.Activity);
+    method @Deprecated public static void finishAffinity(android.app.Activity);
+    method @Deprecated public static void finishAfterTransition(android.app.Activity);
+    method @Deprecated public static android.net.Uri? getReferrer(android.app.Activity);
     method @Deprecated public static boolean invalidateOptionsMenu(android.app.Activity!);
     method public static boolean isLaunchedFromBubble(android.app.Activity);
-    method public static void postponeEnterTransition(android.app.Activity);
+    method @Deprecated public static void postponeEnterTransition(android.app.Activity);
     method public static void recreate(android.app.Activity);
     method public static androidx.core.view.DragAndDropPermissionsCompat? requestDragAndDropPermissions(android.app.Activity, android.view.DragEvent);
     method public static void requestPermissions(android.app.Activity, String![], @IntRange(from=0) int);
@@ -58,9 +58,9 @@ package androidx.core.app {
     method public static void setLocusContext(android.app.Activity, androidx.core.content.LocusIdCompat?, android.os.Bundle?);
     method public static void setPermissionCompatDelegate(androidx.core.app.ActivityCompat.PermissionCompatDelegate?);
     method public static boolean shouldShowRequestPermissionRationale(android.app.Activity, String);
-    method public static void startActivityForResult(android.app.Activity, android.content.Intent, int, android.os.Bundle?);
-    method public static void startIntentSenderForResult(android.app.Activity, android.content.IntentSender, int, android.content.Intent?, int, int, int, android.os.Bundle?) throws android.content.IntentSender.SendIntentException;
-    method public static void startPostponedEnterTransition(android.app.Activity);
+    method @Deprecated public static void startActivityForResult(android.app.Activity, android.content.Intent, int, android.os.Bundle?);
+    method @Deprecated public static void startIntentSenderForResult(android.app.Activity, android.content.IntentSender, int, android.content.Intent?, int, int, int, android.os.Bundle?) throws android.content.IntentSender.SendIntentException;
+    method @Deprecated public static void startPostponedEnterTransition(android.app.Activity);
   }
 
   public static interface ActivityCompat.OnRequestPermissionsResultCallback {
@@ -102,9 +102,9 @@ package androidx.core.app {
   public final class AlarmManagerCompat {
     method public static boolean canScheduleExactAlarms(android.app.AlarmManager);
     method public static void setAlarmClock(android.app.AlarmManager, long, android.app.PendingIntent, android.app.PendingIntent);
-    method public static void setAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
+    method @Deprecated public static void setAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
     method @Deprecated public static void setExact(android.app.AlarmManager, int, long, android.app.PendingIntent);
-    method public static void setExactAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
+    method @Deprecated public static void setExactAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
   }
 
   @RequiresApi(28) public class AppComponentFactory extends android.app.AppComponentFactory {
@@ -133,11 +133,11 @@ package androidx.core.app {
     method public static int noteOpNoThrow(android.content.Context, String, int, String);
     method public static int noteProxyOp(android.content.Context, String, String);
     method public static int noteProxyOpNoThrow(android.content.Context, String, String);
-    method public static String? permissionToOp(String);
-    field public static final int MODE_ALLOWED = 0; // 0x0
-    field public static final int MODE_DEFAULT = 3; // 0x3
-    field public static final int MODE_ERRORED = 2; // 0x2
-    field public static final int MODE_IGNORED = 1; // 0x1
+    method @Deprecated public static String? permissionToOp(String);
+    field @Deprecated public static final int MODE_ALLOWED = 0; // 0x0
+    field @Deprecated public static final int MODE_DEFAULT = 3; // 0x3
+    field @Deprecated public static final int MODE_ERRORED = 2; // 0x2
+    field @Deprecated public static final int MODE_IGNORED = 1; // 0x1
   }
 
   @Deprecated public final class BundleCompat {
@@ -1361,26 +1361,26 @@ package androidx.core.content {
     method public static android.content.Context createAttributionContext(android.content.Context, String?);
     method public static android.content.Context? createDeviceProtectedStorageContext(android.content.Context);
     method public static String? getAttributionTag(android.content.Context);
-    method public static java.io.File getCodeCacheDir(android.content.Context);
-    method @ColorInt public static int getColor(android.content.Context, @ColorRes int);
+    method @Deprecated public static java.io.File getCodeCacheDir(android.content.Context);
+    method @Deprecated @ColorInt public static int getColor(android.content.Context, @ColorRes int);
     method public static android.content.res.ColorStateList? getColorStateList(android.content.Context, @ColorRes int);
     method public static android.content.Context getContextForLanguage(android.content.Context);
     method public static java.io.File? getDataDir(android.content.Context);
     method public static android.view.Display getDisplayOrDefault(@DisplayContext android.content.Context);
-    method public static android.graphics.drawable.Drawable? getDrawable(android.content.Context, @DrawableRes int);
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawable(android.content.Context, @DrawableRes int);
     method @Deprecated public static java.io.File![] getExternalCacheDirs(android.content.Context);
     method @Deprecated public static java.io.File![] getExternalFilesDirs(android.content.Context, String?);
     method public static java.util.concurrent.Executor getMainExecutor(android.content.Context);
-    method public static java.io.File? getNoBackupFilesDir(android.content.Context);
+    method @Deprecated public static java.io.File? getNoBackupFilesDir(android.content.Context);
     method @Deprecated public static java.io.File![] getObbDirs(android.content.Context);
     method public static String getString(android.content.Context, int);
-    method public static <T> T? getSystemService(android.content.Context, Class<T>);
-    method public static String? getSystemServiceName(android.content.Context, Class<? extends java.lang.Object!>);
+    method @Deprecated public static <T> T? getSystemService(android.content.Context, Class<T>);
+    method @Deprecated public static String? getSystemServiceName(android.content.Context, Class<? extends java.lang.Object!>);
     method public static boolean isDeviceProtectedStorage(android.content.Context);
-    method public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, int);
+    method @Deprecated public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, int);
     method public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, String?, android.os.Handler?, int);
-    method public static boolean startActivities(android.content.Context, android.content.Intent![]);
-    method public static boolean startActivities(android.content.Context, android.content.Intent![], android.os.Bundle?);
+    method @Deprecated public static boolean startActivities(android.content.Context, android.content.Intent![]);
+    method @Deprecated public static boolean startActivities(android.content.Context, android.content.Intent![], android.os.Bundle?);
     method @Deprecated public static void startActivity(android.content.Context, android.content.Intent, android.os.Bundle?);
     method public static void startForegroundService(android.content.Context, android.content.Intent);
     field public static final int RECEIVER_EXPORTED = 2; // 0x2
@@ -1656,10 +1656,10 @@ package androidx.core.content.res {
   public final class ResourcesCompat {
     method public static void clearCachesForTheme(android.content.res.Resources.Theme);
     method public static android.graphics.Typeface? getCachedFont(android.content.Context, @FontRes int) throws android.content.res.Resources.NotFoundException;
-    method @ColorInt public static int getColor(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated @ColorInt public static int getColor(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
     method public static android.content.res.ColorStateList? getColorStateList(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
-    method public static android.graphics.drawable.Drawable? getDrawable(android.content.res.Resources, @DrawableRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
-    method public static android.graphics.drawable.Drawable? getDrawableForDensity(android.content.res.Resources, @DrawableRes int, int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawable(android.content.res.Resources, @DrawableRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawableForDensity(android.content.res.Resources, @DrawableRes int, int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
     method public static float getFloat(android.content.res.Resources, @DimenRes int);
     method public static android.graphics.Typeface? getFont(android.content.Context, @FontRes int) throws android.content.res.Resources.NotFoundException;
     method public static void getFont(android.content.Context, @FontRes int, androidx.core.content.res.ResourcesCompat.FontCallback, android.os.Handler?) throws android.content.res.Resources.NotFoundException;
@@ -1937,7 +1937,7 @@ package androidx.core.graphics {
   }
 
   public final class PaintCompat {
-    method public static boolean hasGlyph(android.graphics.Paint, String);
+    method @Deprecated public static boolean hasGlyph(android.graphics.Paint, String);
     method public static boolean setBlendMode(android.graphics.Paint, androidx.core.graphics.BlendModeCompat?);
   }
 
@@ -2095,25 +2095,25 @@ package androidx.core.graphics.drawable {
     method public static inline android.graphics.drawable.ColorDrawable toDrawable(@ColorInt int);
   }
 
-  public final class DrawableCompat {
-    method public static void applyTheme(android.graphics.drawable.Drawable, android.content.res.Resources.Theme);
-    method public static boolean canApplyTheme(android.graphics.drawable.Drawable);
-    method public static void clearColorFilter(android.graphics.drawable.Drawable);
+  @Deprecated public final class DrawableCompat {
+    method @Deprecated public static void applyTheme(android.graphics.drawable.Drawable, android.content.res.Resources.Theme);
+    method @Deprecated public static boolean canApplyTheme(android.graphics.drawable.Drawable);
+    method @Deprecated public static void clearColorFilter(android.graphics.drawable.Drawable);
     method @Deprecated public static int getAlpha(android.graphics.drawable.Drawable);
-    method public static android.graphics.ColorFilter? getColorFilter(android.graphics.drawable.Drawable);
-    method public static int getLayoutDirection(android.graphics.drawable.Drawable);
-    method public static void inflate(android.graphics.drawable.Drawable, android.content.res.Resources, org.xmlpull.v1.XmlPullParser, android.util.AttributeSet, android.content.res.Resources.Theme?) throws java.io.IOException, org.xmlpull.v1.XmlPullParserException;
+    method @Deprecated public static android.graphics.ColorFilter? getColorFilter(android.graphics.drawable.Drawable);
+    method @Deprecated public static int getLayoutDirection(android.graphics.drawable.Drawable);
+    method @Deprecated public static void inflate(android.graphics.drawable.Drawable, android.content.res.Resources, org.xmlpull.v1.XmlPullParser, android.util.AttributeSet, android.content.res.Resources.Theme?) throws java.io.IOException, org.xmlpull.v1.XmlPullParserException;
     method @Deprecated public static boolean isAutoMirrored(android.graphics.drawable.Drawable);
     method @Deprecated public static void jumpToCurrentState(android.graphics.drawable.Drawable);
     method @Deprecated public static void setAutoMirrored(android.graphics.drawable.Drawable, boolean);
-    method public static void setHotspot(android.graphics.drawable.Drawable, float, float);
-    method public static void setHotspotBounds(android.graphics.drawable.Drawable, int, int, int, int);
-    method public static boolean setLayoutDirection(android.graphics.drawable.Drawable, int);
-    method public static void setTint(android.graphics.drawable.Drawable, @ColorInt int);
-    method public static void setTintList(android.graphics.drawable.Drawable, android.content.res.ColorStateList?);
-    method public static void setTintMode(android.graphics.drawable.Drawable, android.graphics.PorterDuff.Mode?);
-    method public static <T extends android.graphics.drawable.Drawable> T unwrap(android.graphics.drawable.Drawable);
-    method public static android.graphics.drawable.Drawable wrap(android.graphics.drawable.Drawable);
+    method @Deprecated public static void setHotspot(android.graphics.drawable.Drawable, float, float);
+    method @Deprecated public static void setHotspotBounds(android.graphics.drawable.Drawable, int, int, int, int);
+    method @Deprecated public static boolean setLayoutDirection(android.graphics.drawable.Drawable, int);
+    method @Deprecated public static void setTint(android.graphics.drawable.Drawable, @ColorInt int);
+    method @Deprecated public static void setTintList(android.graphics.drawable.Drawable, android.content.res.ColorStateList?);
+    method @Deprecated public static void setTintMode(android.graphics.drawable.Drawable, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static <T extends android.graphics.drawable.Drawable> T unwrap(android.graphics.drawable.Drawable);
+    method @Deprecated public static android.graphics.drawable.Drawable wrap(android.graphics.drawable.Drawable);
   }
 
   public final class DrawableKt {
@@ -2546,9 +2546,9 @@ package androidx.core.os {
     method @Deprecated @RequiresApi(24) public static androidx.core.os.LocaleListCompat! wrap(Object!);
   }
 
-  public final class MessageCompat {
-    method public static boolean isAsynchronous(android.os.Message);
-    method public static void setAsynchronous(android.os.Message, boolean);
+  @Deprecated public final class MessageCompat {
+    method @Deprecated public static boolean isAsynchronous(android.os.Message);
+    method @Deprecated public static void setAsynchronous(android.os.Message, boolean);
   }
 
   public class OperationCanceledException extends java.lang.RuntimeException {
@@ -3191,21 +3191,21 @@ package androidx.core.util {
     method public static Runnable asRunnable(kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
-  public final class SizeFCompat {
-    ctor public SizeFCompat(float, float);
-    method public float getHeight();
-    method public float getWidth();
-    method public android.util.SizeF toSizeF();
-    method public static androidx.core.util.SizeFCompat toSizeFCompat(android.util.SizeF);
+  @Deprecated public final class SizeFCompat {
+    ctor @Deprecated public SizeFCompat(float, float);
+    method @Deprecated public float getHeight();
+    method @Deprecated public float getWidth();
+    method @Deprecated public android.util.SizeF toSizeF();
+    method @Deprecated public static androidx.core.util.SizeFCompat toSizeFCompat(android.util.SizeF);
   }
 
   public final class SizeKt {
     method public static inline operator int component1(android.util.Size);
     method public static inline operator float component1(android.util.SizeF);
-    method public static inline operator float component1(androidx.core.util.SizeFCompat);
+    method @Deprecated public static inline operator float component1(androidx.core.util.SizeFCompat);
     method public static inline operator int component2(android.util.Size);
     method public static inline operator float component2(android.util.SizeF);
-    method public static inline operator float component2(androidx.core.util.SizeFCompat);
+    method @Deprecated public static inline operator float component2(androidx.core.util.SizeFCompat);
   }
 
   public final class SparseArrayKt {
@@ -3894,11 +3894,11 @@ package androidx.core.view {
     method public static androidx.core.view.WindowInsetsCompat computeSystemWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat, android.graphics.Rect);
     method public static androidx.core.view.WindowInsetsCompat dispatchApplyWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat);
     method public static void dispatchFinishTemporaryDetach(android.view.View);
-    method public static boolean dispatchNestedFling(android.view.View, float, float, boolean);
-    method public static boolean dispatchNestedPreFling(android.view.View, float, float);
-    method public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?);
+    method @Deprecated public static boolean dispatchNestedFling(android.view.View, float, float, boolean);
+    method @Deprecated public static boolean dispatchNestedPreFling(android.view.View, float, float);
+    method @Deprecated public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?);
     method public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?, int);
-    method public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?);
+    method @Deprecated public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?);
     method public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?, int);
     method public static void dispatchNestedScroll(android.view.View, int, int, int, int, int[]?, int, int[]);
     method public static void dispatchStartTemporaryDetach(android.view.View);
@@ -3910,12 +3910,12 @@ package androidx.core.view {
     method @UiThread public static CharSequence? getAccessibilityPaneTitle(android.view.View);
     method @Deprecated public static float getAlpha(android.view.View!);
     method public static androidx.core.view.autofill.AutofillIdCompat? getAutofillId(android.view.View);
-    method public static android.content.res.ColorStateList? getBackgroundTintList(android.view.View);
-    method public static android.graphics.PorterDuff.Mode? getBackgroundTintMode(android.view.View);
+    method @Deprecated public static android.content.res.ColorStateList? getBackgroundTintList(android.view.View);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getBackgroundTintMode(android.view.View);
     method @Deprecated public static android.graphics.Rect? getClipBounds(android.view.View);
     method public static androidx.core.view.contentcapture.ContentCaptureSessionCompat? getContentCaptureSession(android.view.View);
     method @Deprecated public static android.view.Display? getDisplay(android.view.View);
-    method public static float getElevation(android.view.View);
+    method @Deprecated public static float getElevation(android.view.View);
     method @Deprecated public static boolean getFitsSystemWindows(android.view.View);
     method @Deprecated public static int getImportantForAccessibility(android.view.View);
     method public static int getImportantForAutofill(android.view.View);
@@ -3943,21 +3943,21 @@ package androidx.core.view {
     method @Deprecated public static float getRotationY(android.view.View!);
     method @Deprecated public static float getScaleX(android.view.View!);
     method @Deprecated public static float getScaleY(android.view.View!);
-    method public static int getScrollIndicators(android.view.View);
+    method @Deprecated public static int getScrollIndicators(android.view.View);
     method @UiThread public static CharSequence? getStateDescription(android.view.View);
     method public static java.util.List<android.graphics.Rect!> getSystemGestureExclusionRects(android.view.View);
-    method public static String? getTransitionName(android.view.View);
+    method @Deprecated public static String? getTransitionName(android.view.View);
     method @Deprecated public static float getTranslationX(android.view.View!);
     method @Deprecated public static float getTranslationY(android.view.View!);
-    method public static float getTranslationZ(android.view.View);
+    method @Deprecated public static float getTranslationZ(android.view.View);
     method @Deprecated public static androidx.core.view.WindowInsetsControllerCompat? getWindowInsetsController(android.view.View);
     method @Deprecated public static int getWindowSystemUiVisibility(android.view.View);
     method @Deprecated public static float getX(android.view.View!);
     method @Deprecated public static float getY(android.view.View!);
-    method public static float getZ(android.view.View);
+    method @Deprecated public static float getZ(android.view.View);
     method public static boolean hasAccessibilityDelegate(android.view.View);
     method public static boolean hasExplicitFocusable(android.view.View);
-    method public static boolean hasNestedScrollingParent(android.view.View);
+    method @Deprecated public static boolean hasNestedScrollingParent(android.view.View);
     method public static boolean hasNestedScrollingParent(android.view.View, int);
     method @Deprecated public static boolean hasOnClickListeners(android.view.View);
     method @Deprecated public static boolean hasOverlappingRendering(android.view.View);
@@ -3965,21 +3965,21 @@ package androidx.core.view {
     method @UiThread public static boolean isAccessibilityHeading(android.view.View);
     method @Deprecated public static boolean isAttachedToWindow(android.view.View);
     method public static boolean isFocusedByDefault(android.view.View);
-    method public static boolean isImportantForAccessibility(android.view.View);
+    method @Deprecated public static boolean isImportantForAccessibility(android.view.View);
     method public static boolean isImportantForAutofill(android.view.View);
     method public static boolean isImportantForContentCapture(android.view.View);
     method @Deprecated public static boolean isInLayout(android.view.View);
     method public static boolean isKeyboardNavigationCluster(android.view.View);
     method @Deprecated public static boolean isLaidOut(android.view.View);
     method @Deprecated public static boolean isLayoutDirectionResolved(android.view.View);
-    method public static boolean isNestedScrollingEnabled(android.view.View);
+    method @Deprecated public static boolean isNestedScrollingEnabled(android.view.View);
     method @Deprecated public static boolean isOpaque(android.view.View!);
     method @Deprecated public static boolean isPaddingRelative(android.view.View);
     method @UiThread public static boolean isScreenReaderFocusable(android.view.View);
     method @Deprecated public static void jumpDrawablesToCurrentState(android.view.View!);
     method public static android.view.View? keyboardNavigationClusterSearch(android.view.View, android.view.View?, int);
-    method public static void offsetLeftAndRight(android.view.View, int);
-    method public static void offsetTopAndBottom(android.view.View, int);
+    method @Deprecated public static void offsetLeftAndRight(android.view.View, int);
+    method @Deprecated public static void offsetTopAndBottom(android.view.View, int);
     method public static androidx.core.view.WindowInsetsCompat onApplyWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat);
     method @Deprecated public static void onInitializeAccessibilityEvent(android.view.View!, android.view.accessibility.AccessibilityEvent!);
     method @Deprecated public static void onInitializeAccessibilityNodeInfo(android.view.View, androidx.core.view.accessibility.AccessibilityNodeInfoCompat);
@@ -3995,7 +3995,7 @@ package androidx.core.view {
     method public static void removeAccessibilityAction(android.view.View, int);
     method public static void removeOnUnhandledKeyEventListener(android.view.View, androidx.core.view.ViewCompat.OnUnhandledKeyEventListenerCompat);
     method public static void replaceAccessibilityAction(android.view.View, androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat, CharSequence?, androidx.core.view.accessibility.AccessibilityViewCommand?);
-    method public static void requestApplyInsets(android.view.View);
+    method @Deprecated public static void requestApplyInsets(android.view.View);
     method public static <T extends android.view.View> T requireViewById(android.view.View, @IdRes int);
     method @Deprecated public static int resolveSizeAndState(int, int, int);
     method public static boolean restoreDefaultFocus(android.view.View);
@@ -4009,12 +4009,12 @@ package androidx.core.view {
     method public static void setAutofillHints(android.view.View, java.lang.String!...?);
     method public static void setAutofillId(android.view.View, androidx.core.view.autofill.AutofillIdCompat?);
     method @Deprecated public static void setBackground(android.view.View, android.graphics.drawable.Drawable?);
-    method public static void setBackgroundTintList(android.view.View, android.content.res.ColorStateList?);
-    method public static void setBackgroundTintMode(android.view.View, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static void setBackgroundTintList(android.view.View, android.content.res.ColorStateList?);
+    method @Deprecated public static void setBackgroundTintMode(android.view.View, android.graphics.PorterDuff.Mode?);
     method @Deprecated public static void setChildrenDrawingOrderEnabled(android.view.ViewGroup!, boolean);
     method @Deprecated public static void setClipBounds(android.view.View, android.graphics.Rect?);
     method public static void setContentCaptureSession(android.view.View, androidx.core.view.contentcapture.ContentCaptureSessionCompat?);
-    method public static void setElevation(android.view.View, float);
+    method @Deprecated public static void setElevation(android.view.View, float);
     method @Deprecated public static void setFitsSystemWindows(android.view.View!, boolean);
     method public static void setFocusedByDefault(android.view.View, boolean);
     method @Deprecated public static void setHasTransientState(android.view.View, boolean);
@@ -4026,7 +4026,7 @@ package androidx.core.view {
     method @Deprecated public static void setLayerPaint(android.view.View, android.graphics.Paint?);
     method @Deprecated public static void setLayerType(android.view.View!, int, android.graphics.Paint!);
     method @Deprecated public static void setLayoutDirection(android.view.View, int);
-    method public static void setNestedScrollingEnabled(android.view.View, boolean);
+    method @Deprecated public static void setNestedScrollingEnabled(android.view.View, boolean);
     method public static void setNextClusterForwardId(android.view.View, int);
     method public static void setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener?);
     method public static void setOnReceiveContentListener(android.view.View, String![]?, androidx.core.view.OnReceiveContentListener?);
@@ -4042,23 +4042,23 @@ package androidx.core.view {
     method @Deprecated public static void setScaleX(android.view.View!, float);
     method @Deprecated public static void setScaleY(android.view.View!, float);
     method @UiThread public static void setScreenReaderFocusable(android.view.View, boolean);
-    method public static void setScrollIndicators(android.view.View, int);
-    method public static void setScrollIndicators(android.view.View, int, int);
+    method @Deprecated public static void setScrollIndicators(android.view.View, int);
+    method @Deprecated public static void setScrollIndicators(android.view.View, int, int);
     method @UiThread public static void setStateDescription(android.view.View, CharSequence?);
     method public static void setSystemGestureExclusionRects(android.view.View, java.util.List<android.graphics.Rect!>);
     method public static void setTooltipText(android.view.View, CharSequence?);
-    method public static void setTransitionName(android.view.View, String?);
+    method @Deprecated public static void setTransitionName(android.view.View, String?);
     method @Deprecated public static void setTranslationX(android.view.View!, float);
     method @Deprecated public static void setTranslationY(android.view.View!, float);
-    method public static void setTranslationZ(android.view.View, float);
+    method @Deprecated public static void setTranslationZ(android.view.View, float);
     method public static void setWindowInsetsAnimationCallback(android.view.View, androidx.core.view.WindowInsetsAnimationCompat.Callback?);
     method @Deprecated public static void setX(android.view.View!, float);
     method @Deprecated public static void setY(android.view.View!, float);
-    method public static void setZ(android.view.View, float);
+    method @Deprecated public static void setZ(android.view.View, float);
     method public static boolean startDragAndDrop(android.view.View, android.content.ClipData?, android.view.View.DragShadowBuilder, Object?, int);
-    method public static boolean startNestedScroll(android.view.View, int);
+    method @Deprecated public static boolean startNestedScroll(android.view.View, int);
     method public static boolean startNestedScroll(android.view.View, int, int);
-    method public static void stopNestedScroll(android.view.View);
+    method @Deprecated public static void stopNestedScroll(android.view.View);
     method public static void stopNestedScroll(android.view.View, int);
     method public static void transformMatrixToGlobal(android.view.View, android.graphics.Matrix);
     method public static void updateDragShadow(android.view.View, android.view.View.DragShadowBuilder);
@@ -4273,13 +4273,13 @@ package androidx.core.view {
     method public void onAnimationUpdate(android.view.View);
   }
 
-  public class ViewStructureCompat {
-    method public void setClassName(String);
-    method public void setContentDescription(CharSequence);
-    method public void setDimens(int, int, int, int, int, int);
-    method public void setText(CharSequence);
-    method public android.view.ViewStructure toViewStructure();
-    method public static androidx.core.view.ViewStructureCompat toViewStructureCompat(android.view.ViewStructure);
+  @Deprecated public class ViewStructureCompat {
+    method @Deprecated public void setClassName(String);
+    method @Deprecated public void setContentDescription(CharSequence);
+    method @Deprecated public void setDimens(int, int, int, int, int, int);
+    method @Deprecated public void setText(CharSequence);
+    method @Deprecated public android.view.ViewStructure toViewStructure();
+    method @Deprecated public static androidx.core.view.ViewStructureCompat toViewStructureCompat(android.view.ViewStructure);
   }
 
   public final class WindowCompat {
@@ -5135,10 +5135,10 @@ package androidx.core.view.accessibility {
 
 package androidx.core.view.animation {
 
-  public final class PathInterpolatorCompat {
-    method public static android.view.animation.Interpolator create(android.graphics.Path);
-    method public static android.view.animation.Interpolator create(float, float);
-    method public static android.view.animation.Interpolator create(float, float, float, float);
+  @Deprecated public final class PathInterpolatorCompat {
+    method @Deprecated public static android.view.animation.Interpolator create(android.graphics.Path);
+    method @Deprecated public static android.view.animation.Interpolator create(float, float);
+    method @Deprecated public static android.view.animation.Interpolator create(float, float, float, float);
   }
 
 }
@@ -5156,7 +5156,7 @@ package androidx.core.view.contentcapture {
 
   public class ContentCaptureSessionCompat {
     method public android.view.autofill.AutofillId? newAutofillId(long);
-    method public androidx.core.view.ViewStructureCompat? newVirtualViewStructure(android.view.autofill.AutofillId, long);
+    method @Deprecated public androidx.core.view.ViewStructureCompat? newVirtualViewStructure(android.view.autofill.AutofillId, long);
     method public void notifyViewTextChanged(android.view.autofill.AutofillId, CharSequence?);
     method public void notifyViewsAppeared(java.util.List<android.view.ViewStructure!>);
     method public void notifyViewsDisappeared(long[]);
@@ -5293,20 +5293,20 @@ package androidx.core.widget {
     field public static final float RELATIVE_UNSPECIFIED = 0.0f;
   }
 
-  public final class CheckedTextViewCompat {
+  @Deprecated public final class CheckedTextViewCompat {
     method @Deprecated public static android.graphics.drawable.Drawable? getCheckMarkDrawable(android.widget.CheckedTextView);
-    method public static android.content.res.ColorStateList? getCheckMarkTintList(android.widget.CheckedTextView);
-    method public static android.graphics.PorterDuff.Mode? getCheckMarkTintMode(android.widget.CheckedTextView);
-    method public static void setCheckMarkTintList(android.widget.CheckedTextView, android.content.res.ColorStateList?);
-    method public static void setCheckMarkTintMode(android.widget.CheckedTextView, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static android.content.res.ColorStateList? getCheckMarkTintList(android.widget.CheckedTextView);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getCheckMarkTintMode(android.widget.CheckedTextView);
+    method @Deprecated public static void setCheckMarkTintList(android.widget.CheckedTextView, android.content.res.ColorStateList?);
+    method @Deprecated public static void setCheckMarkTintMode(android.widget.CheckedTextView, android.graphics.PorterDuff.Mode?);
   }
 
-  public final class CompoundButtonCompat {
-    method public static android.graphics.drawable.Drawable? getButtonDrawable(android.widget.CompoundButton);
-    method public static android.content.res.ColorStateList? getButtonTintList(android.widget.CompoundButton);
-    method public static android.graphics.PorterDuff.Mode? getButtonTintMode(android.widget.CompoundButton);
-    method public static void setButtonTintList(android.widget.CompoundButton, android.content.res.ColorStateList?);
-    method public static void setButtonTintMode(android.widget.CompoundButton, android.graphics.PorterDuff.Mode?);
+  @Deprecated public final class CompoundButtonCompat {
+    method @Deprecated public static android.graphics.drawable.Drawable? getButtonDrawable(android.widget.CompoundButton);
+    method @Deprecated public static android.content.res.ColorStateList? getButtonTintList(android.widget.CompoundButton);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getButtonTintMode(android.widget.CompoundButton);
+    method @Deprecated public static void setButtonTintList(android.widget.CompoundButton, android.content.res.ColorStateList?);
+    method @Deprecated public static void setButtonTintMode(android.widget.CompoundButton, android.graphics.PorterDuff.Mode?);
   }
 
   public class ContentLoadingProgressBar extends android.widget.ProgressBar {
@@ -5334,11 +5334,11 @@ package androidx.core.widget {
     method @Deprecated public void setSize(int, int);
   }
 
-  public class ImageViewCompat {
-    method public static android.content.res.ColorStateList? getImageTintList(android.widget.ImageView);
-    method public static android.graphics.PorterDuff.Mode? getImageTintMode(android.widget.ImageView);
-    method public static void setImageTintList(android.widget.ImageView, android.content.res.ColorStateList?);
-    method public static void setImageTintMode(android.widget.ImageView, android.graphics.PorterDuff.Mode?);
+  @Deprecated public class ImageViewCompat {
+    method @Deprecated public static android.content.res.ColorStateList? getImageTintList(android.widget.ImageView);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getImageTintMode(android.widget.ImageView);
+    method @Deprecated public static void setImageTintList(android.widget.ImageView, android.content.res.ColorStateList?);
+    method @Deprecated public static void setImageTintMode(android.widget.ImageView, android.graphics.PorterDuff.Mode?);
   }
 
   public final class ListPopupWindowCompat {
@@ -5410,11 +5410,11 @@ package androidx.core.widget {
     method public static android.view.View.OnTouchListener? getDragToOpenListener(Object);
   }
 
-  public final class PopupWindowCompat {
-    method public static boolean getOverlapAnchor(android.widget.PopupWindow);
-    method public static int getWindowLayoutType(android.widget.PopupWindow);
-    method public static void setOverlapAnchor(android.widget.PopupWindow, boolean);
-    method public static void setWindowLayoutType(android.widget.PopupWindow, int);
+  @Deprecated public final class PopupWindowCompat {
+    method @Deprecated public static boolean getOverlapAnchor(android.widget.PopupWindow);
+    method @Deprecated public static int getWindowLayoutType(android.widget.PopupWindow);
+    method @Deprecated public static void setOverlapAnchor(android.widget.PopupWindow, boolean);
+    method @Deprecated public static void setWindowLayoutType(android.widget.PopupWindow, int);
     method @Deprecated public static void showAsDropDown(android.widget.PopupWindow, android.view.View, int, int, int);
   }
 
@@ -5467,7 +5467,7 @@ package androidx.core.widget {
     method public static void setLineHeight(android.widget.TextView, @IntRange(from=0) @Px int);
     method public static void setLineHeight(android.widget.TextView, int, @FloatRange(from=0) float);
     method public static void setPrecomputedText(android.widget.TextView, androidx.core.text.PrecomputedTextCompat);
-    method public static void setTextAppearance(android.widget.TextView, @StyleRes int);
+    method @Deprecated public static void setTextAppearance(android.widget.TextView, @StyleRes int);
     method public static void setTextMetricsParams(android.widget.TextView, androidx.core.text.PrecomputedTextCompat.Params);
     field public static final int AUTO_SIZE_TEXT_TYPE_NONE = 0; // 0x0
     field public static final int AUTO_SIZE_TEXT_TYPE_UNIFORM = 1; // 0x1

--- a/core/core/api/restricted_current.txt
+++ b/core/core/api/restricted_current.txt
@@ -56,13 +56,13 @@ package androidx.core.app {
 
   public class ActivityCompat extends androidx.core.content.ContextCompat {
     ctor protected ActivityCompat();
-    method public static void finishAffinity(android.app.Activity);
-    method public static void finishAfterTransition(android.app.Activity);
+    method @Deprecated public static void finishAffinity(android.app.Activity);
+    method @Deprecated public static void finishAfterTransition(android.app.Activity);
     method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public static androidx.core.app.ActivityCompat.PermissionCompatDelegate? getPermissionCompatDelegate();
-    method public static android.net.Uri? getReferrer(android.app.Activity);
+    method @Deprecated public static android.net.Uri? getReferrer(android.app.Activity);
     method @Deprecated public static boolean invalidateOptionsMenu(android.app.Activity!);
     method public static boolean isLaunchedFromBubble(android.app.Activity);
-    method public static void postponeEnterTransition(android.app.Activity);
+    method @Deprecated public static void postponeEnterTransition(android.app.Activity);
     method public static void recreate(android.app.Activity);
     method public static androidx.core.view.DragAndDropPermissionsCompat? requestDragAndDropPermissions(android.app.Activity, android.view.DragEvent);
     method public static void requestPermissions(android.app.Activity, String![], @IntRange(from=0) int);
@@ -72,9 +72,9 @@ package androidx.core.app {
     method public static void setLocusContext(android.app.Activity, androidx.core.content.LocusIdCompat?, android.os.Bundle?);
     method public static void setPermissionCompatDelegate(androidx.core.app.ActivityCompat.PermissionCompatDelegate?);
     method public static boolean shouldShowRequestPermissionRationale(android.app.Activity, String);
-    method public static void startActivityForResult(android.app.Activity, android.content.Intent, int, android.os.Bundle?);
-    method public static void startIntentSenderForResult(android.app.Activity, android.content.IntentSender, int, android.content.Intent?, int, int, int, android.os.Bundle?) throws android.content.IntentSender.SendIntentException;
-    method public static void startPostponedEnterTransition(android.app.Activity);
+    method @Deprecated public static void startActivityForResult(android.app.Activity, android.content.Intent, int, android.os.Bundle?);
+    method @Deprecated public static void startIntentSenderForResult(android.app.Activity, android.content.IntentSender, int, android.content.Intent?, int, int, int, android.os.Bundle?) throws android.content.IntentSender.SendIntentException;
+    method @Deprecated public static void startPostponedEnterTransition(android.app.Activity);
   }
 
   public static interface ActivityCompat.OnRequestPermissionsResultCallback {
@@ -120,9 +120,9 @@ package androidx.core.app {
   public final class AlarmManagerCompat {
     method public static boolean canScheduleExactAlarms(android.app.AlarmManager);
     method public static void setAlarmClock(android.app.AlarmManager, long, android.app.PendingIntent, android.app.PendingIntent);
-    method public static void setAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
+    method @Deprecated public static void setAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
     method @Deprecated public static void setExact(android.app.AlarmManager, int, long, android.app.PendingIntent);
-    method public static void setExactAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
+    method @Deprecated public static void setExactAndAllowWhileIdle(android.app.AlarmManager, int, long, android.app.PendingIntent);
   }
 
   @RequiresApi(28) public class AppComponentFactory extends android.app.AppComponentFactory {
@@ -156,11 +156,11 @@ package androidx.core.app {
     method public static int noteOpNoThrow(android.content.Context, String, int, String);
     method public static int noteProxyOp(android.content.Context, String, String);
     method public static int noteProxyOpNoThrow(android.content.Context, String, String);
-    method public static String? permissionToOp(String);
-    field public static final int MODE_ALLOWED = 0; // 0x0
-    field public static final int MODE_DEFAULT = 3; // 0x3
-    field public static final int MODE_ERRORED = 2; // 0x2
-    field public static final int MODE_IGNORED = 1; // 0x1
+    method @Deprecated public static String? permissionToOp(String);
+    field @Deprecated public static final int MODE_ALLOWED = 0; // 0x0
+    field @Deprecated public static final int MODE_DEFAULT = 3; // 0x3
+    field @Deprecated public static final int MODE_ERRORED = 2; // 0x2
+    field @Deprecated public static final int MODE_IGNORED = 1; // 0x1
   }
 
   @Deprecated public final class BundleCompat {
@@ -1497,26 +1497,26 @@ package androidx.core.content {
     method public static android.content.Context createAttributionContext(android.content.Context, String?);
     method public static android.content.Context? createDeviceProtectedStorageContext(android.content.Context);
     method public static String? getAttributionTag(android.content.Context);
-    method public static java.io.File getCodeCacheDir(android.content.Context);
-    method @ColorInt public static int getColor(android.content.Context, @ColorRes int);
+    method @Deprecated public static java.io.File getCodeCacheDir(android.content.Context);
+    method @Deprecated @ColorInt public static int getColor(android.content.Context, @ColorRes int);
     method public static android.content.res.ColorStateList? getColorStateList(android.content.Context, @ColorRes int);
     method public static android.content.Context getContextForLanguage(android.content.Context);
     method public static java.io.File? getDataDir(android.content.Context);
     method public static android.view.Display getDisplayOrDefault(@DisplayContext android.content.Context);
-    method public static android.graphics.drawable.Drawable? getDrawable(android.content.Context, @DrawableRes int);
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawable(android.content.Context, @DrawableRes int);
     method @Deprecated public static java.io.File![] getExternalCacheDirs(android.content.Context);
     method @Deprecated public static java.io.File![] getExternalFilesDirs(android.content.Context, String?);
     method public static java.util.concurrent.Executor getMainExecutor(android.content.Context);
-    method public static java.io.File? getNoBackupFilesDir(android.content.Context);
+    method @Deprecated public static java.io.File? getNoBackupFilesDir(android.content.Context);
     method @Deprecated public static java.io.File![] getObbDirs(android.content.Context);
     method public static String getString(android.content.Context, int);
-    method public static <T> T? getSystemService(android.content.Context, Class<T>);
-    method public static String? getSystemServiceName(android.content.Context, Class<? extends java.lang.Object!>);
+    method @Deprecated public static <T> T? getSystemService(android.content.Context, Class<T>);
+    method @Deprecated public static String? getSystemServiceName(android.content.Context, Class<? extends java.lang.Object!>);
     method public static boolean isDeviceProtectedStorage(android.content.Context);
-    method public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, int);
+    method @Deprecated public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, int);
     method public static android.content.Intent? registerReceiver(android.content.Context, android.content.BroadcastReceiver?, android.content.IntentFilter, String?, android.os.Handler?, int);
-    method public static boolean startActivities(android.content.Context, android.content.Intent![]);
-    method public static boolean startActivities(android.content.Context, android.content.Intent![], android.os.Bundle?);
+    method @Deprecated public static boolean startActivities(android.content.Context, android.content.Intent![]);
+    method @Deprecated public static boolean startActivities(android.content.Context, android.content.Intent![], android.os.Bundle?);
     method @Deprecated public static void startActivity(android.content.Context, android.content.Intent, android.os.Bundle?);
     method public static void startForegroundService(android.content.Context, android.content.Intent);
     field public static final int RECEIVER_EXPORTED = 2; // 0x2
@@ -1887,10 +1887,10 @@ package androidx.core.content.res {
   public final class ResourcesCompat {
     method public static void clearCachesForTheme(android.content.res.Resources.Theme);
     method public static android.graphics.Typeface? getCachedFont(android.content.Context, @FontRes int) throws android.content.res.Resources.NotFoundException;
-    method @ColorInt public static int getColor(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated @ColorInt public static int getColor(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
     method public static android.content.res.ColorStateList? getColorStateList(android.content.res.Resources, @ColorRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
-    method public static android.graphics.drawable.Drawable? getDrawable(android.content.res.Resources, @DrawableRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
-    method public static android.graphics.drawable.Drawable? getDrawableForDensity(android.content.res.Resources, @DrawableRes int, int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawable(android.content.res.Resources, @DrawableRes int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
+    method @Deprecated public static android.graphics.drawable.Drawable? getDrawableForDensity(android.content.res.Resources, @DrawableRes int, int, android.content.res.Resources.Theme?) throws android.content.res.Resources.NotFoundException;
     method public static float getFloat(android.content.res.Resources, @DimenRes int);
     method public static android.graphics.Typeface? getFont(android.content.Context, @FontRes int) throws android.content.res.Resources.NotFoundException;
     method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public static android.graphics.Typeface? getFont(android.content.Context, @FontRes int, android.util.TypedValue, int, androidx.core.content.res.ResourcesCompat.FontCallback?) throws android.content.res.Resources.NotFoundException;
@@ -2207,7 +2207,7 @@ package androidx.core.graphics {
   }
 
   public final class PaintCompat {
-    method public static boolean hasGlyph(android.graphics.Paint, String);
+    method @Deprecated public static boolean hasGlyph(android.graphics.Paint, String);
     method public static boolean setBlendMode(android.graphics.Paint, androidx.core.graphics.BlendModeCompat?);
   }
 
@@ -2418,25 +2418,25 @@ package androidx.core.graphics.drawable {
     method public static inline android.graphics.drawable.ColorDrawable toDrawable(@ColorInt int);
   }
 
-  public final class DrawableCompat {
-    method public static void applyTheme(android.graphics.drawable.Drawable, android.content.res.Resources.Theme);
-    method public static boolean canApplyTheme(android.graphics.drawable.Drawable);
-    method public static void clearColorFilter(android.graphics.drawable.Drawable);
+  @Deprecated public final class DrawableCompat {
+    method @Deprecated public static void applyTheme(android.graphics.drawable.Drawable, android.content.res.Resources.Theme);
+    method @Deprecated public static boolean canApplyTheme(android.graphics.drawable.Drawable);
+    method @Deprecated public static void clearColorFilter(android.graphics.drawable.Drawable);
     method @Deprecated public static int getAlpha(android.graphics.drawable.Drawable);
-    method public static android.graphics.ColorFilter? getColorFilter(android.graphics.drawable.Drawable);
-    method public static int getLayoutDirection(android.graphics.drawable.Drawable);
-    method public static void inflate(android.graphics.drawable.Drawable, android.content.res.Resources, org.xmlpull.v1.XmlPullParser, android.util.AttributeSet, android.content.res.Resources.Theme?) throws java.io.IOException, org.xmlpull.v1.XmlPullParserException;
+    method @Deprecated public static android.graphics.ColorFilter? getColorFilter(android.graphics.drawable.Drawable);
+    method @Deprecated public static int getLayoutDirection(android.graphics.drawable.Drawable);
+    method @Deprecated public static void inflate(android.graphics.drawable.Drawable, android.content.res.Resources, org.xmlpull.v1.XmlPullParser, android.util.AttributeSet, android.content.res.Resources.Theme?) throws java.io.IOException, org.xmlpull.v1.XmlPullParserException;
     method @Deprecated public static boolean isAutoMirrored(android.graphics.drawable.Drawable);
     method @Deprecated public static void jumpToCurrentState(android.graphics.drawable.Drawable);
     method @Deprecated public static void setAutoMirrored(android.graphics.drawable.Drawable, boolean);
-    method public static void setHotspot(android.graphics.drawable.Drawable, float, float);
-    method public static void setHotspotBounds(android.graphics.drawable.Drawable, int, int, int, int);
-    method public static boolean setLayoutDirection(android.graphics.drawable.Drawable, int);
-    method public static void setTint(android.graphics.drawable.Drawable, @ColorInt int);
-    method public static void setTintList(android.graphics.drawable.Drawable, android.content.res.ColorStateList?);
-    method public static void setTintMode(android.graphics.drawable.Drawable, android.graphics.PorterDuff.Mode?);
-    method public static <T extends android.graphics.drawable.Drawable> T unwrap(android.graphics.drawable.Drawable);
-    method public static android.graphics.drawable.Drawable wrap(android.graphics.drawable.Drawable);
+    method @Deprecated public static void setHotspot(android.graphics.drawable.Drawable, float, float);
+    method @Deprecated public static void setHotspotBounds(android.graphics.drawable.Drawable, int, int, int, int);
+    method @Deprecated public static boolean setLayoutDirection(android.graphics.drawable.Drawable, int);
+    method @Deprecated public static void setTint(android.graphics.drawable.Drawable, @ColorInt int);
+    method @Deprecated public static void setTintList(android.graphics.drawable.Drawable, android.content.res.ColorStateList?);
+    method @Deprecated public static void setTintMode(android.graphics.drawable.Drawable, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static <T extends android.graphics.drawable.Drawable> T unwrap(android.graphics.drawable.Drawable);
+    method @Deprecated public static android.graphics.drawable.Drawable wrap(android.graphics.drawable.Drawable);
   }
 
   public final class DrawableKt {
@@ -2965,9 +2965,9 @@ package androidx.core.os {
     method @Deprecated @RequiresApi(24) public static androidx.core.os.LocaleListCompat! wrap(Object!);
   }
 
-  public final class MessageCompat {
-    method public static boolean isAsynchronous(android.os.Message);
-    method public static void setAsynchronous(android.os.Message, boolean);
+  @Deprecated public final class MessageCompat {
+    method @Deprecated public static boolean isAsynchronous(android.os.Message);
+    method @Deprecated public static void setAsynchronous(android.os.Message, boolean);
   }
 
   public class OperationCanceledException extends java.lang.RuntimeException {
@@ -3674,21 +3674,21 @@ package androidx.core.util {
     method public static Runnable asRunnable(kotlin.coroutines.Continuation<? super kotlin.Unit>);
   }
 
-  public final class SizeFCompat {
-    ctor public SizeFCompat(float, float);
-    method public float getHeight();
-    method public float getWidth();
-    method public android.util.SizeF toSizeF();
-    method public static androidx.core.util.SizeFCompat toSizeFCompat(android.util.SizeF);
+  @Deprecated public final class SizeFCompat {
+    ctor @Deprecated public SizeFCompat(float, float);
+    method @Deprecated public float getHeight();
+    method @Deprecated public float getWidth();
+    method @Deprecated public android.util.SizeF toSizeF();
+    method @Deprecated public static androidx.core.util.SizeFCompat toSizeFCompat(android.util.SizeF);
   }
 
   public final class SizeKt {
     method public static inline operator int component1(android.util.Size);
     method public static inline operator float component1(android.util.SizeF);
-    method public static inline operator float component1(androidx.core.util.SizeFCompat);
+    method @Deprecated public static inline operator float component1(androidx.core.util.SizeFCompat);
     method public static inline operator int component2(android.util.Size);
     method public static inline operator float component2(android.util.SizeF);
-    method public static inline operator float component2(androidx.core.util.SizeFCompat);
+    method @Deprecated public static inline operator float component2(androidx.core.util.SizeFCompat);
   }
 
   public final class SparseArrayKt {
@@ -4419,11 +4419,11 @@ package androidx.core.view {
     method public static androidx.core.view.WindowInsetsCompat computeSystemWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat, android.graphics.Rect);
     method public static androidx.core.view.WindowInsetsCompat dispatchApplyWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat);
     method public static void dispatchFinishTemporaryDetach(android.view.View);
-    method public static boolean dispatchNestedFling(android.view.View, float, float, boolean);
-    method public static boolean dispatchNestedPreFling(android.view.View, float, float);
-    method public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?);
+    method @Deprecated public static boolean dispatchNestedFling(android.view.View, float, float, boolean);
+    method @Deprecated public static boolean dispatchNestedPreFling(android.view.View, float, float);
+    method @Deprecated public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?);
     method public static boolean dispatchNestedPreScroll(android.view.View, int, int, int[]?, int[]?, @androidx.core.view.ViewCompat.NestedScrollType int);
-    method public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?);
+    method @Deprecated public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?);
     method public static boolean dispatchNestedScroll(android.view.View, int, int, int, int, int[]?, @androidx.core.view.ViewCompat.NestedScrollType int);
     method public static void dispatchNestedScroll(android.view.View, int, int, int, int, int[]?, @androidx.core.view.ViewCompat.NestedScrollType int, int[]);
     method public static void dispatchStartTemporaryDetach(android.view.View);
@@ -4435,12 +4435,12 @@ package androidx.core.view {
     method @UiThread public static CharSequence? getAccessibilityPaneTitle(android.view.View);
     method @Deprecated public static float getAlpha(android.view.View!);
     method public static androidx.core.view.autofill.AutofillIdCompat? getAutofillId(android.view.View);
-    method public static android.content.res.ColorStateList? getBackgroundTintList(android.view.View);
-    method public static android.graphics.PorterDuff.Mode? getBackgroundTintMode(android.view.View);
+    method @Deprecated public static android.content.res.ColorStateList? getBackgroundTintList(android.view.View);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getBackgroundTintMode(android.view.View);
     method @Deprecated public static android.graphics.Rect? getClipBounds(android.view.View);
     method public static androidx.core.view.contentcapture.ContentCaptureSessionCompat? getContentCaptureSession(android.view.View);
     method @Deprecated public static android.view.Display? getDisplay(android.view.View);
-    method public static float getElevation(android.view.View);
+    method @Deprecated public static float getElevation(android.view.View);
     method @Deprecated public static boolean getFitsSystemWindows(android.view.View);
     method @Deprecated public static int getImportantForAccessibility(android.view.View);
     method public static int getImportantForAutofill(android.view.View);
@@ -4468,21 +4468,21 @@ package androidx.core.view {
     method @Deprecated public static float getRotationY(android.view.View!);
     method @Deprecated public static float getScaleX(android.view.View!);
     method @Deprecated public static float getScaleY(android.view.View!);
-    method public static int getScrollIndicators(android.view.View);
+    method @Deprecated public static int getScrollIndicators(android.view.View);
     method @UiThread public static CharSequence? getStateDescription(android.view.View);
     method public static java.util.List<android.graphics.Rect!> getSystemGestureExclusionRects(android.view.View);
-    method public static String? getTransitionName(android.view.View);
+    method @Deprecated public static String? getTransitionName(android.view.View);
     method @Deprecated public static float getTranslationX(android.view.View!);
     method @Deprecated public static float getTranslationY(android.view.View!);
-    method public static float getTranslationZ(android.view.View);
+    method @Deprecated public static float getTranslationZ(android.view.View);
     method @Deprecated public static androidx.core.view.WindowInsetsControllerCompat? getWindowInsetsController(android.view.View);
     method @Deprecated public static int getWindowSystemUiVisibility(android.view.View);
     method @Deprecated public static float getX(android.view.View!);
     method @Deprecated public static float getY(android.view.View!);
-    method public static float getZ(android.view.View);
+    method @Deprecated public static float getZ(android.view.View);
     method public static boolean hasAccessibilityDelegate(android.view.View);
     method public static boolean hasExplicitFocusable(android.view.View);
-    method public static boolean hasNestedScrollingParent(android.view.View);
+    method @Deprecated public static boolean hasNestedScrollingParent(android.view.View);
     method public static boolean hasNestedScrollingParent(android.view.View, @androidx.core.view.ViewCompat.NestedScrollType int);
     method @Deprecated public static boolean hasOnClickListeners(android.view.View);
     method @Deprecated public static boolean hasOverlappingRendering(android.view.View);
@@ -4490,21 +4490,21 @@ package androidx.core.view {
     method @UiThread public static boolean isAccessibilityHeading(android.view.View);
     method @Deprecated public static boolean isAttachedToWindow(android.view.View);
     method public static boolean isFocusedByDefault(android.view.View);
-    method public static boolean isImportantForAccessibility(android.view.View);
+    method @Deprecated public static boolean isImportantForAccessibility(android.view.View);
     method public static boolean isImportantForAutofill(android.view.View);
     method public static boolean isImportantForContentCapture(android.view.View);
     method @Deprecated public static boolean isInLayout(android.view.View);
     method public static boolean isKeyboardNavigationCluster(android.view.View);
     method @Deprecated public static boolean isLaidOut(android.view.View);
     method @Deprecated public static boolean isLayoutDirectionResolved(android.view.View);
-    method public static boolean isNestedScrollingEnabled(android.view.View);
+    method @Deprecated public static boolean isNestedScrollingEnabled(android.view.View);
     method @Deprecated public static boolean isOpaque(android.view.View!);
     method @Deprecated public static boolean isPaddingRelative(android.view.View);
     method @UiThread public static boolean isScreenReaderFocusable(android.view.View);
     method @Deprecated public static void jumpDrawablesToCurrentState(android.view.View!);
     method public static android.view.View? keyboardNavigationClusterSearch(android.view.View, android.view.View?, @androidx.core.view.ViewCompat.FocusDirection int);
-    method public static void offsetLeftAndRight(android.view.View, int);
-    method public static void offsetTopAndBottom(android.view.View, int);
+    method @Deprecated public static void offsetLeftAndRight(android.view.View, int);
+    method @Deprecated public static void offsetTopAndBottom(android.view.View, int);
     method public static androidx.core.view.WindowInsetsCompat onApplyWindowInsets(android.view.View, androidx.core.view.WindowInsetsCompat);
     method @Deprecated public static void onInitializeAccessibilityEvent(android.view.View!, android.view.accessibility.AccessibilityEvent!);
     method @Deprecated public static void onInitializeAccessibilityNodeInfo(android.view.View, androidx.core.view.accessibility.AccessibilityNodeInfoCompat);
@@ -4520,7 +4520,7 @@ package androidx.core.view {
     method public static void removeAccessibilityAction(android.view.View, int);
     method public static void removeOnUnhandledKeyEventListener(android.view.View, androidx.core.view.ViewCompat.OnUnhandledKeyEventListenerCompat);
     method public static void replaceAccessibilityAction(android.view.View, androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat, CharSequence?, androidx.core.view.accessibility.AccessibilityViewCommand?);
-    method public static void requestApplyInsets(android.view.View);
+    method @Deprecated public static void requestApplyInsets(android.view.View);
     method public static <T extends android.view.View> T requireViewById(android.view.View, @IdRes int);
     method @Deprecated public static int resolveSizeAndState(int, int, int);
     method public static boolean restoreDefaultFocus(android.view.View);
@@ -4534,12 +4534,12 @@ package androidx.core.view {
     method public static void setAutofillHints(android.view.View, java.lang.String!...?);
     method public static void setAutofillId(android.view.View, androidx.core.view.autofill.AutofillIdCompat?);
     method @Deprecated public static void setBackground(android.view.View, android.graphics.drawable.Drawable?);
-    method public static void setBackgroundTintList(android.view.View, android.content.res.ColorStateList?);
-    method public static void setBackgroundTintMode(android.view.View, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static void setBackgroundTintList(android.view.View, android.content.res.ColorStateList?);
+    method @Deprecated public static void setBackgroundTintMode(android.view.View, android.graphics.PorterDuff.Mode?);
     method @Deprecated public static void setChildrenDrawingOrderEnabled(android.view.ViewGroup!, boolean);
     method @Deprecated public static void setClipBounds(android.view.View, android.graphics.Rect?);
     method public static void setContentCaptureSession(android.view.View, androidx.core.view.contentcapture.ContentCaptureSessionCompat?);
-    method public static void setElevation(android.view.View, float);
+    method @Deprecated public static void setElevation(android.view.View, float);
     method @Deprecated public static void setFitsSystemWindows(android.view.View!, boolean);
     method public static void setFocusedByDefault(android.view.View, boolean);
     method @Deprecated public static void setHasTransientState(android.view.View, boolean);
@@ -4551,7 +4551,7 @@ package androidx.core.view {
     method @Deprecated public static void setLayerPaint(android.view.View, android.graphics.Paint?);
     method @Deprecated public static void setLayerType(android.view.View!, int, android.graphics.Paint!);
     method @Deprecated public static void setLayoutDirection(android.view.View, int);
-    method public static void setNestedScrollingEnabled(android.view.View, boolean);
+    method @Deprecated public static void setNestedScrollingEnabled(android.view.View, boolean);
     method public static void setNextClusterForwardId(android.view.View, int);
     method public static void setOnApplyWindowInsetsListener(android.view.View, androidx.core.view.OnApplyWindowInsetsListener?);
     method public static void setOnReceiveContentListener(android.view.View, String![]?, androidx.core.view.OnReceiveContentListener?);
@@ -4567,23 +4567,23 @@ package androidx.core.view {
     method @Deprecated public static void setScaleX(android.view.View!, float);
     method @Deprecated public static void setScaleY(android.view.View!, float);
     method @UiThread public static void setScreenReaderFocusable(android.view.View, boolean);
-    method public static void setScrollIndicators(android.view.View, @androidx.core.view.ViewCompat.ScrollIndicators int);
-    method public static void setScrollIndicators(android.view.View, @androidx.core.view.ViewCompat.ScrollIndicators int, @androidx.core.view.ViewCompat.ScrollIndicators int);
+    method @Deprecated public static void setScrollIndicators(android.view.View, @androidx.core.view.ViewCompat.ScrollIndicators int);
+    method @Deprecated public static void setScrollIndicators(android.view.View, @androidx.core.view.ViewCompat.ScrollIndicators int, @androidx.core.view.ViewCompat.ScrollIndicators int);
     method @UiThread public static void setStateDescription(android.view.View, CharSequence?);
     method public static void setSystemGestureExclusionRects(android.view.View, java.util.List<android.graphics.Rect!>);
     method public static void setTooltipText(android.view.View, CharSequence?);
-    method public static void setTransitionName(android.view.View, String?);
+    method @Deprecated public static void setTransitionName(android.view.View, String?);
     method @Deprecated public static void setTranslationX(android.view.View!, float);
     method @Deprecated public static void setTranslationY(android.view.View!, float);
-    method public static void setTranslationZ(android.view.View, float);
+    method @Deprecated public static void setTranslationZ(android.view.View, float);
     method public static void setWindowInsetsAnimationCallback(android.view.View, androidx.core.view.WindowInsetsAnimationCompat.Callback?);
     method @Deprecated public static void setX(android.view.View!, float);
     method @Deprecated public static void setY(android.view.View!, float);
-    method public static void setZ(android.view.View, float);
+    method @Deprecated public static void setZ(android.view.View, float);
     method public static boolean startDragAndDrop(android.view.View, android.content.ClipData?, android.view.View.DragShadowBuilder, Object?, int);
-    method public static boolean startNestedScroll(android.view.View, @androidx.core.view.ViewCompat.ScrollAxis int);
+    method @Deprecated public static boolean startNestedScroll(android.view.View, @androidx.core.view.ViewCompat.ScrollAxis int);
     method public static boolean startNestedScroll(android.view.View, @androidx.core.view.ViewCompat.ScrollAxis int, @androidx.core.view.ViewCompat.NestedScrollType int);
-    method public static void stopNestedScroll(android.view.View);
+    method @Deprecated public static void stopNestedScroll(android.view.View);
     method public static void stopNestedScroll(android.view.View, @androidx.core.view.ViewCompat.NestedScrollType int);
     method public static void transformMatrixToGlobal(android.view.View, android.graphics.Matrix);
     method public static void updateDragShadow(android.view.View, android.view.View.DragShadowBuilder);
@@ -4816,13 +4816,13 @@ package androidx.core.view {
     method public void onAnimationUpdate(android.view.View);
   }
 
-  public class ViewStructureCompat {
-    method public void setClassName(String);
-    method public void setContentDescription(CharSequence);
-    method public void setDimens(int, int, int, int, int, int);
-    method public void setText(CharSequence);
-    method public android.view.ViewStructure toViewStructure();
-    method public static androidx.core.view.ViewStructureCompat toViewStructureCompat(android.view.ViewStructure);
+  @Deprecated public class ViewStructureCompat {
+    method @Deprecated public void setClassName(String);
+    method @Deprecated public void setContentDescription(CharSequence);
+    method @Deprecated public void setDimens(int, int, int, int, int, int);
+    method @Deprecated public void setText(CharSequence);
+    method @Deprecated public android.view.ViewStructure toViewStructure();
+    method @Deprecated public static androidx.core.view.ViewStructureCompat toViewStructureCompat(android.view.ViewStructure);
   }
 
   public final class WindowCompat {
@@ -5718,10 +5718,10 @@ package androidx.core.view.accessibility {
 
 package androidx.core.view.animation {
 
-  public final class PathInterpolatorCompat {
-    method public static android.view.animation.Interpolator create(android.graphics.Path);
-    method public static android.view.animation.Interpolator create(float, float);
-    method public static android.view.animation.Interpolator create(float, float, float, float);
+  @Deprecated public final class PathInterpolatorCompat {
+    method @Deprecated public static android.view.animation.Interpolator create(android.graphics.Path);
+    method @Deprecated public static android.view.animation.Interpolator create(float, float);
+    method @Deprecated public static android.view.animation.Interpolator create(float, float, float, float);
   }
 
 }
@@ -5739,7 +5739,7 @@ package androidx.core.view.contentcapture {
 
   public class ContentCaptureSessionCompat {
     method public android.view.autofill.AutofillId? newAutofillId(long);
-    method public androidx.core.view.ViewStructureCompat? newVirtualViewStructure(android.view.autofill.AutofillId, long);
+    method @Deprecated public androidx.core.view.ViewStructureCompat? newVirtualViewStructure(android.view.autofill.AutofillId, long);
     method public void notifyViewTextChanged(android.view.autofill.AutofillId, CharSequence?);
     method public void notifyViewsAppeared(java.util.List<android.view.ViewStructure!>);
     method public void notifyViewsDisappeared(long[]);
@@ -5888,20 +5888,20 @@ package androidx.core.widget {
     field @Deprecated @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public static final boolean PLATFORM_SUPPORTS_AUTOSIZE;
   }
 
-  public final class CheckedTextViewCompat {
+  @Deprecated public final class CheckedTextViewCompat {
     method @Deprecated public static android.graphics.drawable.Drawable? getCheckMarkDrawable(android.widget.CheckedTextView);
-    method public static android.content.res.ColorStateList? getCheckMarkTintList(android.widget.CheckedTextView);
-    method public static android.graphics.PorterDuff.Mode? getCheckMarkTintMode(android.widget.CheckedTextView);
-    method public static void setCheckMarkTintList(android.widget.CheckedTextView, android.content.res.ColorStateList?);
-    method public static void setCheckMarkTintMode(android.widget.CheckedTextView, android.graphics.PorterDuff.Mode?);
+    method @Deprecated public static android.content.res.ColorStateList? getCheckMarkTintList(android.widget.CheckedTextView);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getCheckMarkTintMode(android.widget.CheckedTextView);
+    method @Deprecated public static void setCheckMarkTintList(android.widget.CheckedTextView, android.content.res.ColorStateList?);
+    method @Deprecated public static void setCheckMarkTintMode(android.widget.CheckedTextView, android.graphics.PorterDuff.Mode?);
   }
 
-  public final class CompoundButtonCompat {
-    method public static android.graphics.drawable.Drawable? getButtonDrawable(android.widget.CompoundButton);
-    method public static android.content.res.ColorStateList? getButtonTintList(android.widget.CompoundButton);
-    method public static android.graphics.PorterDuff.Mode? getButtonTintMode(android.widget.CompoundButton);
-    method public static void setButtonTintList(android.widget.CompoundButton, android.content.res.ColorStateList?);
-    method public static void setButtonTintMode(android.widget.CompoundButton, android.graphics.PorterDuff.Mode?);
+  @Deprecated public final class CompoundButtonCompat {
+    method @Deprecated public static android.graphics.drawable.Drawable? getButtonDrawable(android.widget.CompoundButton);
+    method @Deprecated public static android.content.res.ColorStateList? getButtonTintList(android.widget.CompoundButton);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getButtonTintMode(android.widget.CompoundButton);
+    method @Deprecated public static void setButtonTintList(android.widget.CompoundButton, android.content.res.ColorStateList?);
+    method @Deprecated public static void setButtonTintMode(android.widget.CompoundButton, android.graphics.PorterDuff.Mode?);
   }
 
   public class ContentLoadingProgressBar extends android.widget.ProgressBar {
@@ -5929,11 +5929,11 @@ package androidx.core.widget {
     method @Deprecated public void setSize(int, int);
   }
 
-  public class ImageViewCompat {
-    method public static android.content.res.ColorStateList? getImageTintList(android.widget.ImageView);
-    method public static android.graphics.PorterDuff.Mode? getImageTintMode(android.widget.ImageView);
-    method public static void setImageTintList(android.widget.ImageView, android.content.res.ColorStateList?);
-    method public static void setImageTintMode(android.widget.ImageView, android.graphics.PorterDuff.Mode?);
+  @Deprecated public class ImageViewCompat {
+    method @Deprecated public static android.content.res.ColorStateList? getImageTintList(android.widget.ImageView);
+    method @Deprecated public static android.graphics.PorterDuff.Mode? getImageTintMode(android.widget.ImageView);
+    method @Deprecated public static void setImageTintList(android.widget.ImageView, android.content.res.ColorStateList?);
+    method @Deprecated public static void setImageTintMode(android.widget.ImageView, android.graphics.PorterDuff.Mode?);
   }
 
   public final class ListPopupWindowCompat {
@@ -6005,11 +6005,11 @@ package androidx.core.widget {
     method public static android.view.View.OnTouchListener? getDragToOpenListener(Object);
   }
 
-  public final class PopupWindowCompat {
-    method public static boolean getOverlapAnchor(android.widget.PopupWindow);
-    method public static int getWindowLayoutType(android.widget.PopupWindow);
-    method public static void setOverlapAnchor(android.widget.PopupWindow, boolean);
-    method public static void setWindowLayoutType(android.widget.PopupWindow, int);
+  @Deprecated public final class PopupWindowCompat {
+    method @Deprecated public static boolean getOverlapAnchor(android.widget.PopupWindow);
+    method @Deprecated public static int getWindowLayoutType(android.widget.PopupWindow);
+    method @Deprecated public static void setOverlapAnchor(android.widget.PopupWindow, boolean);
+    method @Deprecated public static void setWindowLayoutType(android.widget.PopupWindow, int);
     method @Deprecated public static void showAsDropDown(android.widget.PopupWindow, android.view.View, int, int, int);
   }
 
@@ -6062,7 +6062,7 @@ package androidx.core.widget {
     method public static void setLineHeight(android.widget.TextView, @IntRange(from=0) @Px int);
     method public static void setLineHeight(android.widget.TextView, int, @FloatRange(from=0) float);
     method public static void setPrecomputedText(android.widget.TextView, androidx.core.text.PrecomputedTextCompat);
-    method public static void setTextAppearance(android.widget.TextView, @StyleRes int);
+    method @Deprecated public static void setTextAppearance(android.widget.TextView, @StyleRes int);
     method public static void setTextMetricsParams(android.widget.TextView, androidx.core.text.PrecomputedTextCompat.Params);
     method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public static android.view.ActionMode.Callback? unwrapCustomSelectionActionModeCallback(android.view.ActionMode.Callback?);
     method @RestrictTo(androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX) public static android.view.ActionMode.Callback? wrapCustomSelectionActionModeCallback(android.widget.TextView, android.view.ActionMode.Callback?);

--- a/core/core/src/androidTest/java/android/support/v4/testutils/LayoutDirectionActions.java
+++ b/core/core/src/androidTest/java/android/support/v4/testutils/LayoutDirectionActions.java
@@ -20,7 +20,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 import android.view.View;
 
-import androidx.core.view.ViewCompat;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
 
@@ -46,7 +45,7 @@ public class LayoutDirectionActions {
             public void perform(UiController uiController, View view) {
                 uiController.loopMainThreadUntilIdle();
 
-                ViewCompat.setLayoutDirection(view, layoutDirection);
+                view.setLayoutDirection(layoutDirection);
 
                 uiController.loopMainThreadUntilIdle();
             }

--- a/core/core/src/androidTest/java/android/support/v4/testutils/TextViewActions.java
+++ b/core/core/src/androidTest/java/android/support/v4/testutils/TextViewActions.java
@@ -25,7 +25,6 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
 import androidx.annotation.StyleRes;
-import androidx.core.widget.TextViewCompat;
 import androidx.test.espresso.UiController;
 import androidx.test.espresso.ViewAction;
 
@@ -134,7 +133,7 @@ public class TextViewActions {
                 uiController.loopMainThreadUntilIdle();
 
                 TextView textView = (TextView) view;
-                TextViewCompat.setTextAppearance(textView, styleResId);
+                textView.setTextAppearance(styleResId);
 
                 uiController.loopMainThreadUntilIdle();
             }
@@ -163,7 +162,7 @@ public class TextViewActions {
                 uiController.loopMainThreadUntilIdle();
 
                 TextView textView = (TextView) view;
-                TextViewCompat.setCompoundDrawablesRelative(textView, start, top, end, bottom);
+                textView.setCompoundDrawablesRelative(start, top, end, bottom);
 
                 uiController.loopMainThreadUntilIdle();
             }
@@ -192,8 +191,7 @@ public class TextViewActions {
                 uiController.loopMainThreadUntilIdle();
 
                 TextView textView = (TextView) view;
-                TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                        textView, start, top, end, bottom);
+                textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
 
                 uiController.loopMainThreadUntilIdle();
             }
@@ -222,8 +220,7 @@ public class TextViewActions {
                 uiController.loopMainThreadUntilIdle();
 
                 TextView textView = (TextView) view;
-                TextViewCompat.setCompoundDrawablesRelativeWithIntrinsicBounds(
-                        textView, start, top, end, bottom);
+                textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom);
 
                 uiController.loopMainThreadUntilIdle();
             }

--- a/core/core/src/androidTest/java/androidx/core/app/NotificationCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/app/NotificationCompatTest.java
@@ -70,7 +70,6 @@ import androidx.collection.ArraySet;
 import androidx.core.R;
 import androidx.core.app.NotificationCompat.MessagingStyle.Message;
 import androidx.core.app.NotificationCompat.Style;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.LocusIdCompat;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -3118,7 +3117,7 @@ public class NotificationCompatTest extends BaseInstrumentationTestCase<TestActi
         // Check that the decline action has the suggested color and title.
         assertEquals(mContext.getString(R.string.call_notification_hang_up_action),
                 notification.actions[0].title.toString());
-        assertEquals(ContextCompat.getColor(mContext, R.color.call_notification_decline_color),
+        assertEquals(mContext.getColor(R.color.call_notification_decline_color),
                 ((SpannableStringBuilder) notification.actions[0].title).getSpans(0,
                         notification.actions[0].title.length(),
                         ForegroundColorSpan.class)[0].getForegroundColor());
@@ -3126,7 +3125,7 @@ public class NotificationCompatTest extends BaseInstrumentationTestCase<TestActi
         // Check that the answer action has the suggested color and title.
         assertEquals(mContext.getString(R.string.call_notification_answer_action),
                 notification.actions[1].title.toString());
-        assertEquals(ContextCompat.getColor(mContext, R.color.call_notification_answer_color),
+        assertEquals(mContext.getColor(R.color.call_notification_answer_color),
                 ((SpannableStringBuilder) notification.actions[1].title).getSpans(0,
                         notification.actions[1].title.length(),
                         ForegroundColorSpan.class)[0].getForegroundColor());

--- a/core/core/src/androidTest/java/androidx/core/content/FileProviderTest.java
+++ b/core/core/src/androidTest/java/androidx/core/content/FileProviderTest.java
@@ -466,12 +466,12 @@ public class FileProviderTest {
                 buildPath(Environment.getExternalStorageDirectory(), "Android", "obb", "foobar"));
         assertEquals("content://moocow/test_external/Android/obb/foobar", actual.toString());
 
-        File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(mContext, null);
+        File[] externalFilesDirs = mContext.getExternalFilesDirs(null);
         actual = FileProvider.getUriForFile(mContext, TEST_AUTHORITY,
                 buildPath(externalFilesDirs[0], "foo", "bar"));
         assertEquals("content://moocow/test_external_files/foo/bar", actual.toString());
 
-        File[] externalCacheDirs = ContextCompat.getExternalCacheDirs(mContext);
+        File[] externalCacheDirs = mContext.getExternalCacheDirs();
         actual = FileProvider.getUriForFile(mContext, TEST_AUTHORITY,
                 buildPath(externalCacheDirs[0], "foo", "bar"));
         assertEquals("content://moocow/test_external_cache/foo/bar", actual.toString());

--- a/core/core/src/androidTest/java/androidx/core/content/pm/ShortcutInfoCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/content/pm/ShortcutInfoCompatTest.java
@@ -39,7 +39,6 @@ import android.os.PersistableBundle;
 
 import androidx.core.app.Person;
 import androidx.core.app.TestActivity;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.LocusIdCompat;
 import androidx.core.graphics.drawable.IconCompat;
 import androidx.core.test.R;
@@ -115,14 +114,14 @@ public class ShortcutInfoCompatTest {
         assertEquals(mAction, intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT));
         assertNull(intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE));
 
-        verifyBadgeBitmap(intent, ContextCompat.getColor(mContext, R.color.test_red),
-                ContextCompat.getColor(mContext, R.color.test_blue));
+        verifyBadgeBitmap(intent, mContext.getColor(R.color.test_red),
+                mContext.getColor(R.color.test_blue));
     }
 
     @Test
     public void testAddToIntent_badgeApplication() {
         ApplicationInfo appInfo = spy(mContext.getApplicationInfo());
-        doReturn(ContextCompat.getDrawable(mContext, R.drawable.test_drawable_green))
+        doReturn(mContext.getDrawable(R.drawable.test_drawable_green))
                 .when(appInfo).loadIcon(any(PackageManager.class));
         doReturn(appInfo).when(mContext).getApplicationInfo();
 
@@ -134,8 +133,8 @@ public class ShortcutInfoCompatTest {
         assertEquals(mAction, intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_INTENT));
         assertNull(intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE));
 
-        verifyBadgeBitmap(intent, ContextCompat.getColor(mContext, R.color.test_red),
-                ContextCompat.getColor(mContext, R.color.test_green));
+        verifyBadgeBitmap(intent, mContext.getColor(R.color.test_red),
+                mContext.getColor(R.color.test_green));
     }
 
     @Test

--- a/core/core/src/androidTest/java/androidx/core/graphics/drawable/IconCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/graphics/drawable/IconCompatTest.java
@@ -37,7 +37,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 
-import androidx.core.content.ContextCompat;
 import androidx.core.test.R;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -112,11 +111,11 @@ public class IconCompatTest {
         bitmap.eraseColor(Color.RED);
         Intent intent = new Intent();
 
-        Drawable badge = ContextCompat.getDrawable(context, R.drawable.test_drawable_blue);
+        Drawable badge = context.getDrawable(R.drawable.test_drawable_blue);
         IconCompat.createWithBitmap(bitmap).addToShortcutIntent(intent, badge, mContext);
         assertNotSame(bitmap, intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON));
 
-        verifyBadgeBitmap(intent, Color.RED, ContextCompat.getColor(context, R.color.test_blue));
+        verifyBadgeBitmap(intent, Color.RED, context.getColor(R.color.test_blue));
     }
 
     @Test
@@ -131,13 +130,13 @@ public class IconCompatTest {
         assertNull(intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON));
 
         intent = new Intent();
-        Drawable badge = ContextCompat.getDrawable(context, R.drawable.test_drawable_red);
+        Drawable badge = context.getDrawable(R.drawable.test_drawable_red);
         IconCompat.createWithResource(context, R.drawable.test_drawable_blue)
                 .addToShortcutIntent(intent, badge, mContext);
 
         assertNull(intent.getParcelableExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE));
-        verifyBadgeBitmap(intent, ContextCompat.getColor(context, R.color.test_blue),
-                ContextCompat.getColor(context, R.color.test_red));
+        verifyBadgeBitmap(intent, context.getColor(R.color.test_blue),
+                context.getColor(R.color.test_red));
     }
 
     @Test
@@ -402,8 +401,7 @@ public class IconCompatTest {
 
         assertNotNull(actualDrawable);
         Bitmap actualBitmap = drawDrawableToBitmap(actualDrawable);
-        Drawable expectedDrawable =
-                ContextCompat.getDrawable(mContext, R.drawable.test_drawable_green);
+        Drawable expectedDrawable = mContext.getDrawable(R.drawable.test_drawable_green);
         Bitmap expectedBitmap = drawDrawableToBitmap(expectedDrawable);
         assertTrue(actualBitmap.sameAs(expectedBitmap));
     }

--- a/core/core/src/androidTest/java/androidx/core/os/HandlerCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/os/HandlerCompatTest.java
@@ -126,7 +126,7 @@ public final class HandlerCompatTest {
         Message message = Message.obtain(handler, new Runnable() {
             @Override
             public void run() {
-                isAsync.set(MessageCompat.isAsynchronous(self.get()));
+                isAsync.set(self.get().isAsynchronous());
                 latch.countDown();
             }
         });
@@ -160,7 +160,7 @@ public final class HandlerCompatTest {
         Handler handler = HandlerCompat.createAsync(mThread.getLooper(), new Handler.Callback() {
             @Override
             public boolean handleMessage(Message msg) {
-                isAsync.set(MessageCompat.isAsynchronous(msg));
+                isAsync.set(msg.isAsynchronous());
                 latch.countDown();
                 return true;
             }

--- a/core/core/src/androidTest/java/androidx/core/view/SoftwareKeyboardControllerCompatActivityTest.kt
+++ b/core/core/src/androidTest/java/androidx/core/view/SoftwareKeyboardControllerCompatActivityTest.kt
@@ -234,7 +234,7 @@ public class SoftwareKeyboardControllerCompatActivityTest {
             WindowInsetsCompat.CONSUMED
         }
 
-        scenario.onActivity { ViewCompat.requestApplyInsets(this) }
+        scenario.onActivity { requestApplyInsets() }
 
         try {
             // Perform the action

--- a/core/core/src/main/java/androidx/core/app/ActivityCompat.java
+++ b/core/core/src/main/java/androidx/core/app/ActivityCompat.java
@@ -38,6 +38,7 @@ import android.view.View;
 
 import androidx.annotation.IdRes;
 import androidx.annotation.IntRange;
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.core.content.ContextCompat;
@@ -218,6 +219,7 @@ public class ActivityCompat extends ContextCompat {
      * @deprecated Use {@link Activity#invalidateOptionsMenu()} directly.
      */
     @Deprecated
+    @ReplaceWith(expression = "activity.invalidateOptionsMenu()")
     public static boolean invalidateOptionsMenu(Activity activity) {
         activity.invalidateOptionsMenu();
         return true;
@@ -242,7 +244,10 @@ public class ActivityCompat extends ContextCompat {
      *                {@link ActivityOptionsCompat} for how to build the Bundle
      *                supplied here; there are no supported definitions for
      *                building it manually.
+     * @deprecated Call {@link Activity#startActivityForResult(Intent, int, Bundle)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "activity.startActivityForResult(intent, requestCode, options)")
     public static void startActivityForResult(@NonNull Activity activity, @NonNull Intent intent,
             int requestCode, @Nullable Bundle options) {
         activity.startActivityForResult(intent, requestCode, options);
@@ -273,7 +278,11 @@ public class ActivityCompat extends ContextCompat {
      *                {@link ActivityOptionsCompat} for how to build the Bundle
      *                supplied here; there are no supported definitions for
      *                building it manually.
+     * @deprecated Call {@link Activity#startIntentSenderForResult(IntentSender, int, Intent, int,
+     * int, int, Bundle)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "activity.startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags, options)")
     public static void startIntentSenderForResult(@NonNull Activity activity,
             @NonNull IntentSender intent, int requestCode, @Nullable Intent fillInIntent,
             int flagsMask, int flagsValues, int extraFlags, @Nullable Bundle options)
@@ -288,7 +297,11 @@ public class ActivityCompat extends ContextCompat {
      *
      * <p>On Android 4.1+ calling this method will call through to the native version of this
      * method. For other platforms {@link Activity#finish()} will be called instead.</p>
+     *
+     * @deprecated Call {@link Activity#finishAffinity()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "activity.finishAffinity()")
     public static void finishAffinity(@NonNull Activity activity) {
         activity.finishAffinity();
     }
@@ -299,9 +312,10 @@ public class ActivityCompat extends ContextCompat {
      * {@link Activity#finish()} is called. If no entry Transition was used, finish() is called
      * immediately and the Activity exit Transition is run.
      *
-     * <p>On Android 4.4 or lower, this method only finishes the Activity with no
-     * special exit transition.</p>
+     * @deprecated Call {@link Activity#finishAfterTransition()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "activity.finishAfterTransition()")
     public static void finishAfterTransition(@NonNull Activity activity) {
         activity.finishAfterTransition();
     }
@@ -321,7 +335,11 @@ public class ActivityCompat extends ContextCompat {
      *
      * <p>Note that this is <em>not</em> a security feature -- you can not trust the
      * referrer information, applications can spoof it.</p>
+     *
+     * @deprecated Call {@link Activity#getReferrer()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "activity.getReferrer()")
     public static @Nullable Uri getReferrer(@NonNull Activity activity) {
         return activity.getReferrer();
     }
@@ -391,10 +409,20 @@ public class ActivityCompat extends ContextCompat {
         activity.setExitSharedElementCallback(frameworkCallback);
     }
 
+    /**
+     * @deprecated Call {@link Activity#postponeEnterTransition()} directly.
+     */
+    @Deprecated
+    @ReplaceWith(expression = "activity.postponeEnterTransition()")
     public static void postponeEnterTransition(@NonNull Activity activity) {
         activity.postponeEnterTransition();
     }
 
+    /**
+     * @deprecated Call {@link Activity#startPostponedEnterTransition()} directly.
+     */
+    @Deprecated
+    @ReplaceWith(expression = "activity.startPostponedEnterTransition()")
     public static void startPostponedEnterTransition(@NonNull Activity activity) {
         activity.startPostponedEnterTransition();
     }

--- a/core/core/src/main/java/androidx/core/app/ActivityOptionsCompat.java
+++ b/core/core/src/main/java/androidx/core/app/ActivityOptionsCompat.java
@@ -354,7 +354,7 @@ public class ActivityOptionsCompat {
 
     /**
      * Returns the created options as a Bundle, which can be passed to
-     * {@link androidx.core.content.ContextCompat#startActivity(Context, android.content.Intent, Bundle)}.
+     * {@link Context#startActivity(android.content.Intent, Bundle)}.
      * Note that the returned Bundle is still owned by the ActivityOptions
      * object; you must not modify it, but can supply it to the startActivity
      * methods that take an options Bundle.

--- a/core/core/src/main/java/androidx/core/app/AlarmManagerCompat.java
+++ b/core/core/src/main/java/androidx/core/app/AlarmManagerCompat.java
@@ -22,6 +22,7 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.os.Build;
 
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 
 import org.jspecify.annotations.NonNull;
@@ -36,7 +37,7 @@ public final class AlarmManagerCompat {
      * The system may choose to display information about this alarm to the user.
      *
      * <p>
-     * This method is like {@link #setExact}, but implies
+     * This method is like {@link AlarmManager#setExact}, but implies
      * {@link AlarmManager#RTC_WAKEUP}.
      *
      * @param alarmManager AlarmManager instance used to set the alarm
@@ -51,7 +52,7 @@ public final class AlarmManagerCompat {
      * @see AlarmManager#set
      * @see AlarmManager#setRepeating
      * @see AlarmManager#setWindow
-     * @see #setExact
+     * @see AlarmManager#setExact
      * @see AlarmManager#cancel
      * @see AlarmManager#getNextAlarmClock()
      * @see android.content.Context#sendBroadcast
@@ -102,7 +103,7 @@ public final class AlarmManagerCompat {
      * IntentSender.getBroadcast()}.
      *
      * @see AlarmManager#set(int, long, PendingIntent)
-     * @see #setExactAndAllowWhileIdle
+     * @see AlarmManager#setExactAndAllowWhileIdle
      * @see AlarmManager#cancel
      * @see android.content.Context#sendBroadcast
      * @see android.content.Context#registerReceiver
@@ -111,7 +112,10 @@ public final class AlarmManagerCompat {
      * @see AlarmManager#ELAPSED_REALTIME_WAKEUP
      * @see AlarmManager#RTC
      * @see AlarmManager#RTC_WAKEUP
+     * @deprecated Call {@link AlarmManager#setAndAllowWhileIdle(int, long, PendingIntent)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "alarmManager.setAndAllowWhileIdle(type, triggerAtMillis, operation)")
     public static void setAndAllowWhileIdle(@NonNull AlarmManager alarmManager, int type,
             long triggerAtMillis, @NonNull PendingIntent operation) {
         alarmManager.setAndAllowWhileIdle(type, triggerAtMillis, operation);
@@ -155,17 +159,17 @@ public final class AlarmManagerCompat {
      * @deprecated Call {@link AlarmManager#setExact(int, long, PendingIntent)} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "alarmManager.setExact(type, triggerAtMillis, operation)")
+    @ReplaceWith(expression = "alarmManager.setExact(type, triggerAtMillis, operation)")
     public static void setExact(@NonNull AlarmManager alarmManager, int type, long triggerAtMillis,
             @NonNull PendingIntent operation) {
         alarmManager.setExact(type, triggerAtMillis, operation);
     }
 
     /**
-     * Like {@link #setExact}, but this alarm will be allowed to execute
+     * Like {@link AlarmManager#setExact}, but this alarm will be allowed to execute
      * even when the system is in low-power idle modes.  If you don't need exact scheduling of
      * the alarm but still need to execute while idle, consider using
-     * {@link #setAndAllowWhileIdle}.  This type of alarm must <b>only</b>
+     * {@link AlarmManager#setAndAllowWhileIdle}.  This type of alarm must <b>only</b>
      * be used for situations where it is actually required that the alarm go off while in
      * idle -- a reasonable example would be for a calendar notification that should make a
      * sound so the user is aware of it.  When the alarm is dispatched, the app will also be
@@ -211,7 +215,10 @@ public final class AlarmManagerCompat {
      * @see AlarmManager#ELAPSED_REALTIME_WAKEUP
      * @see AlarmManager#RTC
      * @see AlarmManager#RTC_WAKEUP
+     * @deprecated Call {@link AlarmManager#setExactAndAllowWhileIdle(int, long, PendingIntent)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "alarmManager.setExactAndAllowWhileIdle(type, triggerAtMillis, operation)")
     public static void setExactAndAllowWhileIdle(@NonNull AlarmManager alarmManager, int type,
             long triggerAtMillis, @NonNull PendingIntent operation) {
         alarmManager.setExactAndAllowWhileIdle(type, triggerAtMillis, operation);

--- a/core/core/src/main/java/androidx/core/app/AppOpsManagerCompat.java
+++ b/core/core/src/main/java/androidx/core/app/AppOpsManagerCompat.java
@@ -22,6 +22,7 @@ import android.app.AppOpsManager;
 import android.content.Context;
 import android.os.Binder;
 
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 
 import org.jspecify.annotations.NonNull;
@@ -35,21 +36,33 @@ public final class AppOpsManagerCompat {
     /**
      * Result from {@link #noteOp}: the given caller is allowed to
      * perform the given operation.
+     *
+     * @deprecated Call {@link AppOpsManager#MODE_ALLOWED} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "AppOpsManager.MODE_ALLOWED", imports = "android.app.AppOpsManager")
     public static final int MODE_ALLOWED = AppOpsManager.MODE_ALLOWED;
 
     /**
      * Result from {@link #noteOp}: the given caller is not allowed to perform
      * the given operation, and this attempt should <em>silently fail</em> (it
      * should not cause the app to crash).
+     *
+     * @deprecated Call {@link AppOpsManager#MODE_IGNORED} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "AppOpsManager.MODE_IGNORED", imports = "android.app.AppOpsManager")
     public static final int MODE_IGNORED = AppOpsManager.MODE_IGNORED;
 
     /**
      * Result from {@link #noteOpNoThrow}: the
      * given caller is not allowed to perform the given operation, and this attempt should
      * cause it to have a fatal error, typically a {@link SecurityException}.
+     *
+     * @deprecated Call {@link AppOpsManager#MODE_ERRORED} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "AppOpsManager.MODE_ERRORED", imports = "android.app.AppOpsManager")
     public static final int MODE_ERRORED = AppOpsManager.MODE_ERRORED;
 
     /**
@@ -57,7 +70,11 @@ public final class AppOpsManagerCompat {
      * security check.  This mode is not normally used; it should only be used
      * with appop permissions, and callers must explicitly check for it and
      * deal with it.
+     *
+     * @deprecated Call {@link AppOpsManager#MODE_DEFAULT} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "AppOpsManager.MODE_DEFAULT", imports = "android.app.AppOpsManager")
     public static final int MODE_DEFAULT = AppOpsManager.MODE_DEFAULT;
 
     private AppOpsManagerCompat() {}
@@ -67,7 +84,10 @@ public final class AppOpsManagerCompat {
      *
      * @param permission The permission.
      * @return The app op associated with the permission or null.
+     * @deprecated Call {@link AppOpsManager#permissionToOp(String)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "AppOpsManager.permissionToOp(permission)")
     public static @Nullable String permissionToOp(@NonNull String permission) {
         return AppOpsManager.permissionToOp(permission);
     }
@@ -75,16 +95,16 @@ public final class AppOpsManagerCompat {
     /**
      * Make note of an application performing an operation.  Note that you must pass
      * in both the uid and name of the application to be checked; this function will verify
-     * that these two match, and if not, return {@link #MODE_IGNORED}.  If this call
+     * that these two match, and if not, return {@link AppOpsManager#MODE_IGNORED}.  If this call
      * succeeds, the last execution time of the operation for this app will be updated to
      * the current time.
      * @param context Your context.
      * @param op The operation to note.  One of the OPSTR_* constants.
      * @param uid The user id of the application attempting to perform the operation.
      * @param packageName The name of the application attempting to perform the operation.
-     * @return Returns {@link #MODE_ALLOWED} if the operation is allowed, or
-     * {@link #MODE_IGNORED} if it is not allowed and should be silently ignored (without
-     * causing the app to crash).
+     * @return Returns {@link AppOpsManager#MODE_ALLOWED} if the operation is allowed, or
+     * {@link AppOpsManager#MODE_IGNORED} if it is not allowed and should be silently ignored
+     * (without causing the app to crash).
      * @throws SecurityException If the app has been configured to crash on this op.
      */
     public static int noteOp(@NonNull Context context, @NonNull String op, int uid,
@@ -96,7 +116,7 @@ public final class AppOpsManagerCompat {
 
     /**
      * Like {@link #noteOp} but instead of throwing a {@link SecurityException} it
-     * returns {@link #MODE_ERRORED}.
+     * returns {@link AppOpsManager#MODE_ERRORED}.
      */
     public static int noteOpNoThrow(@NonNull Context context, @NonNull String op, int uid,
             @NonNull String packageName) {
@@ -110,15 +130,15 @@ public final class AppOpsManagerCompat {
      * application when handling an IPC. Note that you must pass the package name
      * of the application that is being proxied while its UID will be inferred from
      * the IPC state; this function will verify that the calling uid and proxied
-     * package name match, and if not, return {@link #MODE_IGNORED}. If this call
+     * package name match, and if not, return {@link AppOpsManager#MODE_IGNORED}. If this call
      * succeeds, the last execution time of the operation for the proxied app and
      * your app will be updated to the current time.
      * @param context Your context.
      * @param op The operation to note.  One of the OPSTR_* constants.
      * @param proxiedPackageName The name of the application calling into the proxy application.
-     * @return Returns {@link #MODE_ALLOWED} if the operation is allowed, or
-     * {@link #MODE_IGNORED} if it is not allowed and should be silently ignored (without
-     * causing the app to crash).
+     * @return Returns {@link AppOpsManager#MODE_ALLOWED} if the operation is allowed, or
+     * {@link AppOpsManager#MODE_IGNORED} if it is not allowed and should be silently ignored
+     * (without causing the app to crash).
      * @throws SecurityException If the app has been configured to crash on this op.
      */
     public static int noteProxyOp(@NonNull Context context, @NonNull String op,
@@ -129,7 +149,7 @@ public final class AppOpsManagerCompat {
 
     /**
      * Like {@link #noteProxyOp(Context, String, String)} but instead
-     * of throwing a {@link SecurityException} it returns {@link #MODE_ERRORED}.
+     * of throwing a {@link SecurityException} it returns {@link AppOpsManager#MODE_ERRORED}.
      */
     public static int noteProxyOpNoThrow(@NonNull Context context, @NonNull String op,
             @NonNull String proxiedPackageName) {
@@ -145,9 +165,9 @@ public final class AppOpsManagerCompat {
      * @param proxyUid The uid of the proxy application.
      * @param op The operation to note.  One of the OPSTR_* constants.
      * @param proxiedPackageName The name of the application calling into the proxy application.
-     * @return Returns {@link #MODE_ALLOWED} if the operation is allowed, or
-     * @link #MODE_IGNORED} if it is not allowed and should be silently ignored (without
-     * causing the app to crash).
+     * @return Returns {@link AppOpsManager#MODE_ALLOWED} if the operation is allowed, or
+     * {@link AppOpsManager#MODE_IGNORED} if it is not allowed and should be silently ignored
+     * (without causing the app to crash).
      */
     public static int checkOrNoteProxyOp(@NonNull Context context, int proxyUid,
             @NonNull String op, @NonNull String proxiedPackageName) {
@@ -157,7 +177,7 @@ public final class AppOpsManagerCompat {
             int proxiedUid = Binder.getCallingUid();
             int checkProxiedOpResult = Api29Impl.checkOpNoThrow(appOpsManager, op, proxiedUid,
                     proxiedPackageName);
-            if (checkProxiedOpResult != MODE_ALLOWED) {
+            if (checkProxiedOpResult != AppOpsManager.MODE_ALLOWED) {
                 return checkProxiedOpResult;
             }
 
@@ -191,7 +211,7 @@ public final class AppOpsManagerCompat {
         static int checkOpNoThrow(@Nullable AppOpsManager appOpsManager,
                 @NonNull String op, int uid, @NonNull String packageName) {
             if (appOpsManager == null) {
-                return MODE_IGNORED;
+                return AppOpsManager.MODE_IGNORED;
             }
 
             return appOpsManager.checkOpNoThrow(op, uid, packageName);

--- a/core/core/src/main/java/androidx/core/app/NotificationCompat.java
+++ b/core/core/src/main/java/androidx/core/app/NotificationCompat.java
@@ -70,7 +70,6 @@ import androidx.annotation.IntRange;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.core.R;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.LocusIdCompat;
 import androidx.core.content.pm.ShortcutInfoCompat;
 import androidx.core.graphics.drawable.IconCompat;
@@ -5071,7 +5070,7 @@ public class NotificationCompat {
         private @NonNull Action makeAction(int icon, int title, Integer colorInt,
                 int defaultColorRes, PendingIntent intent) {
             if (colorInt == null) {
-                colorInt = ContextCompat.getColor(mBuilder.mContext, defaultColorRes);
+                colorInt = mBuilder.mContext.getColor(defaultColorRes);
             }
             SpannableStringBuilder stringBuilder = new SpannableStringBuilder();
             stringBuilder.append(mBuilder.mContext.getResources().getString(title));

--- a/core/core/src/main/java/androidx/core/app/ShareCompat.java
+++ b/core/core/src/main/java/androidx/core/app/ShareCompat.java
@@ -213,8 +213,8 @@ public final class ShareCompat {
      * <p>During the calling activity's lifecycle, if data within the share intent must
      * change the app should change that state in one of several ways:</p>
      * <ul>
-     * <li>Call {@link ActivityCompat#invalidateOptionsMenu(Activity)}. If the app uses the
-     * Action Bar its menu will be recreated and rebuilt.
+     * <li>Call {@link Activity#invalidateOptionsMenu()}. If the app uses the Action Bar its
+     * menu will be recreated and rebuilt.
      * If not, the activity will receive a call to {@link Activity#onPrepareOptionsMenu(Menu)}
      * the next time the user presses the menu key to open the options menu panel. The activity
      * can then call configureMenuItem again with a new or altered IntentBuilder to reconfigure

--- a/core/core/src/main/java/androidx/core/content/Context.kt
+++ b/core/core/src/main/java/androidx/core/content/Context.kt
@@ -40,10 +40,9 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 /**
  * Return the handle to a system-level service by class.
  *
- * @see ContextCompat.getSystemService
+ * @see Context.getSystemService
  */
-public inline fun <reified T : Any> Context.getSystemService(): T? =
-    ContextCompat.getSystemService(this, T::class.java)
+public inline fun <reified T : Any> Context.getSystemService(): T? = getSystemService(T::class.java)
 
 /**
  * Executes [block] on a [TypedArray] receiver. The [TypedArray] holds the attribute values in [set]

--- a/core/core/src/main/java/androidx/core/content/ContextCompat.java
+++ b/core/core/src/main/java/androidx/core/content/ContextCompat.java
@@ -46,6 +46,7 @@ import androidx.annotation.ColorRes;
 import androidx.annotation.DisplayContext;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.IntDef;
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.core.app.ActivityOptionsCompat;
@@ -92,19 +93,20 @@ public class ContextCompat {
     @Retention(RetentionPolicy.SOURCE)
     public @interface RegisterReceiverFlags {}
     /**
-     * Flag for {@link #registerReceiver}: The receiver can receive broadcasts from Instant Apps.
+     * Flag for {@link Context#registerReceiver}: The receiver can receive broadcasts from
+     * Instant Apps.
      */
     public static final int RECEIVER_VISIBLE_TO_INSTANT_APPS = 0x1;
 
     /**
-     * Flag for {@link #registerReceiver}: The receiver can receive broadcasts from other Apps.
-     * Has the same behavior as marking a statically registered receiver with "exported=true"
+     * Flag for {@link Context#registerReceiver}: The receiver can receive broadcasts from other
+     * Apps. Has the same behavior as marking a statically registered receiver with "exported=true"
      */
     public static final int RECEIVER_EXPORTED = 0x2;
 
     /**
-     * Flag for {@link #registerReceiver}: The receiver cannot receive broadcasts from other Apps.
-     * Has the same behavior as marking a statically registered receiver with "exported=false"
+     * Flag for {@link Context#registerReceiver}: The receiver cannot receive broadcasts from other
+     * Apps. Has the same behavior as marking a statically registered receiver with "exported=false"
      */
     public static final int RECEIVER_NOT_EXPORTED = 0x4;
 
@@ -132,7 +134,10 @@ public class ContextCompat {
      * @param intents Array of intents defining the activities that will be started. The element
      *                length-1 will correspond to the top activity on the resulting task stack.
      * @return true if the underlying API was available and the call was successful, false otherwise
+     * @deprecated Call {@link Context#startActivities(Intent[])} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.startActivities(intents)")
     public static boolean startActivities(@NonNull Context context, Intent @NonNull [] intents) {
         return startActivities(context, intents, null);
     }
@@ -163,7 +168,10 @@ public class ContextCompat {
      * @param options Additional options for how the Activity should be started.
      *                See {@link Context#startActivity(Intent, Bundle)}
      * @return true if the underlying API was available and the call was successful, false otherwise
+     * @deprecated Call {@link Context#startActivities(Intent[], Bundle)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.startActivities(intents, options)")
     public static boolean startActivities(@NonNull Context context, Intent @NonNull [] intents,
             @Nullable Bundle options) {
         context.startActivities(intents, options);
@@ -189,7 +197,7 @@ public class ContextCompat {
      * @deprecated Call {@link Context#startActivity(Intent, Bundle)} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "context.startActivity(intent, options)")
+    @ReplaceWith(expression = "context.startActivity(intent, options)")
     public static void startActivity(@NonNull Context context, @NonNull Intent intent,
             @Nullable Bundle options) {
         context.startActivity(intent, options);
@@ -264,7 +272,7 @@ public class ContextCompat {
      * @deprecated Call {@link Context#getObbDirs()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "context.getObbDirs()")
+    @ReplaceWith(expression = "context.getObbDirs()")
     public static File @NonNull [] getObbDirs(@NonNull Context context) {
         return context.getObbDirs();
     }
@@ -312,10 +320,10 @@ public class ContextCompat {
      *
      * @see Context#getExternalFilesDir(String)
      * @see EnvironmentCompat#getStorageState(File)
-     * @deprecated Call {@link Context#getExternalFilesDir(String)} directly.
+     * @deprecated Call {@link Context#getExternalFilesDirs(String)} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "context.getExternalFilesDirs(type)")
+    @ReplaceWith(expression = "context.getExternalFilesDirs(type)")
     public static File @NonNull [] getExternalFilesDirs(@NonNull Context context,
             @Nullable String type) {
         return context.getExternalFilesDirs(type);
@@ -367,7 +375,7 @@ public class ContextCompat {
      * @deprecated Call {@link Context#getExternalCacheDirs()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "context.getExternalCacheDirs()")
+    @ReplaceWith(expression = "context.getExternalCacheDirs()")
     public static File @NonNull [] getExternalCacheDirs(@NonNull Context context) {
         return context.getExternalCacheDirs();
     }
@@ -375,16 +383,17 @@ public class ContextCompat {
     /**
      * Returns a drawable object associated with a particular resource ID.
      * <p>
-     * Starting in {@link Build.VERSION_CODES#LOLLIPOP}, the
-     * returned drawable will be styled for the specified Context's theme.
+     * The returned drawable will be styled for the specified Context's theme.
      *
      * @param context context to use for getting the drawable.
      * @param id The desired resource identifier, as generated by the aapt tool.
      *           This integer encodes the package, type, and resource entry.
      *           The value 0 is an invalid identifier.
      * @return Drawable An object that can be used to draw this resource.
+     * @deprecated Call {@link Context#getDrawable(int)} directly.
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated
+    @ReplaceWith(expression = "context.getDrawable(id)")
     public static @Nullable Drawable getDrawable(@NonNull Context context, @DrawableRes int id) {
         return context.getDrawable(id);
     }
@@ -412,8 +421,7 @@ public class ContextCompat {
     /**
      * Returns a color associated with a particular resource ID
      * <p>
-     * Starting in {@link Build.VERSION_CODES#M}, the returned
-     * color will be styled for the specified Context's theme.
+     * The returned color will be styled for the specified Context's theme.
      *
      * @param context context to use for getting the color.
      * @param id The desired resource identifier, as generated by the aapt
@@ -422,8 +430,11 @@ public class ContextCompat {
      * @return A single color value in the form 0xAARRGGBB.
      * @throws android.content.res.Resources.NotFoundException if the given ID
      *         does not exist.
+     * @deprecated Call {@link Context#getColor(int)} directly.
      */
     @ColorInt
+    @Deprecated
+    @ReplaceWith(expression = "context.getColor(id)")
     public static int getColor(@NonNull Context context, @ColorRes int id) {
         return context.getColor(id);
     }
@@ -451,8 +462,7 @@ public class ContextCompat {
     /**
      * Returns the absolute path to the directory on the filesystem similar to
      * {@link Context#getFilesDir()}.  The difference is that files placed under this
-     * directory will be excluded from automatic backup to remote storage on
-     * devices running {@link Build.VERSION_CODES#LOLLIPOP} or later.
+     * directory will be excluded from automatic backup to remote storage.
      *
      * <p>No permissions are required to read or write to the returned path, since this
      * path is internal storage.
@@ -460,15 +470,17 @@ public class ContextCompat {
      * @return The path of the directory holding application files that will not be
      * automatically backed up to remote storage.
      * @see Context#getFilesDir()
+     * @deprecated Call {@link Context#getNoBackupFilesDir()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.getNoBackupFilesDir()")
     public static @Nullable File getNoBackupFilesDir(@NonNull Context context) {
         return context.getNoBackupFilesDir();
     }
 
     /**
      * Returns the absolute path to the application specific cache directory on
-     * the filesystem designed for storing cached code. On devices running
-     * {@link Build.VERSION_CODES#LOLLIPOP} or later, the system will delete
+     * the filesystem designed for storing cached code. The system will delete
      * any files stored in this location both when your specific application is
      * upgraded, and when the entire platform is upgraded.
      * <p>
@@ -479,7 +491,10 @@ public class ContextCompat {
      * since this path lives in their private storage.
      *
      * @return The path of the directory holding application code cache files.
+     * @deprecated Call {@link Context#getCodeCacheDir()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.getCodeCacheDir()")
     public static @NonNull File getCodeCacheDir(@NonNull Context context) {
         return context.getCodeCacheDir();
     }
@@ -598,7 +613,10 @@ public class ContextCompat {
      * @param serviceClass The class of the desired service.
      * @return The service or null if the class is not a supported system service.
      * @see Context#getSystemService(Class)
+     * @deprecated Call {@link Context#getSystemService(Class)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.getSystemService(serviceClass)")
     public static <T> @Nullable T getSystemService(@NonNull Context context,
             @NonNull Class<T> serviceClass) {
         return context.getSystemService(serviceClass);
@@ -618,7 +636,11 @@ public class ContextCompat {
      * or null if there are none.
      * @see Context#registerReceiver(BroadcastReceiver, IntentFilter, int)
      * @see https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers
+     * @deprecated Call {@link Context#registerReceiver(BroadcastReceiver, IntentFilter, int)}
+     * directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.registerReceiver(receiver, filter, flags)")
     public static @Nullable Intent registerReceiver(@NonNull Context context,
             @Nullable BroadcastReceiver receiver, @NonNull IntentFilter filter,
             @RegisterReceiverFlags int flags) {
@@ -693,7 +715,10 @@ public class ContextCompat {
      * @param serviceClass The class of the desired service.
      * @return The service name or null if the class is not a supported system service.
      * @see Context#getSystemServiceName(Class)
+     * @deprecated Call {@link Context#getSystemServiceName(Class)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "context.getSystemServiceName(serviceClass)")
     public static @Nullable String getSystemServiceName(@NonNull Context context,
             @NonNull Class<?> serviceClass) {
         return context.getSystemServiceName(serviceClass);

--- a/core/core/src/main/java/androidx/core/content/FileProvider.java
+++ b/core/core/src/main/java/androidx/core/content/FileProvider.java
@@ -524,12 +524,12 @@ public class FileProvider extends ContentProvider {
                 } else if (TAG_EXTERNAL.equals(tag)) {
                     target = Environment.getExternalStorageDirectory();
                 } else if (TAG_EXTERNAL_FILES.equals(tag)) {
-                    File[] externalFilesDirs = ContextCompat.getExternalFilesDirs(context, null);
+                    File[] externalFilesDirs = context.getExternalFilesDirs(null);
                     if (externalFilesDirs.length > 0) {
                         target = externalFilesDirs[0];
                     }
                 } else if (TAG_EXTERNAL_CACHE.equals(tag)) {
-                    File[] externalCacheDirs = ContextCompat.getExternalCacheDirs(context);
+                    File[] externalCacheDirs = context.getExternalCacheDirs();
                     if (externalCacheDirs.length > 0) {
                         target = externalCacheDirs[0];
                     }

--- a/core/core/src/main/java/androidx/core/content/PermissionChecker.java
+++ b/core/core/src/main/java/androidx/core/content/PermissionChecker.java
@@ -18,6 +18,7 @@ package androidx.core.content;
 
 import static androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP_PREFIX;
 
+import android.app.AppOpsManager;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Binder;
@@ -99,7 +100,7 @@ public final class PermissionChecker {
             return PERMISSION_DENIED;
         }
 
-        String op = AppOpsManagerCompat.permissionToOp(permission);
+        String op = AppOpsManager.permissionToOp(permission);
         if (op == null) {
             return PERMISSION_GRANTED;
         }
@@ -124,7 +125,7 @@ public final class PermissionChecker {
             checkOpResult = AppOpsManagerCompat.noteProxyOpNoThrow(context, op, packageName);
         }
 
-        return checkOpResult == AppOpsManagerCompat.MODE_ALLOWED ? PERMISSION_GRANTED :
+        return checkOpResult == AppOpsManager.MODE_ALLOWED ? PERMISSION_GRANTED :
                 PERMISSION_DENIED_APP_OP;
     }
 

--- a/core/core/src/main/java/androidx/core/content/res/ResourcesCompat.java
+++ b/core/core/src/main/java/androidx/core/content/res/ResourcesCompat.java
@@ -45,6 +45,7 @@ import androidx.annotation.DimenRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.FontRes;
 import androidx.annotation.GuardedBy;
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.core.content.res.FontResourcesParserCompat.FamilyResourceEntry;
@@ -125,7 +126,10 @@ public final class ResourcesCompat {
      * @return Drawable An object that can be used to draw this resource.
      * @throws NotFoundException Throws NotFoundException if the given ID does
      *                           not exist.
+     * @deprecated Call {@link Resources#getDrawable(int, Theme)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "res.getDrawable(id, theme)")
     public static @Nullable Drawable getDrawable(@NonNull Resources res, @DrawableRes int id,
             @Nullable Theme theme) throws NotFoundException {
         return res.getDrawable(id, theme);
@@ -147,7 +151,10 @@ public final class ResourcesCompat {
      * @return Drawable An object that can be used to draw this resource.
      * @throws NotFoundException Throws NotFoundException if the given ID does
      *                           not exist.
+     * @deprecated Call {@link Resources#getDrawableForDensity(int, int, Theme)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "res.getDrawableForDensity(id, density, theme)")
     public static @Nullable Drawable getDrawableForDensity(@NonNull Resources res,
             @DrawableRes int id, int density, @Nullable Theme theme) throws NotFoundException {
         return res.getDrawableForDensity(id, density, theme);
@@ -167,8 +174,11 @@ public final class ResourcesCompat {
      * @return A single color value in the form {@code 0xAARRGGBB}.
      * @throws NotFoundException Throws NotFoundException if the given ID does
      *                           not exist.
+     * @deprecated Call {@link Resources#getColor(int, Theme)} directly.
      */
     @ColorInt
+    @Deprecated
+    @ReplaceWith(expression = "res.getColor(id, theme)")
     public static int getColor(@NonNull Resources res, @ColorRes int id, @Nullable Theme theme)
             throws NotFoundException {
         return res.getColor(id, theme);

--- a/core/core/src/main/java/androidx/core/graphics/PaintCompat.java
+++ b/core/core/src/main/java/androidx/core/graphics/PaintCompat.java
@@ -24,6 +24,7 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffXfermode;
 import android.os.Build;
 
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 
 import org.jspecify.annotations.NonNull;
@@ -41,7 +42,10 @@ public final class PaintCompat {
      * @param paint the paint instance to check
      * @param string the string to test whether there is glyph support
      * @return true if the typeface set on the given paint has a glyph for the string
+     * @deprecated Call {@link Paint#hasGlyph(String)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "paint.hasGlyph(string)")
     public static boolean hasGlyph(@NonNull Paint paint, @NonNull String string) {
         return paint.hasGlyph(string);
     }

--- a/core/core/src/main/java/androidx/core/graphics/drawable/DrawableCompat.java
+++ b/core/core/src/main/java/androidx/core/graphics/drawable/DrawableCompat.java
@@ -24,6 +24,7 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 
 import androidx.annotation.ColorInt;
+import androidx.annotation.ReplaceWith;
 import androidx.core.view.ViewCompat;
 
 import org.jspecify.annotations.NonNull;
@@ -34,8 +35,11 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 
 /**
- * Helper for accessing features in {@link android.graphics.drawable.Drawable}.
+ * Helper for accessing features in {@link Drawable}.
+ *
+ * @deprecated Use {@link Drawable} directly.
  */
+@Deprecated
 public final class DrawableCompat {
 
     /**
@@ -45,7 +49,7 @@ public final class DrawableCompat {
      *
      * @deprecated Use {@link Drawable#jumpToCurrentState()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "drawable.jumpToCurrentState()")
+    @ReplaceWith(expression = "drawable.jumpToCurrentState()")
     @Deprecated
     public static void jumpToCurrentState(@NonNull Drawable drawable) {
         drawable.jumpToCurrentState();
@@ -55,9 +59,6 @@ public final class DrawableCompat {
      * Set whether this Drawable is automatically mirrored when its layout
      * direction is RTL (right-to left). See
      * {@link android.util.LayoutDirection}.
-     * <p>
-     * If running on a pre-{@link android.os.Build.VERSION_CODES#KITKAT} device
-     * this method does nothing.
      *
      * @param drawable The Drawable against which to invoke the method.
      * @param mirrored Set to true if the Drawable should be mirrored, false if
@@ -65,7 +66,7 @@ public final class DrawableCompat {
      * @deprecated Call {@link Drawable#setAutoMirrored(boolean)} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "drawable.setAutoMirrored(mirrored)")
+    @ReplaceWith(expression = "drawable.setAutoMirrored(mirrored)")
     public static void setAutoMirrored(@NonNull Drawable drawable, boolean mirrored) {
         drawable.setAutoMirrored(mirrored);
     }
@@ -73,9 +74,6 @@ public final class DrawableCompat {
     /**
      * Tells if this Drawable will be automatically mirrored when its layout
      * direction is RTL right-to-left. See {@link android.util.LayoutDirection}.
-     * <p>
-     * If running on a pre-{@link android.os.Build.VERSION_CODES#KITKAT} device
-     * this method returns false.
      *
      * @param drawable The Drawable against which to invoke the method.
      * @return boolean Returns true if this Drawable will be automatically
@@ -83,7 +81,7 @@ public final class DrawableCompat {
      * @deprecated Call {@link Drawable#isAutoMirrored()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "drawable.isAutoMirrored()")
+    @ReplaceWith(expression = "drawable.isAutoMirrored()")
     public static boolean isAutoMirrored(@NonNull Drawable drawable) {
         return drawable.isAutoMirrored();
     }
@@ -94,7 +92,10 @@ public final class DrawableCompat {
      * @param drawable The Drawable against which to invoke the method.
      * @param x The X coordinate of the center of the hotspot
      * @param y The Y coordinate of the center of the hotspot
+     * @deprecated Call {@link Drawable#setHotspot(float, float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setHotspot(x, y)")
     public static void setHotspot(@NonNull Drawable drawable, float x, float y) {
         drawable.setHotspot(x, y);
     }
@@ -108,7 +109,10 @@ public final class DrawableCompat {
      * @param top position in pixels of the top bound
      * @param right position in pixels of the right bound
      * @param bottom position in pixels of the bottom bound
+     * @deprecated Call {@link Drawable#setHotspotBounds(int, int, int, int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setHotspotBounds(left, top, right, bottom)")
     public static void setHotspotBounds(@NonNull Drawable drawable, int left, int top,
             int right, int bottom) {
         drawable.setHotspotBounds(left, top, right, bottom);
@@ -119,7 +123,10 @@ public final class DrawableCompat {
      *
      * @param drawable The Drawable against which to invoke the method.
      * @param tint     Color to use for tinting this drawable
+     * @deprecated Call {@link Drawable#setTint(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setTint(tint)")
     public static void setTint(@NonNull Drawable drawable, @ColorInt int tint) {
         drawable.setTint(tint);
     }
@@ -129,7 +136,10 @@ public final class DrawableCompat {
      *
      * @param drawable The Drawable against which to invoke the method.
      * @param tint     Color state list to use for tinting this drawable, or null to clear the tint
+     * @deprecated Call {@link Drawable#setTintList(ColorStateList)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setTintList(tint)")
     public static void setTintList(@NonNull Drawable drawable, @Nullable ColorStateList tint) {
         drawable.setTintList(tint);
     }
@@ -139,7 +149,10 @@ public final class DrawableCompat {
      *
      * @param drawable The Drawable against which to invoke the method.
      * @param tintMode A Porter-Duff blending mode
+     * @deprecated Call {@link Drawable#setTintMode(PorterDuff.Mode)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setTintMode(tintMode)")
     public static void setTintMode(@NonNull Drawable drawable, PorterDuff.@Nullable Mode tintMode) {
         drawable.setTintMode(tintMode);
     }
@@ -152,7 +165,7 @@ public final class DrawableCompat {
      * @deprecated Call {@link Drawable#getAlpha()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "drawable.getAlpha()")
+    @ReplaceWith(expression = "drawable.getAlpha()")
     @SuppressWarnings("unused")
     public static int getAlpha(@NonNull Drawable drawable) {
         return drawable.getAlpha();
@@ -160,16 +173,20 @@ public final class DrawableCompat {
 
     /**
      * Applies the specified theme to this Drawable and its children.
+     * @deprecated Call {@link Drawable#applyTheme(Resources.Theme)} directly.
      */
-    @SuppressWarnings("unused")
+    @Deprecated
+    @ReplaceWith(expression = "drawable.applyTheme(theme)")
     public static void applyTheme(@NonNull Drawable drawable, Resources.@NonNull Theme theme) {
         drawable.applyTheme(theme);
     }
 
     /**
      * Whether a theme can be applied to this Drawable and its children.
+     * @deprecated Call {@link Drawable#canApplyTheme()} directly.
      */
-    @SuppressWarnings("unused")
+    @Deprecated
+    @ReplaceWith(expression = "drawable.canApplyTheme()")
     public static boolean canApplyTheme(@NonNull Drawable drawable) {
         return drawable.canApplyTheme();
     }
@@ -178,16 +195,21 @@ public final class DrawableCompat {
      * Returns the current color filter, or {@code null} if none set.
      *
      * @return the current color filter, or {@code null} if none set
+     * @deprecated Call {@link Drawable#getColorFilter()} directly.
      */
-    @SuppressWarnings("unused")
+    @Deprecated
+    @ReplaceWith(expression = "drawable.getColorFilter()")
     public static @Nullable ColorFilter getColorFilter(@NonNull Drawable drawable) {
         return drawable.getColorFilter();
     }
 
     /**
      * Removes the color filter from the given drawable.
+     *
+     * @deprecated Call {@link Drawable#clearColorFilter()} directly.
      */
-    @SuppressWarnings("unused")
+    @Deprecated
+    @ReplaceWith(expression = "drawable.clearColorFilter()")
     public static void clearColorFilter(@NonNull Drawable drawable) {
         drawable.clearColorFilter();
     }
@@ -202,7 +224,10 @@ public final class DrawableCompat {
      * @param theme Theme to apply, may be null
      * @throws XmlPullParserException
      * @throws IOException
+     * @deprecated Call {@link Drawable#inflate(Resources, XmlPullParser, AttributeSet, Resources.Theme)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.inflate(res, parser, attrs, theme)")
     public static void inflate(@NonNull Drawable drawable, @NonNull Resources res,
             @NonNull XmlPullParser parser, @NonNull AttributeSet attrs,
             Resources.@Nullable Theme theme)
@@ -236,11 +261,14 @@ public final class DrawableCompat {
      * @param drawable The Drawable to process
      * @return A drawable capable of being tinted across all API levels.
      *
-     * @see #setTint(Drawable, int)
-     * @see #setTintList(Drawable, ColorStateList)
-     * @see #setTintMode(Drawable, PorterDuff.Mode)
+     * @see Drawable#setTint(int)
+     * @see Drawable#setTintList(ColorStateList)
+     * @see Drawable#setTintMode(PorterDuff.Mode)
      * @see #unwrap(Drawable)
+     * @deprecated Call methods on {@link drawable} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable")
     public static @NonNull Drawable wrap(@NonNull Drawable drawable) {
         return drawable;
     }
@@ -254,7 +282,10 @@ public final class DrawableCompat {
      * @return the unwrapped {@link Drawable} or {@code drawable} if it hasn't been wrapped.
      *
      * @see #wrap(Drawable)
+     * @deprecated Call methods on {@link Drawable} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable")
     @SuppressWarnings({"TypeParameterUnusedInFormals", "unchecked"})
     public static <T extends Drawable> T unwrap(@NonNull Drawable drawable) {
         if (drawable instanceof WrappedDrawable) {
@@ -276,7 +307,10 @@ public final class DrawableCompat {
      *         appearance of the drawable to change such that it needs to be
      *         re-drawn, {@code false} otherwise
      * @see Drawable#getLayoutDirection()
+     * @deprecated Call {@link Drawable#setLayoutDirection(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.setLayoutDirection(layoutDirection)")
     public static boolean setLayoutDirection(@NonNull Drawable drawable, int layoutDirection) {
         return drawable.setLayoutDirection(layoutDirection);
     }
@@ -287,7 +321,10 @@ public final class DrawableCompat {
      * @return One of {@link ViewCompat#LAYOUT_DIRECTION_LTR},
      *         {@link ViewCompat#LAYOUT_DIRECTION_RTL}
      * @see Drawable#setLayoutDirection(int)
+     * @deprecated Call {@link Drawable#getLayoutDirection()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "drawable.getLayoutDirection()")
     public static int getLayoutDirection(@NonNull Drawable drawable) {
         return drawable.getLayoutDirection();
     }

--- a/core/core/src/main/java/androidx/core/graphics/drawable/IconCompat.java
+++ b/core/core/src/main/java/androidx/core/graphics/drawable/IconCompat.java
@@ -54,7 +54,6 @@ import androidx.annotation.IntDef;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
-import androidx.core.content.ContextCompat;
 import androidx.core.util.ObjectsCompat;
 import androidx.core.util.Preconditions;
 import androidx.versionedparcelable.CustomVersionedParcelable;
@@ -623,7 +622,7 @@ public class IconCompat extends CustomVersionedParcelable {
                                 Intent.ShortcutIconResource.fromContext(context, mInt1));
                         return;
                     } else {
-                        Drawable dr = ContextCompat.getDrawable(context, mInt1);
+                        Drawable dr = context.getDrawable(mInt1);
                         if (dr.getIntrinsicWidth() <= 0 || dr.getIntrinsicHeight() <= 0) {
                             int size = ((ActivityManager) context.getSystemService(
                                     Context.ACTIVITY_SERVICE)).getLauncherLargeIconSize();

--- a/core/core/src/main/java/androidx/core/graphics/drawable/WrappedDrawableApi14.java
+++ b/core/core/src/main/java/androidx/core/graphics/drawable/WrappedDrawableApi14.java
@@ -191,12 +191,12 @@ class WrappedDrawableApi14 extends Drawable
 
     @Override
     public void setAutoMirrored(boolean mirrored) {
-        DrawableCompat.setAutoMirrored(mDrawable, mirrored);
+        mDrawable.setAutoMirrored(mirrored);
     }
 
     @Override
     public boolean isAutoMirrored() {
-        return DrawableCompat.isAutoMirrored(mDrawable);
+        return mDrawable.isAutoMirrored();
     }
 
     @Override

--- a/core/core/src/main/java/androidx/core/os/MessageCompat.java
+++ b/core/core/src/main/java/androidx/core/os/MessageCompat.java
@@ -20,11 +20,16 @@ import android.os.Looper;
 import android.os.Message;
 import android.view.View;
 
+import androidx.annotation.ReplaceWith;
+
 import org.jspecify.annotations.NonNull;
 
 /**
  * Helper for accessing features in {@link Message}.
+ *
+ * @deprecated Use {@link Message} directly.
  */
+@Deprecated
 public final class MessageCompat {
     /**
      * Sets whether the message is asynchronous, meaning that it is not
@@ -49,10 +54,12 @@ public final class MessageCompat {
      *
      * @param message message for this to set the mode.
      * @param async True if the message is asynchronous.
-     *
-     * @see #isAsynchronous(Message)
+     * @see Message#isAsynchronous()
      * @see Message#setAsynchronous(boolean)
+     * @deprecated Call {@link Message#setAsynchronous(boolean)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "async.setAsynchronous()")
     public static void setAsynchronous(@NonNull Message message, boolean async) {
         message.setAsynchronous(async);
     }
@@ -62,10 +69,12 @@ public final class MessageCompat {
      * subject to {@link Looper} synchronization barriers.
      *
      * @return True if the message is asynchronous.
-     *
-     * @see #setAsynchronous(Message, boolean)
+     * @see Message#setAsynchronous(boolean)
      * @see Message#isAsynchronous()
+     * @deprecated Call {@link Message#isAsynchronous()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "message.isAsynchronous()")
     public static boolean isAsynchronous(@NonNull Message message) {
         return message.isAsynchronous();
     }

--- a/core/core/src/main/java/androidx/core/util/Size.kt
+++ b/core/core/src/main/java/androidx/core/util/Size.kt
@@ -70,6 +70,7 @@ public inline operator fun SizeF.component2(): Float = height
  * val (w, h) = mySize
  * ```
  */
+@Deprecated("Use SizeF.component1()")
 public inline operator fun SizeFCompat.component1(): Float = width
 
 /**
@@ -80,4 +81,5 @@ public inline operator fun SizeFCompat.component1(): Float = width
  * val (w, h) = mySize
  * ```
  */
+@Deprecated("Use SizeF.component2()")
 public inline operator fun SizeFCompat.component2(): Float = height

--- a/core/core/src/main/java/androidx/core/util/SizeFCompat.java
+++ b/core/core/src/main/java/androidx/core/util/SizeFCompat.java
@@ -18,6 +18,8 @@ package androidx.core.util;
 
 import android.util.SizeF;
 
+import androidx.annotation.ReplaceWith;
+
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -25,12 +27,20 @@ import org.jspecify.annotations.NonNull;
  * height are finite values stored as a floating point representation.
  * <p>
  * This is a backward-compatible version of {@link SizeF}.
+ *
+ * @deprecated Use {@link SizeF} instead.
  */
+@Deprecated
 public final class SizeFCompat {
 
     private final float mWidth;
     private final float mHeight;
 
+    /**
+     * @deprecated Call {@link SizeF#SizeF(float, float) new SizeF(float, float)} directly.
+     */
+    @Deprecated
+    @ReplaceWith(expression = "new SizeF(width, height)", imports = "android.util.SizeF")
     public SizeFCompat(float width, float height) {
         mWidth = Preconditions.checkArgumentFinite(width, "width");
         mHeight = Preconditions.checkArgumentFinite(height, "height");
@@ -70,12 +80,22 @@ public final class SizeFCompat {
         return mWidth + "x" + mHeight;
     }
 
-    /** Converts this {@link SizeFCompat} into a {@link SizeF}. */
+    /**
+     * Converts this {@link SizeFCompat} into a {@link SizeF}.
+     *
+     * @deprecated This method is not needed anymore.
+     */
+    @Deprecated
     public @NonNull SizeF toSizeF() {
         return new SizeF(getWidth(), getHeight());
     }
 
-    /** Converts this {@link SizeF} into a {@link SizeFCompat}. */
+    /**
+     * Converts this {@link SizeF} into a {@link SizeFCompat}.
+     *
+     * @deprecated This method is not needed anymore.
+     */
+    @Deprecated
     public static @NonNull SizeFCompat toSizeFCompat(@NonNull SizeF size) {
         return new SizeFCompat(size.getWidth(), size.getHeight());
     }

--- a/core/core/src/main/java/androidx/core/view/AccessibilityDelegateCompat.java
+++ b/core/core/src/main/java/androidx/core/view/AccessibilityDelegateCompat.java
@@ -225,16 +225,14 @@ public class AccessibilityDelegateCompat {
      * text content.
      * <p>
      * The default implementation behaves as
-     * {@link ViewCompat#onPopulateAccessibilityEvent(View, AccessibilityEvent)
-     * ViewCompat#onPopulateAccessibilityEvent(AccessibilityEvent)} for
+     * {@link View#onPopulateAccessibilityEvent(AccessibilityEvent)} for
      * the case of no accessibility delegate been set.
      * </p>
      *
      * @param host The View hosting the delegate.
      * @param event The accessibility event which to populate.
      *
-     * @see ViewCompat#onPopulateAccessibilityEvent(View ,AccessibilityEvent)
-     *      ViewCompat#onPopulateAccessibilityEvent(View, AccessibilityEvent)
+     * @see View#onPopulateAccessibilityEvent(AccessibilityEvent)
      */
     public void onPopulateAccessibilityEvent(@NonNull View host,
             @NonNull AccessibilityEvent event) {
@@ -246,16 +244,14 @@ public class AccessibilityDelegateCompat {
      * the host View which is the event source.
      * <p>
      * The default implementation behaves as
-     * {@link ViewCompat#onInitializeAccessibilityEvent(View v, AccessibilityEvent event)
-     * ViewCompat#onInitalizeAccessibilityEvent(View v, AccessibilityEvent event)} for
+     * {@link View#onInitializeAccessibilityEvent(AccessibilityEvent)} for
      * the case of no accessibility delegate been set.
      * </p>
      *
      * @param host The View hosting the delegate.
      * @param event The event to initialize.
      *
-     * @see ViewCompat#onInitializeAccessibilityEvent(View, AccessibilityEvent)
-     *      ViewCompat#onInitializeAccessibilityEvent(View, AccessibilityEvent)
+     * @see View#onInitializeAccessibilityEvent(AccessibilityEvent)
      */
     public void onInitializeAccessibilityEvent(@NonNull View host,
             @NonNull AccessibilityEvent event) {
@@ -266,16 +262,14 @@ public class AccessibilityDelegateCompat {
      * Initializes an {@link AccessibilityNodeInfoCompat} with information about the host view.
      * <p>
      * The default implementation behaves as
-     * {@link ViewCompat#onInitializeAccessibilityNodeInfo(View, AccessibilityNodeInfoCompat)
-     * ViewCompat#onInitializeAccessibilityNodeInfo(View, AccessibilityNodeInfoCompat)} for
+     * {@link View#onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo)} for
      * the case of no accessibility delegate been set.
      * </p>
      *
      * @param host The View hosting the delegate.
      * @param info The instance to initialize.
      *
-     * @see ViewCompat#onInitializeAccessibilityNodeInfo(View, AccessibilityNodeInfoCompat)
-     *      ViewCompat#onInitializeAccessibilityNodeInfo(View, AccessibilityNodeInfoCompat)
+     * @see View#onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo)
      */
     public void onInitializeAccessibilityNodeInfo(@NonNull View host,
             @NonNull AccessibilityNodeInfoCompat info) {

--- a/core/core/src/main/java/androidx/core/view/NestedScrollingChildHelper.java
+++ b/core/core/src/main/java/androidx/core/view/NestedScrollingChildHelper.java
@@ -69,7 +69,7 @@ public class NestedScrollingChildHelper {
      */
     public void setNestedScrollingEnabled(boolean enabled) {
         if (mIsNestedScrollingEnabled) {
-            ViewCompat.stopNestedScroll(mView);
+            mView.stopNestedScroll();
         }
         mIsNestedScrollingEnabled = enabled;
     }
@@ -386,7 +386,7 @@ public class NestedScrollingChildHelper {
      * signature to implement the standard policy.</p>
      */
     public void onDetachedFromWindow() {
-        ViewCompat.stopNestedScroll(mView);
+        mView.stopNestedScroll();
     }
 
     /**
@@ -399,7 +399,7 @@ public class NestedScrollingChildHelper {
      * @param child Child view stopping its nested scroll. This may not be a direct child view.
      */
     public void onStopNestedScroll(@NonNull View child) {
-        ViewCompat.stopNestedScroll(mView);
+        mView.stopNestedScroll();
     }
 
     private ViewParent getNestedScrollingParentForType(@NestedScrollType int type) {

--- a/core/core/src/main/java/androidx/core/view/NestedScrollingParent.java
+++ b/core/core/src/main/java/androidx/core/view/NestedScrollingParent.java
@@ -45,7 +45,7 @@ public interface NestedScrollingParent {
      * nested scroll operation if appropriate.
      *
      * <p>This method will be called in response to a descendant view invoking
-     * {@link ViewCompat#startNestedScroll(View, int)}. Each parent up the view hierarchy will be
+     * {@link View#startNestedScroll(int)}. Each parent up the view hierarchy will be
      * given an opportunity to respond and claim the nested scrolling operation by returning
      * <code>true</code>.</p>
      *

--- a/core/core/src/main/java/androidx/core/view/NestedScrollingParent2.java
+++ b/core/core/src/main/java/androidx/core/view/NestedScrollingParent2.java
@@ -44,7 +44,7 @@ public interface NestedScrollingParent2 extends NestedScrollingParent {
      * nested scroll operation if appropriate.
      *
      * <p>This method will be called in response to a descendant view invoking
-     * {@link ViewCompat#startNestedScroll(View, int)}. Each parent up the view hierarchy will be
+     * {@link View#startNestedScroll(int)}. Each parent up the view hierarchy will be
      * given an opportunity to respond and claim the nested scrolling operation by returning
      * <code>true</code>.</p>
      *

--- a/core/core/src/main/java/androidx/core/view/ViewCompat.java
+++ b/core/core/src/main/java/androidx/core/view/ViewCompat.java
@@ -67,6 +67,7 @@ import androidx.annotation.FloatRange;
 import androidx.annotation.IdRes;
 import androidx.annotation.IntDef;
 import androidx.annotation.Px;
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.UiThread;
@@ -261,7 +262,7 @@ public class ViewCompat {
      * automatically announce changes to this view. This is the default live
      * region mode for most views.
      * <p>
-     * Use with {@link ViewCompat#setAccessibilityLiveRegion(View, int)}.
+     * Use with {@link View#setAccessibilityLiveRegion(int)}.
      */
     public static final int ACCESSIBILITY_LIVE_REGION_NONE = 0x00000000;
 
@@ -269,7 +270,7 @@ public class ViewCompat {
      * Live region mode specifying that accessibility services should announce
      * changes to this view.
      * <p>
-     * Use with {@link ViewCompat#setAccessibilityLiveRegion(View, int)}.
+     * Use with {@link View#setAccessibilityLiveRegion(int)}.
      */
     public static final int ACCESSIBILITY_LIVE_REGION_POLITE = 0x00000001;
 
@@ -277,7 +278,7 @@ public class ViewCompat {
      * Live region mode specifying that accessibility services should interrupt
      * ongoing speech to immediately announce changes to this view.
      * <p>
-     * Use with {@link ViewCompat#setAccessibilityLiveRegion(View, int)}.
+     * Use with {@link View#setAccessibilityLiveRegion(int)}.
      */
     public static final int ACCESSIBILITY_LIVE_REGION_ASSERTIVE = 0x00000002;
 
@@ -375,7 +376,7 @@ public class ViewCompat {
 
     /**
      * Horizontal layout direction of this view is inherited from its parent.
-     * Use with {@link #setLayoutDirection}.
+     * Use with {@link View#setLayoutDirection}.
      *
      * @deprecated Use {@link View#LAYOUT_DIRECTION_INHERIT} directly.
      */
@@ -384,7 +385,7 @@ public class ViewCompat {
 
     /**
      * Horizontal layout direction of this view is from deduced from the default language
-     * script for the locale. Use with {@link #setLayoutDirection}.
+     * script for the locale. Use with {@link View#setLayoutDirection}.
      *
      * @deprecated Use {@link View#LAYOUT_DIRECTION_LOCALE} directly.
      */
@@ -392,8 +393,8 @@ public class ViewCompat {
     public static final int LAYOUT_DIRECTION_LOCALE = 3;
 
     /**
-     * Bits of {@link #getMeasuredWidthAndState} and
-     * {@link #getMeasuredWidthAndState} that provide the actual measured size.
+     * Bits of {@link View#getMeasuredWidthAndState} and
+     * {@link View#getMeasuredWidthAndState} that provide the actual measured size.
      *
      * @deprecated Use {@link View#MEASURED_SIZE_MASK} directly.
      */
@@ -401,8 +402,8 @@ public class ViewCompat {
     public static final int MEASURED_SIZE_MASK = 0x00ffffff;
 
     /**
-     * Bits of {@link #getMeasuredWidthAndState} and
-     * {@link #getMeasuredWidthAndState} that provide the additional state bits.
+     * Bits of {@link View#getMeasuredWidthAndState} and
+     * {@link View#getMeasuredWidthAndState} that provide the additional state bits.
      *
      * @deprecated Use {@link View#MEASURED_STATE_MASK} directly.
      */
@@ -412,8 +413,8 @@ public class ViewCompat {
     /**
      * Bit shift of {@link #MEASURED_STATE_MASK} to get to the height bits
      * for functions that combine both width and height into a single int,
-     * such as {@link #getMeasuredState} and the childState argument of
-     * {@link #resolveSizeAndState(int, int, int)}.
+     * such as {@link View#getMeasuredState} and the childState argument of
+     * {@link View#resolveSizeAndState(int, int, int)}.
      *
      * @deprecated Use {@link View#MEASURED_HEIGHT_STATE_SHIFT} directly.
      */
@@ -421,8 +422,8 @@ public class ViewCompat {
     public static final int MEASURED_HEIGHT_STATE_SHIFT = 16;
 
     /**
-     * Bit of {@link #getMeasuredWidthAndState} and
-     * {@link #getMeasuredWidthAndState} that indicates the measured size
+     * Bit of {@link View#getMeasuredWidthAndState} and
+     * {@link View#getMeasuredWidthAndState} that indicates the measured size
      * is smaller that the space the view would like to have.
      *
      * @deprecated Use {@link View#MEASURED_STATE_TOO_SMALL} directly.
@@ -486,54 +487,54 @@ public class ViewCompat {
     /**
      * Scroll indicator direction for the top edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_TOP = 0x1;
 
     /**
      * Scroll indicator direction for the bottom edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_BOTTOM = 0x2;
 
     /**
      * Scroll indicator direction for the left edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_LEFT = 0x4;
 
     /**
      * Scroll indicator direction for the right edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_RIGHT = 0x8;
 
     /**
      * Scroll indicator direction for the starting edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_START = 0x10;
 
     /**
      * Scroll indicator direction for the ending edge of the view.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
      */
     public static final int SCROLL_INDICATOR_END = 0x20;
 
@@ -584,7 +585,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#canScrollHorizontally(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.canScrollHorizontally(direction)")
+    @ReplaceWith(expression = "view.canScrollHorizontally(direction)")
     @Deprecated
     public static boolean canScrollHorizontally(View view, int direction) {
         return view.canScrollHorizontally(direction);
@@ -598,7 +599,7 @@ public class ViewCompat {
      * @return true if this view can be scrolled in the specified direction, false otherwise.
      * @deprecated Use {@link View#canScrollVertically(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.canScrollVertically(direction)")
+    @ReplaceWith(expression = "view.canScrollVertically(direction)")
     @Deprecated
     public static boolean canScrollVertically(View view, int direction) {
         return view.canScrollVertically(direction);
@@ -615,7 +616,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#getOverScrollMode()} directly. This method will be
      * removed in a future release.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getOverScrollMode()")
+    @ReplaceWith(expression = "view.getOverScrollMode()")
     @Deprecated
     @OverScroll
     public static int getOverScrollMode(View view) {
@@ -637,7 +638,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#setOverScrollMode(int)} directly. This method will be
      * removed in a future release.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setOverScrollMode(overScrollMode)")
+    @ReplaceWith(expression = "view.setOverScrollMode(overScrollMode)")
     @Deprecated
     public static void setOverScrollMode(View view, @OverScroll int overScrollMode) {
         view.setOverScrollMode(overScrollMode);
@@ -681,7 +682,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#onPopulateAccessibilityEvent(AccessibilityEvent)} directly.
      * This method will be removed in a future release.
      */
-    @androidx.annotation.ReplaceWith(expression = "v.onPopulateAccessibilityEvent(event)")
+    @ReplaceWith(expression = "v.onPopulateAccessibilityEvent(event)")
     @Deprecated
     public static void onPopulateAccessibilityEvent(View v, AccessibilityEvent event) {
         v.onPopulateAccessibilityEvent(event);
@@ -714,7 +715,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#onInitializeAccessibilityEvent(AccessibilityEvent)} directly.
      * This method will be removed in a future release.
      */
-    @androidx.annotation.ReplaceWith(expression = "v.onInitializeAccessibilityEvent(event)")
+    @ReplaceWith(expression = "v.onInitializeAccessibilityEvent(event)")
     @Deprecated
     public static void onInitializeAccessibilityEvent(View v, AccessibilityEvent event) {
         v.onInitializeAccessibilityEvent(event);
@@ -749,7 +750,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo)}
      * directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "v.onInitializeAccessibilityNodeInfo(info.unwrap())")
+    @ReplaceWith(expression = "v.onInitializeAccessibilityNodeInfo(info.unwrap())")
     @Deprecated
     public static void onInitializeAccessibilityNodeInfo(@NonNull View v,
             @NonNull AccessibilityNodeInfoCompat info) {
@@ -1285,7 +1286,7 @@ public class ViewCompat {
      * @return true if the view has transient state
      * @deprecated Call {@link View#hasTransientState()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.hasTransientState()")
+    @ReplaceWith(expression = "view.hasTransientState()")
     @Deprecated
     public static boolean hasTransientState(@NonNull View view) {
         return view.hasTransientState();
@@ -1299,7 +1300,7 @@ public class ViewCompat {
      * @param hasTransientState true if this view has transient state
      * @deprecated Call {@link View#setHasTransientState(boolean)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setHasTransientState(hasTransientState)")
+    @ReplaceWith(expression = "view.setHasTransientState(hasTransientState)")
     @Deprecated
     public static void setHasTransientState(@NonNull View view, boolean hasTransientState) {
         view.setHasTransientState(hasTransientState);
@@ -1315,7 +1316,7 @@ public class ViewCompat {
      * @param view View to invalidate
      * @deprecated Call {@link View#postInvalidateOnAnimation()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.postInvalidateOnAnimation()")
+    @ReplaceWith(expression = "view.postInvalidateOnAnimation()")
     @Deprecated
     public static void postInvalidateOnAnimation(@NonNull View view) {
         view.postInvalidateOnAnimation();
@@ -1335,7 +1336,7 @@ public class ViewCompat {
      * @param bottom The bottom coordinate of the rectangle to invalidate.
      * @deprecated Call {@link View#postInvalidateOnAnimation(int, int, int, int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.postInvalidateOnAnimation(left, top, right, bottom)")
+    @ReplaceWith(expression = "view.postInvalidateOnAnimation(left, top, right, bottom)")
     @Deprecated
     public static void postInvalidateOnAnimation(@NonNull View view, int left, int top,
             int right, int bottom) {
@@ -1353,7 +1354,7 @@ public class ViewCompat {
      * @param action The Runnable that will be executed.
      * @deprecated Call {@link View#postOnAnimation(Runnable)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.postOnAnimation(action)")
+    @ReplaceWith(expression = "view.postOnAnimation(action)")
     @Deprecated
     public static void postOnAnimation(@NonNull View view, @NonNull Runnable action) {
         view.postOnAnimation(action);
@@ -1373,7 +1374,7 @@ public class ViewCompat {
      *        will be executed.
      * @deprecated Call {@link View#postOnAnimationDelayed(Runnable, long)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.postOnAnimationDelayed(action, delayMillis)")
+    @ReplaceWith(expression = "view.postOnAnimationDelayed(action, delayMillis)")
     @Deprecated
     @SuppressLint("LambdaLast")
     public static void postOnAnimationDelayed(@NonNull View view, @NonNull Runnable action,
@@ -1395,7 +1396,7 @@ public class ViewCompat {
      * @see #IMPORTANT_FOR_ACCESSIBILITY_AUTO
      * @deprecated Call {@link View#getImportantForAccessibility()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getImportantForAccessibility()")
+    @ReplaceWith(expression = "view.getImportantForAccessibility()")
     @Deprecated
     @ImportantForAccessibility
     public static int getImportantForAccessibility(@NonNull View view) {
@@ -1422,7 +1423,7 @@ public class ViewCompat {
      * @see #IMPORTANT_FOR_ACCESSIBILITY_AUTO
      * @deprecated Call {@link View#setImportantForAccessibility(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setImportantForAccessibility(mode)")
+    @ReplaceWith(expression = "view.setImportantForAccessibility(mode)")
     @Deprecated
     @UiThread
     public static void setImportantForAccessibility(@NonNull View view,
@@ -1440,7 +1441,7 @@ public class ViewCompat {
      * returns <code>false</code>.
      * <p>
      * Otherwise, the value is computed according to the view's
-     * {@link #getImportantForAccessibility(View)} value:
+     * {@link View#getImportantForAccessibility()} value:
      * <ol>
      * <li>{@link #IMPORTANT_FOR_ACCESSIBILITY_NO} or
      * {@link #IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS}, return <code>false
@@ -1455,7 +1456,7 @@ public class ViewCompat {
      * <li>Has an interaction listener, e.g. {@link View.OnTouchListener},
      * {@link View.OnKeyListener}, etc.</li>
      * <li>Is an accessibility live region, e.g.
-     * {@link #getAccessibilityLiveRegion(View)} is not
+     * {@link View#getAccessibilityLiveRegion()} is not
      * {@link #ACCESSIBILITY_LIVE_REGION_NONE}.</li>
      * </ul>
      * </ol>
@@ -1464,9 +1465,12 @@ public class ViewCompat {
      *
      * @param view view for which to check the state.
      * @return Whether the view is exposed for accessibility.
-     * @see #setImportantForAccessibility(View, int)
-     * @see #getImportantForAccessibility(View)
+     * @see View#setImportantForAccessibility(int)
+     * @see View#getImportantForAccessibility()
+     * @deprecated Call {@link View#isImportantForAccessibility()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.isImportantForAccessibility(resId)")
     public static boolean isImportantForAccessibility(@NonNull View view) {
         return view.isImportantForAccessibility();
     }
@@ -1492,7 +1496,7 @@ public class ViewCompat {
      * @return Whether the action was performed.
      * @deprecated Call {@link View#performAccessibilityAction(int, Bundle)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.performAccessibilityAction(action, arguments)")
+    @ReplaceWith(expression = "view.performAccessibilityAction(action, arguments)")
     @Deprecated
     public static boolean performAccessibilityAction(@NonNull View view, int action,
             @Nullable Bundle arguments) {
@@ -1824,7 +1828,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#getAlpha()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getAlpha()")
+    @ReplaceWith(expression = "view.getAlpha()")
     @Deprecated
     public static float getAlpha(View view) {
         return view.getAlpha();
@@ -1864,7 +1868,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setLayerType(int, Paint)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setLayerType(layerType, paint)")
+    @ReplaceWith(expression = "view.setLayerType(layerType, paint)")
     @Deprecated
     public static void setLayerType(View view, @LayerType int layerType, Paint paint) {
         view.setLayerType(layerType, paint);
@@ -1874,21 +1878,21 @@ public class ViewCompat {
      * Indicates what type of layer is currently associated with this view. By default
      * a view does not have a layer, and the layer type is {@link View#LAYER_TYPE_NONE}.
      * Refer to the documentation of
-     * {@link #setLayerType(android.view.View, int, android.graphics.Paint)}
+     * {@link View#setLayerType(int, android.graphics.Paint)}
      * for more information on the different types of layers.
      *
      * @param view The view to fetch the layer type from
      * @return {@link View#LAYER_TYPE_NONE}, {@link View#LAYER_TYPE_SOFTWARE} or
      *         {@link View#LAYER_TYPE_HARDWARE}
      *
-     * @see #setLayerType(android.view.View, int, android.graphics.Paint)
+     * @see View#setLayerType(int, android.graphics.Paint)
      * @see View#LAYER_TYPE_NONE
      * @see View#LAYER_TYPE_SOFTWARE
      * @see View#LAYER_TYPE_HARDWARE
      *
      * @deprecated Use {@link View#getLayerType()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getLayerType()")
+    @ReplaceWith(expression = "view.getLayerType()")
     @Deprecated
     @LayerType
     public static int getLayerType(View view) {
@@ -1904,7 +1908,7 @@ public class ViewCompat {
      * @return The labeled view id.
      * @deprecated Call {@link View#getLabelFor()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getLabelFor()")
+    @ReplaceWith(expression = "view.getLabelFor()")
     @Deprecated
     public static int getLabelFor(@NonNull View view) {
         return view.getLabelFor();
@@ -1918,7 +1922,7 @@ public class ViewCompat {
      * @param labeledId The labeled view id.
      * @deprecated Call {@link View#setLabelFor(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setLabelFor(labeledId)")
+    @ReplaceWith(expression = "view.setLabelFor(labeledId)")
     @Deprecated
     public static void setLabelFor(@NonNull View view, @IdRes int labeledId) {
         view.setLabelFor(labeledId);
@@ -1927,9 +1931,9 @@ public class ViewCompat {
     /**
      * Updates the {@link Paint} object used with the current layer (used only if the current
      * layer type is not set to {@link View#LAYER_TYPE_NONE}). Changed properties of the Paint
-     * provided to {@link #setLayerType(android.view.View, int, android.graphics.Paint)}
+     * provided to {@link View#setLayerType(int, android.graphics.Paint)}
      * will be used the next time the View is redrawn, but
-     * {@link #setLayerPaint(android.view.View, android.graphics.Paint)}
+     * {@link View#setLayerPaint(android.graphics.Paint)}
      * must be called to ensure that the view gets redrawn immediately.
      *
      * <p>A layer is associated with an optional {@link android.graphics.Paint}
@@ -1952,10 +1956,10 @@ public class ViewCompat {
      *        and can be null. It is ignored when the layer type is
      *        {@link View#LAYER_TYPE_NONE}
      *
-     * @see #setLayerType(View, int, android.graphics.Paint)
+     * @see View#setLayerType(int, android.graphics.Paint)
      * @deprecated Call {@link View#setLayerPaint(Paint)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setLayerPaint(paint)")
+    @ReplaceWith(expression = "view.setLayerPaint(paint)")
     @Deprecated
     public static void setLayerPaint(@NonNull View view, @Nullable Paint paint) {
         view.setLayerPaint(paint);
@@ -1973,7 +1977,7 @@ public class ViewCompat {
      *
      * @deprecated Call {@link View#getLayoutDirection()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getLayoutDirection()")
+    @ReplaceWith(expression = "view.getLayoutDirection()")
     @Deprecated
     @ResolvedLayoutDirectionMode
     public static int getLayoutDirection(@NonNull View view) {
@@ -1998,7 +2002,7 @@ public class ViewCompat {
      *
      * @deprecated Call {@link View#setLayoutDirection(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setLayoutDirection(layoutDirection)")
+    @ReplaceWith(expression = "view.setLayoutDirection(layoutDirection)")
     @Deprecated
     public static void setLayoutDirection(@NonNull View view,
             @LayoutDirectionMode int layoutDirection) {
@@ -2014,7 +2018,7 @@ public class ViewCompat {
      * @return The parent for use in accessibility inspection
      * @deprecated Call {@link View#getParentForAccessibility()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getParentForAccessibility()")
+    @ReplaceWith(expression = "view.getParentForAccessibility()")
     @Deprecated
     public static @Nullable ViewParent getParentForAccessibility(@NonNull View view) {
         return view.getParentForAccessibility();
@@ -2057,7 +2061,7 @@ public class ViewCompat {
      * @deprecated Use {@link View#isOpaque()} directly. This method will be
      * removed in a future release.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isOpaque()")
+    @ReplaceWith(expression = "view.isOpaque()")
     @Deprecated
     public static boolean isOpaque(View view) {
         return view.isOpaque();
@@ -2080,6 +2084,7 @@ public class ViewCompat {
      * @deprecated Use {@link View#resolveSizeAndState(int, int, int)} directly.
      */
     @Deprecated
+    @ReplaceWith(expression = "View.resolveSizeAndState(size, measureSpec, childMeasuredState)")
     public static int resolveSizeAndState(int size, int measureSpec, int childMeasuredState) {
         return View.resolveSizeAndState(size, measureSpec, childMeasuredState);
     }
@@ -2096,7 +2101,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#getMeasuredWidth()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMeasuredWidthAndState()")
+    @ReplaceWith(expression = "view.getMeasuredWidthAndState()")
     @Deprecated
     public static int getMeasuredWidthAndState(View view) {
         return view.getMeasuredWidthAndState();
@@ -2114,29 +2119,29 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#getMeasuredHeightAndState()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMeasuredHeightAndState()")
+    @ReplaceWith(expression = "view.getMeasuredHeightAndState()")
     @Deprecated
     public static int getMeasuredHeightAndState(View view) {
         return view.getMeasuredHeightAndState();
     }
 
     /**
-     * Return only the state bits of {@link #getMeasuredWidthAndState}
-     * and {@link #getMeasuredHeightAndState}, combined into one integer.
+     * Return only the state bits of {@link View#getMeasuredWidthAndState}
+     * and {@link View#getMeasuredHeightAndState}, combined into one integer.
      * The width component is in the regular bits {@link #MEASURED_STATE_MASK}
      * and the height component is at the shifted bits
      * {@link #MEASURED_HEIGHT_STATE_SHIFT}>>{@link #MEASURED_STATE_MASK}.
      *
      * @deprecated Use {@link View#getMeasuredState()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMeasuredState()")
+    @ReplaceWith(expression = "view.getMeasuredState()")
     @Deprecated
     public static int getMeasuredState(View view) {
         return view.getMeasuredState();
     }
 
     /**
-     * Merge two states as returned by {@link #getMeasuredState(View)}.
+     * Merge two states as returned by {@link View#getMeasuredState()}.
      * @param curState The current state as returned from a view or the result
      * of combining multiple views.
      * @param newState The new view state to combine.
@@ -2146,6 +2151,7 @@ public class ViewCompat {
      * @deprecated Use {@link View#combineMeasuredStates(int, int)} directly.
      */
     @Deprecated
+    @ReplaceWith(expression = "View.combineMeasuredStates(curState, newState)")
     public static int combineMeasuredStates(int curState, int newState) {
         return View.combineMeasuredStates(curState, newState);
     }
@@ -2156,10 +2162,10 @@ public class ViewCompat {
      * @param view The view from which to obtain the live region mode
      * @return The live region mode for the view.
      *
-     * @see ViewCompat#setAccessibilityLiveRegion(View, int)
+     * @see View#setAccessibilityLiveRegion(int)
      * @deprecated Call {@link View#getAccessibilityLiveRegion()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getAccessibilityLiveRegion()")
+    @ReplaceWith(expression = "view.getAccessibilityLiveRegion()")
     @Deprecated
     @AccessibilityLiveRegion
     public static int getAccessibilityLiveRegion(@NonNull View view) {
@@ -2207,7 +2213,7 @@ public class ViewCompat {
      *        </ul>
      * @deprecated Call {@link View#setAccessibilityLiveRegion(int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setAccessibilityLiveRegion(mode)")
+    @ReplaceWith(expression = "view.setAccessibilityLiveRegion(mode)")
     @Deprecated
     public static void setAccessibilityLiveRegion(@NonNull View view,
             @AccessibilityLiveRegion int mode) {
@@ -2223,7 +2229,7 @@ public class ViewCompat {
      * @return the start padding in pixels
      * @deprecated Call {@link View#getPaddingStart()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getPaddingStart()")
+    @ReplaceWith(expression = "view.getPaddingStart()")
     @Deprecated
     @Px
     public static int getPaddingStart(@NonNull View view) {
@@ -2239,7 +2245,7 @@ public class ViewCompat {
      * @return the end padding in pixels
      * @deprecated Call {@link View#getPaddingEnd()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getPaddingEnd()")
+    @ReplaceWith(expression = "view.getPaddingEnd()")
     @Deprecated
     @Px
     public static int getPaddingEnd(@NonNull View view) {
@@ -2249,8 +2255,8 @@ public class ViewCompat {
     /**
      * Sets the relative padding. The view may add on the space required to display
      * the scrollbars, depending on the style and visibility of the scrollbars.
-     * So the values returned from {@link #getPaddingStart}, {@link View#getPaddingTop},
-     * {@link #getPaddingEnd} and {@link View#getPaddingBottom} may be different
+     * So the values returned from {@link View#getPaddingStart}, {@link View#getPaddingTop},
+     * {@link View#getPaddingEnd} and {@link View#getPaddingBottom} may be different
      * from the values set in this call.
      *
      * @param view The view on which to set relative padding
@@ -2260,7 +2266,7 @@ public class ViewCompat {
      * @param bottom the bottom padding in pixels
      * @deprecated Call {@link View#setPaddingRelative(int, int, int, int)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setPaddingRelative(start, top, end, bottom)")
+    @ReplaceWith(expression = "view.setPaddingRelative(start, top, end, bottom)")
     @Deprecated
     public static void setPaddingRelative(@NonNull View view, @Px int start, @Px int top,
             @Px int end, @Px int bottom) {
@@ -2334,7 +2340,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#getTranslationX()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getTranslationX()")
+    @ReplaceWith(expression = "view.getTranslationX()")
     @Deprecated
     public static float getTranslationX(View view) {
         return view.getTranslationX();
@@ -2349,7 +2355,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#getTranslationY()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getTranslationY()")
+    @ReplaceWith(expression = "view.getTranslationY()")
     @Deprecated
     public static float getTranslationY(View view) {
         return view.getTranslationY();
@@ -2363,15 +2369,15 @@ public class ViewCompat {
      * @param view The view whose Matrix will be returned
      * @return The current transform matrix for the view
      *
-     * @see #getRotation(View)
-     * @see #getScaleX(View)
-     * @see #getScaleY(View)
-     * @see #getPivotX(View)
-     * @see #getPivotY(View)
+     * @see View#getRotation()
+     * @see View#getScaleX()
+     * @see View#getScaleY()
+     * @see View#getPivotX()
+     * @see View#getPivotY()
      *
      * @deprecated Use {@link View#getMatrix()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMatrix()")
+    @ReplaceWith(expression = "view.getMatrix()")
     @Deprecated
     public static @Nullable Matrix getMatrix(View view) {
         return view.getMatrix();
@@ -2385,7 +2391,7 @@ public class ViewCompat {
      * @return the minimum width the view will try to be.
      * @deprecated Call {@link View#getMinimumWidth()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMinimumWidth()")
+    @ReplaceWith(expression = "view.getMinimumWidth()")
     @Deprecated
     @SuppressWarnings({"JavaReflectionMemberAccess", "ConstantConditions"})
     // Reflective access to private field, unboxing result of reflective get()
@@ -2401,7 +2407,7 @@ public class ViewCompat {
      * @return the minimum height the view will try to be.
      * @deprecated Call {@link View#getMinimumHeight()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getMinimumHeight()")
+    @ReplaceWith(expression = "view.getMinimumHeight()")
     @Deprecated
     @SuppressWarnings({"JavaReflectionMemberAccess", "ConstantConditions"})
     // Reflective access to private field, unboxing result of reflective get()
@@ -2417,6 +2423,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#animate()} directly.
      */
     @Deprecated
+    @ReplaceWith(expression = "view.animate()")
     public static @NonNull ViewPropertyAnimatorCompat animate(@NonNull View view) {
         if (sViewPropertyAnimatorMap == null) {
             sViewPropertyAnimatorMap = new WeakHashMap<>();
@@ -2440,7 +2447,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setTranslationX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setTranslationX(value)")
+    @ReplaceWith(expression = "view.setTranslationX(value)")
     @Deprecated
     public static void setTranslationX(View view, float value) {
         view.setTranslationX(value);
@@ -2459,7 +2466,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setTranslationY(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setTranslationY(value)")
+    @ReplaceWith(expression = "view.setTranslationY(value)")
     @Deprecated
     public static void setTranslationY(View view, float value) {
         view.setTranslationY(value);
@@ -2478,7 +2485,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setAlpha(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setAlpha(value)")
+    @ReplaceWith(expression = "view.setAlpha(value)")
     @Deprecated
     public static void setAlpha(View view, @FloatRange(from = 0.0, to = 1.0) float value) {
         view.setAlpha(value);
@@ -2486,7 +2493,7 @@ public class ViewCompat {
 
     /**
      * Sets the visual x position of this view, in pixels. This is equivalent to setting the
-     * {@link #setTranslationX(View, float) translationX} property to be the difference between
+     * {@link View#setTranslationX(float) translationX} property to be the difference between
      * the x value passed in and the current left property of the view as determined
      * by the layout bounds.
      *
@@ -2495,7 +2502,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setX(value)")
+    @ReplaceWith(expression = "view.setX(value)")
     @Deprecated
     public static void setX(View view, float value) {
         view.setX(value);
@@ -2503,7 +2510,7 @@ public class ViewCompat {
 
     /**
      * Sets the visual y position of this view, in pixels. This is equivalent to setting the
-     * {@link #setTranslationY(View, float) translationY} property to be the difference between
+     * {@link View#setTranslationY(float) translationY} property to be the difference between
      * the y value passed in and the current top property of the view as determined by the
      * layout bounds.
      *
@@ -2512,7 +2519,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setY(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setY(value)")
+    @ReplaceWith(expression = "view.setY(value)")
     @Deprecated
     public static void setY(View view, float value) {
         view.setY(value);
@@ -2527,7 +2534,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setRotation(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setRotation(value)")
+    @ReplaceWith(expression = "view.setRotation(value)")
     @Deprecated
     public static void setRotation(View view, float value) {
         view.setRotation(value);
@@ -2543,7 +2550,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setRotationX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setRotationX(value)")
+    @ReplaceWith(expression = "view.setRotationX(value)")
     @Deprecated
     public static void setRotationX(View view, float value) {
         view.setRotationX(value);
@@ -2559,7 +2566,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setRotationY(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setRotationY(value)")
+    @ReplaceWith(expression = "view.setRotationY(value)")
     @Deprecated
     public static void setRotationY(View view, float value) {
         view.setRotationY(value);
@@ -2574,7 +2581,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setScaleX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setScaleX(value)")
+    @ReplaceWith(expression = "view.setScaleX(value)")
     @Deprecated
     public static void setScaleX(View view, float value) {
         view.setScaleX(value);
@@ -2589,7 +2596,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setScaleY(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setScaleY(value)")
+    @ReplaceWith(expression = "view.setScaleY(value)")
     @Deprecated
     public static void setScaleY(View view, float value) {
         view.setScaleY(value);
@@ -2597,12 +2604,12 @@ public class ViewCompat {
 
     /**
      * The x location of the point around which the view is
-     * {@link #setRotation(View, float) rotated} and {@link #setScaleX(View, float) scaled}.
+     * {@link View#setRotation(float) rotated} and {@link View#setScaleX(float) scaled}.
      *
      * @param view view for which to get the pivot.
      * @deprecated Use {@link View#getPivotX()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getPivotX()")
+    @ReplaceWith(expression = "view.getPivotX()")
     @Deprecated
     public static float getPivotX(View view) {
         return view.getPivotX();
@@ -2610,7 +2617,7 @@ public class ViewCompat {
 
     /**
      * Sets the x location of the point around which the view is
-     * {@link #setRotation(View, float) rotated} and {@link #setScaleX(View, float) scaled}.
+     * {@link View#setRotation(float) rotated} and {@link View#setScaleX(float) scaled}.
      * By default, the pivot point is centered on the object.
      * Setting this property disables this behavior and causes the view to use only the
      * explicitly set pivotX and pivotY values.
@@ -2620,22 +2627,22 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setPivotX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setPivotX(value)")
+    @ReplaceWith(expression = "view.setPivotX(value)")
     @Deprecated
     public static void setPivotX(View view, float value) {
         view.setPivotX(value);
     }
 
     /**
-     * The y location of the point around which the view is {@link #setRotation(View,
-     * float) rotated} and {@link #setScaleY(View, float) scaled}.
+     * The y location of the point around which the view is {@link View#setRotation(float) rotated}
+     * and {@link View#setScaleY(float) scaled}.
      *
      * @param view view for which to get the pivot.
      * @return The y location of the pivot point.
      *
      * @deprecated Use {@link View#getPivotY()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getPivotY()")
+    @ReplaceWith(expression = "view.getPivotY()")
     @Deprecated
     public static float getPivotY(View view) {
         return view.getPivotY();
@@ -2643,7 +2650,7 @@ public class ViewCompat {
 
     /**
      * Sets the y location of the point around which the view is
-     * {@link #setRotation(View, float) rotated} and {@link #setScaleY(View, float) scaled}.
+     * {@link View#setRotation(float) rotated} and {@link View#setScaleY(float) scaled}.
      * By default, the pivot point is centered on the object.
      * Setting this property disables this behavior and causes the view to use only the
      * explicitly set pivotX and pivotY values.
@@ -2653,7 +2660,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setPivotX(float)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setPivotY(value)")
+    @ReplaceWith(expression = "view.setPivotY(value)")
     @Deprecated
     public static void setPivotY(View view, float value) {
         view.setPivotY(value);
@@ -2663,7 +2670,7 @@ public class ViewCompat {
      * @param view view for which to get the rotation.
      * @deprecated Use {@link View#getRotation()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getRotation()")
+    @ReplaceWith(expression = "view.getRotation()")
     @Deprecated
     public static float getRotation(View view) {
         return view.getRotation();
@@ -2673,7 +2680,7 @@ public class ViewCompat {
      * @param view view for which to get the rotation.
      * @deprecated Use {@link View#getRotationX()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getRotationX()")
+    @ReplaceWith(expression = "view.getRotationX()")
     @Deprecated
     public static float getRotationX(View view) {
         return view.getRotationX();
@@ -2683,7 +2690,7 @@ public class ViewCompat {
      * @param view view for which to get the rotation.
      * @deprecated Use {@link View#getRotationY()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getRotationY()")
+    @ReplaceWith(expression = "view.getRotationY()")
     @Deprecated
     public static float getRotationY(View view) {
         return view.getRotationY();
@@ -2693,7 +2700,7 @@ public class ViewCompat {
      * @param view view for which to get the scale.
      * @deprecated Use {@link View#getScaleX()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getScaleX()")
+    @ReplaceWith(expression = "view.getScaleX()")
     @Deprecated
     public static float getScaleX(View view) {
         return view.getScaleX();
@@ -2703,7 +2710,7 @@ public class ViewCompat {
      * @param view view for which to get the scale.
      * @deprecated Use {@link View#getScaleY()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getScaleY()")
+    @ReplaceWith(expression = "view.getScaleY()")
     @Deprecated
     public static float getScaleY(View view) {
         return view.getScaleY();
@@ -2713,7 +2720,7 @@ public class ViewCompat {
      * @param view view for which to get the X.
      * @deprecated Use {@link View#getX()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getX()")
+    @ReplaceWith(expression = "view.getX()")
     @Deprecated
     public static float getX(View view) {
         return view.getX();
@@ -2723,7 +2730,7 @@ public class ViewCompat {
      * @param view view for which to get the Y.
      * @deprecated Use {@link View#getY()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getY()")
+    @ReplaceWith(expression = "view.getY()")
     @Deprecated
     public static float getY(View view) {
         return view.getY();
@@ -2733,7 +2740,10 @@ public class ViewCompat {
      * @param view view for which to set the elevation.
      * @param elevation view elevation in pixels.
      * Sets the base elevation of this view, in pixels.
+     * @deprecated Call {@link View#setElevation(float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setElevation(elevation)")
     public static void setElevation(@NonNull View view, float elevation) {
         view.setElevation(elevation);
     }
@@ -2743,26 +2753,35 @@ public class ViewCompat {
      *
      * @param view view for which to get the elevation.
      * @return The base depth position of the view, in pixels.
+     * @deprecated Call {@link View#getElevation()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getElevation()")
     public static float getElevation(@NonNull View view) {
         return view.getElevation();
     }
 
     /**
-     * Sets the depth location of this view relative to its {@link #getElevation(View) elevation}.
+     * Sets the depth location of this view relative to its {@link View#getElevation() elevation}.
      * @param view view for which to set the translation.
      * @param translationZ the depth of location of this view relative its elevation.
+     * @deprecated Call {@link View#setTranslationZ(float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setTranslationZ(translationZ)")
     public static void setTranslationZ(@NonNull View view, float translationZ) {
         view.setTranslationZ(translationZ);
     }
 
     /**
-     * The depth location of this view relative to its {@link #getElevation(View) elevation}.
+     * The depth location of this view relative to its {@link View#getElevation() elevation}.
      *
      * @param view view for which to get the translation.
      * @return The depth of this view relative to its elevation.
+     * @deprecated Call {@link View#getTranslationZ()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getTranslationZ()")
     public static float getTranslationZ(@NonNull View view) {
         return view.getTranslationZ();
     }
@@ -2773,7 +2792,10 @@ public class ViewCompat {
      *
      * @param view The View against which to invoke the method.
      * @param transitionName The name of the View to uniquely identify it for Transitions.
+     * @deprecated Call {@link View#setTransitionName(String)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setTransitionName(transitionName)")
     public static void setTransitionName(@NonNull View view, @Nullable String transitionName) {
         view.setTransitionName(transitionName);
     }
@@ -2787,7 +2809,10 @@ public class ViewCompat {
      * @param view The View against which to invoke the method.
      * @return The name used of the View to be used to identify Views in Transitions or null
      * if no name has been given.
+     * @deprecated Call {@link View#getTransitionName()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getTransitionName()")
     public static @Nullable String getTransitionName(@NonNull View view) {
         return view.getTransitionName();
     }
@@ -2815,7 +2840,7 @@ public class ViewCompat {
      * @deprecated SystemUiVisibility flags are deprecated. Use
      * {@link WindowInsetsController} instead.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getWindowSystemUiVisibility()")
+    @ReplaceWith(expression = "view.getWindowSystemUiVisibility()")
     @Deprecated
     public static int getWindowSystemUiVisibility(@NonNull View view) {
         return view.getWindowSystemUiVisibility();
@@ -2826,7 +2851,10 @@ public class ViewCompat {
      * falls back to {@code View.requestFitSystemWindows()} where available.
      *
      * @param view view for which to send the request.
+     * @deprecated Call {@link View#requestApplyInsets()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.requestApplyInsets()")
     public static void requestApplyInsets(@NonNull View view) {
         view.requestApplyInsets();
     }
@@ -2845,6 +2873,7 @@ public class ViewCompat {
      */
     @SuppressLint("BanUncheckedReflection") // Reflective access to bypass Java visibility
     @Deprecated
+    @ReplaceWith(expression = "viewGroup.setChildrenDrawingOrderEnabled(enabled)")
     public static void setChildrenDrawingOrderEnabled(ViewGroup viewGroup, boolean enabled) {
         if (sChildrenDrawingOrderMethod == null) {
             try {
@@ -2873,7 +2902,7 @@ public class ViewCompat {
      * @param view view for which to get the state.
      * @deprecated Call {@link View#getFitsSystemWindows()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getFitsSystemWindows()")
+    @ReplaceWith(expression = "view.getFitsSystemWindows()")
     @Deprecated
     public static boolean getFitsSystemWindows(@NonNull View view) {
         return view.getFitsSystemWindows();
@@ -2891,7 +2920,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setFitsSystemWindows(boolean)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setFitsSystemWindows(fitSystemWindows)")
+    @ReplaceWith(expression = "view.setFitsSystemWindows(fitSystemWindows)")
     @Deprecated
     public static void setFitsSystemWindows(View view, boolean fitSystemWindows) {
         view.setFitsSystemWindows(fitSystemWindows);
@@ -2907,7 +2936,7 @@ public class ViewCompat {
      * @param view view for which to jump the drawable state.
      * @deprecated Use {@link View#jumpDrawablesToCurrentState()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.jumpDrawablesToCurrentState()")
+    @ReplaceWith(expression = "view.jumpDrawablesToCurrentState()")
     @Deprecated
     public static void jumpDrawablesToCurrentState(View view) {
         view.jumpDrawablesToCurrentState();
@@ -3301,7 +3330,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setSaveFromParentEnabled(boolean)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setSaveFromParentEnabled(enabled)")
+    @ReplaceWith(expression = "view.setSaveFromParentEnabled(enabled)")
     @Deprecated
     public static void setSaveFromParentEnabled(View view, boolean enabled) {
         view.setSaveFromParentEnabled(enabled);
@@ -3319,7 +3348,7 @@ public class ViewCompat {
      *
      * @deprecated Use {@link View#setActivated(boolean)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setActivated(activated)")
+    @ReplaceWith(expression = "view.setActivated(activated)")
     @Deprecated
     public static void setActivated(View view, boolean activated) {
         view.setActivated(activated);
@@ -3341,7 +3370,7 @@ public class ViewCompat {
      * @return true if the content in this view might overlap, false otherwise.
      * @deprecated Call {@link View#hasOverlappingRendering()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.hasOverlappingRendering()")
+    @ReplaceWith(expression = "view.hasOverlappingRendering()")
     @Deprecated
     public static boolean hasOverlappingRendering(@NonNull View view) {
         return view.hasOverlappingRendering();
@@ -3355,7 +3384,7 @@ public class ViewCompat {
      * @return true if the padding is relative or false if it is not.
      * @deprecated Call {@link View#isPaddingRelative()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isPaddingRelative()")
+    @ReplaceWith(expression = "view.isPaddingRelative()")
     @Deprecated
     public static boolean isPaddingRelative(@NonNull View view) {
         return view.isPaddingRelative();
@@ -3370,7 +3399,7 @@ public class ViewCompat {
      * @param background the drawable to use as view background.
      * @deprecated Call {@link View#setBackground(Drawable)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setBackground(background)")
+    @ReplaceWith(expression = "view.setBackground(background)")
     @Deprecated
     public static void setBackground(@NonNull View view, @Nullable Drawable background) {
         view.setBackground(background);
@@ -3381,14 +3410,21 @@ public class ViewCompat {
      * <p>
      * Only returns meaningful info when running on API v21 or newer, or if {@code view}
      * implements the {@code TintableBackgroundView} interface.
+     * @deprecated Call {@link View#getBackgroundTintList()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getBackgroundTintList()")
     public static @Nullable ColorStateList getBackgroundTintList(@NonNull View view) {
         return view.getBackgroundTintList();
     }
 
     /**
      * Applies a tint to the background drawable.
+     *
+     * @deprecated Call {@link View#setBackgroundTintList(ColorStateList)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setBackgroundTintList(tintLint)")
     public static void setBackgroundTintList(@NonNull View view,
             @Nullable ColorStateList tintList) {
         view.setBackgroundTintList(tintList);
@@ -3400,16 +3436,23 @@ public class ViewCompat {
      * <p>
      * Only returns meaningful info when running on API v21 or newer, or if {@code view}
      * implements the {@code TintableBackgroundView} interface.
+     * @deprecated Call {@link View#getBackgroundTintMode()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getBackgroundTintMode()")
     public static PorterDuff.@Nullable Mode getBackgroundTintMode(@NonNull View view) {
         return view.getBackgroundTintMode();
     }
 
     /**
      * Specifies the blending mode used to apply the tint specified by
-     * {@link #setBackgroundTintList(android.view.View, android.content.res.ColorStateList)} to
+     * {@link View#setBackgroundTintList(android.content.res.ColorStateList)} to
      * the background drawable. The default mode is {@link PorterDuff.Mode#SRC_IN}.
+     *
+     * @deprecated Call {@link View#setBackgroundTintMode(PorterDuff.Mode)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setBackgroundTintMode(mode)")
     public static void setBackgroundTintMode(@NonNull View view, PorterDuff.@Nullable Mode mode) {
         view.setBackgroundTintMode(mode);
     }
@@ -3423,14 +3466,16 @@ public class ViewCompat {
      * scrolling operations with a compatible parent view in the current hierarchy. If this
      * view does not implement nested scrolling this will have no effect. Disabling nested scrolling
      * while a nested scroll is in progress has the effect of
-     * {@link #stopNestedScroll(View) stopping} the nested scroll.</p>
+     * {@link View#stopNestedScroll() stopping} the nested scroll.</p>
      *
      * @param view view for which to set the state.
      * @param enabled true to enable nested scrolling, false to disable
      *
-     * @see #isNestedScrollingEnabled(View)
+     * @see View#isNestedScrollingEnabled()
+     * @deprecated Call {@link View#setNestedScrollingEnabled(boolean)} directly.
      */
-    @SuppressWarnings("RedundantCast") // Intentionally invoking interface method.
+    @Deprecated
+    @ReplaceWith(expression = "view.setNestedScrollingEnabled(enabled)")
     public static void setNestedScrollingEnabled(@NonNull View view, boolean enabled) {
         view.setNestedScrollingEnabled(enabled);
     }
@@ -3445,8 +3490,11 @@ public class ViewCompat {
      *
      * @return true if nested scrolling is enabled
      *
-     * @see #setNestedScrollingEnabled(View, boolean)
+     * @see View#setNestedScrollingEnabled(boolean)
+     * @deprecated Call {@link View#isNestedScrollingEnabled()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.isNestedScrollingEnabled()")
     public static boolean isNestedScrollingEnabled(@NonNull View view) {
         return view.isNestedScrollingEnabled();
     }
@@ -3462,7 +3510,10 @@ public class ViewCompat {
      *             and/or {@link ViewCompat#SCROLL_AXIS_VERTICAL}.
      * @return true if a cooperative parent was found and nested scrolling has been enabled for
      *         the current gesture.
+     * @deprecated Call {@link View#startNestedScroll(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.startNestedScroll(axes)")
     public static boolean startNestedScroll(@NonNull View view, @ScrollAxis int axes) {
         return view.startNestedScroll(axes);
     }
@@ -3475,8 +3526,11 @@ public class ViewCompat {
      *
      * @param view view for which to stop the scroll.
      *
-     * @see #startNestedScroll(View, int)
+     * @see View#startNestedScroll(int)
+     * @deprecated Call {@link View#stopNestedScroll()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.stopNestedScroll()")
     public static void stopNestedScroll(@NonNull View view) {
         view.stopNestedScroll();
     }
@@ -3489,7 +3543,10 @@ public class ViewCompat {
      *
      * @param view view for which to check the parent.
      * @return whether this view has a nested scrolling parent
+     * @deprecated Call {@link View#hasNestedScrollingParent()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.hasNestedScrollingParent()")
     public static boolean hasNestedScrollingParent(@NonNull View view) {
         return view.hasNestedScrollingParent();
     }
@@ -3511,7 +3568,10 @@ public class ViewCompat {
      *                       to after it completes. View implementations may use this to adjust
      *                       expected input coordinate tracking.
      * @return true if the event was dispatched, false if it could not be dispatched.
+     * @deprecated Call {@link View#dispatchNestedScroll(int, int, int, int, int[])} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, offsetInWindow)")
     public static boolean dispatchNestedScroll(@NonNull View view, int dxConsumed, int dyConsumed,
             int dxUnconsumed, int dyUnconsumed, int @Nullable [] offsetInWindow) {
         return view.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed,
@@ -3535,8 +3595,10 @@ public class ViewCompat {
      *                       to after it completes. View implementations may use this to adjust
      *                       expected input coordinate tracking.
      * @return true if the parent consumed some or all of the scroll delta
+     * @deprecated Call {@link View#dispatchNestedPreScroll(int, int, int[], int[])} directly.
      */
-    @SuppressWarnings("RedundantCast") // Intentionally invoking interface method.
+    @Deprecated
+    @ReplaceWith(expression = "view.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow)")
     public static boolean dispatchNestedPreScroll(@NonNull View view, int dx, int dy,
             int @Nullable [] consumed, int @Nullable [] offsetInWindow) {
         return view.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow);
@@ -3552,20 +3614,20 @@ public class ViewCompat {
      * In the case of touch scrolling the nested scroll will be terminated automatically in
      * the same manner as {@link ViewParent#requestDisallowInterceptTouchEvent(boolean)}.
      * In the event of programmatic scrolling the caller must explicitly call
-     * {@link #stopNestedScroll(View)} to indicate the end of the nested scroll.</p>
+     * {@link View#stopNestedScroll()} to indicate the end of the nested scroll.</p>
      *
      * <p>If <code>startNestedScroll</code> returns true, a cooperative parent was found.
      * If it returns false the caller may ignore the rest of this contract until the next scroll.
      * Calling startNestedScroll while a nested scroll is already in progress will return true.</p>
      *
      * <p>At each incremental step of the scroll the caller should invoke
-     * {@link #dispatchNestedPreScroll(View, int, int, int[], int[]) dispatchNestedPreScroll}
+     * {@link View#dispatchNestedPreScroll(int, int, int[], int[]) dispatchNestedPreScroll}
      * once it has calculated the requested scrolling delta. If it returns true the nested scrolling
      * parent at least partially consumed the scroll and the caller should adjust the amount it
      * scrolls by.</p>
      *
      * <p>After applying the remainder of the scroll delta the caller should invoke
-     * {@link #dispatchNestedScroll(View, int, int, int, int, int[]) dispatchNestedScroll}, passing
+     * {@link View#dispatchNestedScroll(int, int, int, int, int[]) dispatchNestedScroll}, passing
      * both the delta consumed and the delta unconsumed. A nested scrolling parent may treat
      * these values differently. See
      * {@link NestedScrollingParent#onNestedScroll(View, int, int, int, int)}.
@@ -3578,16 +3640,16 @@ public class ViewCompat {
      * @return true if a cooperative parent was found and nested scrolling has been enabled for
      *         the current gesture.
      *
-     * @see #stopNestedScroll(View)
-     * @see #dispatchNestedPreScroll(View, int, int, int[], int[])
-     * @see #dispatchNestedScroll(View, int, int, int, int, int[])
+     * @see View#stopNestedScroll()
+     * @see View#dispatchNestedPreScroll(int, int, int[], int[])
+     * @see View#dispatchNestedScroll(int, int, int, int, int[])
      */
     public static boolean startNestedScroll(@NonNull View view, @ScrollAxis int axes,
             @NestedScrollType int type) {
         if (view instanceof NestedScrollingChild2) {
             return ((NestedScrollingChild2) view).startNestedScroll(axes, type);
         } else if (type == ViewCompat.TYPE_TOUCH) {
-            return startNestedScroll(view, axes);
+            return view.startNestedScroll(axes);
         }
         return false;
     }
@@ -3599,13 +3661,13 @@ public class ViewCompat {
      *
      * @param view view for which to stop the scroll.
      * @param type the type of input which cause this scroll event
-     * @see #startNestedScroll(View, int)
+     * @see View#startNestedScroll(int)
      */
     public static void stopNestedScroll(@NonNull View view, @NestedScrollType int type) {
         if (view instanceof NestedScrollingChild2) {
             ((NestedScrollingChild2) view).stopNestedScroll(type);
         } else if (type == ViewCompat.TYPE_TOUCH) {
-            stopNestedScroll(view);
+             view.stopNestedScroll();
         }
     }
 
@@ -3623,7 +3685,7 @@ public class ViewCompat {
         if (view instanceof NestedScrollingChild2) {
             ((NestedScrollingChild2) view).hasNestedScrollingParent(type);
         } else if (type == ViewCompat.TYPE_TOUCH) {
-            return hasNestedScrollingParent(view);
+            return view.hasNestedScrollingParent();
         }
         return false;
     }
@@ -3634,7 +3696,7 @@ public class ViewCompat {
      * <p>Implementations of views that support nested scrolling should call this to report
      * info about a scroll in progress to the current nested scrolling parent. If a nested scroll
      * is not currently in progress or nested scrolling is not
-     * {@link #isNestedScrollingEnabled(View) enabled} for this view this method does nothing.</p>
+     * {@link View#isNestedScrollingEnabled() enabled} for this view this method does nothing.</p>
      *
      * <p>Compatible View implementations should also call
      * {@link #dispatchNestedPreScroll(View, int, int, int[], int[], int) dispatchNestedPreScroll}
@@ -3677,10 +3739,10 @@ public class ViewCompat {
      * <p>Implementations of views that support nested scrolling should call this to report
      * info about a scroll in progress to the current nested scrolling parent. If a nested scroll
      * is not currently in progress or nested scrolling is not
-     * {@link #isNestedScrollingEnabled(View) enabled} for this view this method does nothing.
+     * {@link View#isNestedScrollingEnabled() enabled} for this view this method does nothing.
      *
      * <p>Compatible View implementations should also call
-     * {@link #dispatchNestedPreScroll(View, int, int, int[], int[]) dispatchNestedPreScroll} before
+     * {@link View#dispatchNestedPreScroll(int, int, int[], int[]) dispatchNestedPreScroll} before
      * consuming a component of the scroll event themselves.
      *
      * @param view view for which to dispatch the scroll.
@@ -3694,7 +3756,7 @@ public class ViewCompat {
      *                       expected input coordinate tracking.
      * @param type the type of input which cause this scroll event
      * @return true if the event was dispatched, and therefore the scroll distance was consumed
-     * @see #dispatchNestedPreScroll(View, int, int, int[], int[])
+     * @see View#dispatchNestedPreScroll(int, int, int[], int[])
      */
     public static boolean dispatchNestedScroll(@NonNull View view, int dxConsumed, int dyConsumed,
             int dxUnconsumed, int dyUnconsumed, int @Nullable [] offsetInWindow,
@@ -3703,7 +3765,7 @@ public class ViewCompat {
             return ((NestedScrollingChild2) view).dispatchNestedScroll(dxConsumed, dyConsumed,
                     dxUnconsumed, dyUnconsumed, offsetInWindow, type);
         } else if (type == ViewCompat.TYPE_TOUCH) {
-            return dispatchNestedScroll(view, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
+            return view.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
                     offsetInWindow);
         }
         return false;
@@ -3728,7 +3790,7 @@ public class ViewCompat {
      *                       expected input coordinate tracking.
      * @param type the type of input which cause this scroll event
      * @return true if the parent consumed some or all of the scroll delta
-     * @see #dispatchNestedScroll(View, int, int, int, int, int[])
+     * @see View#dispatchNestedScroll(int, int, int, int, int[])
      */
     public static boolean dispatchNestedPreScroll(@NonNull View view, int dx, int dy,
             int @Nullable [] consumed, int @Nullable [] offsetInWindow,
@@ -3737,7 +3799,7 @@ public class ViewCompat {
             return ((NestedScrollingChild2) view).dispatchNestedPreScroll(dx, dy, consumed,
                     offsetInWindow, type);
         } else if (type == ViewCompat.TYPE_TOUCH) {
-            return dispatchNestedPreScroll(view, dx, dy, consumed, offsetInWindow);
+            return view.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow);
         }
         return false;
     }
@@ -3760,8 +3822,10 @@ public class ViewCompat {
      * @param velocityY Vertical fling velocity in pixels per second
      * @param consumed true if the child consumed the fling, false otherwise
      * @return true if the nested scrolling parent consumed or otherwise reacted to the fling
+     * @deprecated Call {@link View#dispatchNestedFling(float, float, boolean)} directly.
      */
-    @SuppressWarnings("RedundantCast") // Intentionally invoking interface method.
+    @Deprecated
+    @ReplaceWith(expression = "view.dispatchNestedFling(velocityX, velocityY, consumed)")
     public static boolean dispatchNestedFling(@NonNull View view, float velocityX, float velocityY,
             boolean consumed) {
         return view.dispatchNestedFling(velocityX, velocityY, consumed);
@@ -3797,8 +3861,10 @@ public class ViewCompat {
      * @param velocityX Horizontal fling velocity in pixels per second
      * @param velocityY Vertical fling velocity in pixels per second
      * @return true if a nested scrolling parent consumed the fling
+     * @deprecated Call {@link View#dispatchNestedPreFling(float, float)} directly.
      */
-    @SuppressWarnings("RedundantCast") // Intentionally invoking interface method.
+    @Deprecated
+    @ReplaceWith(expression = "view.dispatchNestedPreFling(velocityX, velocityY)")
     public static boolean dispatchNestedPreFling(@NonNull View view, float velocityX,
             float velocityY) {
         return view.dispatchNestedPreFling(velocityX, velocityY);
@@ -3817,7 +3883,7 @@ public class ViewCompat {
      * @return whether the view hierarchy is currently undergoing a layout pass
      * @deprecated Call {@link View#isInLayout()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isInLayout()")
+    @ReplaceWith(expression = "view.isInLayout()")
     @Deprecated
     public static boolean isInLayout(@NonNull View view) {
         return view.isInLayout();
@@ -3828,7 +3894,7 @@ public class ViewCompat {
      * was last attached to or detached from a window.
      * @deprecated Call {@link View#isLaidOut()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isLaidOut()")
+    @ReplaceWith(expression = "view.isLaidOut()")
     @Deprecated
     public static boolean isLaidOut(@NonNull View view) {
         return view.isLaidOut();
@@ -3845,7 +3911,7 @@ public class ViewCompat {
      * @return true if layout direction has been resolved.
      * @deprecated Call {@link View#isLayoutDirectionResolved()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isLayoutDirectionResolved()")
+    @ReplaceWith(expression = "view.isLayoutDirectionResolved()")
     @Deprecated
     public static boolean isLayoutDirectionResolved(@NonNull View view) {
         return view.isLayoutDirectionResolved();
@@ -3853,21 +3919,24 @@ public class ViewCompat {
 
     /**
      * The visual z position of this view, in pixels. This is equivalent to the
-     * {@link #setTranslationZ(View, float) translationZ} property plus the current
-     * {@link #getElevation(View) elevation} property.
+     * {@link View#setTranslationZ(float) translationZ} property plus the current
+     * {@link View#getElevation() elevation} property.
      *
      * @param view view for which to get the position.
      *
      * @return The visual z position of this view, in pixels.
+     * @deprecated Call {@link View#getZ()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getZ()")
     public static float getZ(@NonNull View view) {
         return view.getZ();
     }
 
     /**
      * Sets the visual z position of this view, in pixels. This is equivalent to setting the
-     * {@link #setTranslationZ(View, float) translationZ} property to be the difference between
-     * the x value passed in and the current {@link #getElevation(View) elevation} property.
+     * {@link View#setTranslationZ(float) translationZ} property to be the difference between
+     * the x value passed in and the current {@link View#getElevation() elevation} property.
      * <p>
      * Compatibility:
      * <ul>
@@ -3876,7 +3945,10 @@ public class ViewCompat {
      *
      * @param view view for which to set the position.
      * @param z The visual z position of this view, in pixels.
+     * @deprecated Call {@link View#setZ(float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setZ(z)")
     public static void setZ(@NonNull View view, float z) {
         view.setZ(z);
     }
@@ -3886,7 +3958,10 @@ public class ViewCompat {
      *
      * @param view view that needs to be offset.
      * @param offset the number of pixels to offset the view by
+     * @deprecated Call {@link View#offsetTopAndBottom(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.offsetTopAndBottom(offset)")
     public static void offsetTopAndBottom(@NonNull View view, int offset) {
         view.offsetTopAndBottom(offset);
     }
@@ -3896,7 +3971,10 @@ public class ViewCompat {
      *
      * @param view view which needs to be offset.
      * @param offset the number of pixels to offset the view by
+     * @deprecated Call {@link View#offsetLeftAndRight(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.offsetLeftAndRight(offset)")
     public static void offsetLeftAndRight(@NonNull View view, int offset) {
         view.offsetLeftAndRight(offset);
     }
@@ -3913,14 +3991,14 @@ public class ViewCompat {
      * this view, to which future drawing operations will be clipped.
      * @deprecated Call {@link View#setClipBounds(Rect)} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.setClipBounds(clipBounds)")
+    @ReplaceWith(expression = "view.setClipBounds(clipBounds)")
     @Deprecated
     public static void setClipBounds(@NonNull View view, @Nullable Rect clipBounds) {
         view.setClipBounds(clipBounds);
     }
 
     /**
-     * Returns a copy of the current {@link #setClipBounds(View, Rect)}.
+     * Returns a copy of the current {@link View#setClipBounds(Rect)}.
      *
      * <p>Prior to API 18 this will return null.</p>
      *
@@ -3928,7 +4006,7 @@ public class ViewCompat {
      * otherwise null.
      * @deprecated Call {@link View#getClipBounds()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getClipBounds()")
+    @ReplaceWith(expression = "view.getClipBounds()")
     @Deprecated
     public static @Nullable Rect getClipBounds(@NonNull View view) {
         return view.getClipBounds();
@@ -3938,7 +4016,7 @@ public class ViewCompat {
      * Returns true if the provided view is currently attached to a window.
      * @deprecated Call {@link View#isAttachedToWindow()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.isAttachedToWindow()")
+    @ReplaceWith(expression = "view.isAttachedToWindow()")
     @Deprecated
     public static boolean isAttachedToWindow(@NonNull View view) {
         return view.isAttachedToWindow();
@@ -3950,7 +4028,7 @@ public class ViewCompat {
      * @return true if there is a listener, false if there is none.
      * @deprecated Call {@link View#hasOnClickListeners()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.hasOnClickListeners()")
+    @ReplaceWith(expression = "view.hasOnClickListeners()")
     @Deprecated
     public static boolean hasOnClickListeners(@NonNull View view) {
         return view.hasOnClickListeners();
@@ -3959,22 +4037,25 @@ public class ViewCompat {
     /**
      * Sets the state of all scroll indicators.
      * <p>
-     * See {@link #setScrollIndicators(View, int, int)} for usage information.
+     * See {@link View#setScrollIndicators(int, int)} for usage information.
      *
      * @param view view for which to set the state.
      * @param indicators a bitmask of indicators that should be enabled, or
      *                   {@code 0} to disable all indicators
      *
-     * @see #setScrollIndicators(View, int, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int, int)
+     * @see View#getScrollIndicators()
+     * @deprecated Call {@link View#setScrollIndicators(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setScrollIndicators(indicators)")
     public static void setScrollIndicators(@NonNull View view, @ScrollIndicators int indicators) {
         view.setScrollIndicators(indicators);
     }
 
     /**
      * Sets the state of the scroll indicators specified by the mask. To change
-     * all scroll indicators at once, see {@link #setScrollIndicators(View, int)}.
+     * all scroll indicators at once, see {@link View#setScrollIndicators(int)}.
      * <p>
      * When a scroll indicator is enabled, it will be displayed if the view
      * can scroll in the direction of the indicator.
@@ -3998,9 +4079,12 @@ public class ViewCompat {
      *             </ul>
      * @param mask the mask for scroll indicators.
      *
-     * @see #setScrollIndicators(View, int)
-     * @see #getScrollIndicators(View)
+     * @see View#setScrollIndicators(int)
+     * @see View#getScrollIndicators()
+     * @deprecated Call {@link View#setScrollIndicators(int, int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setScrollIndicators(indicators, mask)")
     public static void setScrollIndicators(@NonNull View view, @ScrollIndicators int indicators,
             @ScrollIndicators int mask) {
         view.setScrollIndicators(indicators, mask);
@@ -4019,7 +4103,10 @@ public class ViewCompat {
      * @param view view for which to get the state.
      *
      * @return a bitmask representing the enabled scroll indicators
+     * @deprecated Call {@link View#getScrollIndicators()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getScrollIndicators()")
     public static int getScrollIndicators(@NonNull View view) {
         return view.getScrollIndicators();
     }
@@ -4047,7 +4134,7 @@ public class ViewCompat {
      * @return The logical display, or null if the view is not currently attached to a window.
      * @deprecated Call {@link View#getDisplay()} directly.
      */
-    @androidx.annotation.ReplaceWith(expression = "view.getDisplay()")
+    @ReplaceWith(expression = "view.getDisplay()")
     @Deprecated
     public static @Nullable Display getDisplay(@NonNull View view) {
         return view.getDisplay();
@@ -4275,6 +4362,7 @@ public class ViewCompat {
      * @deprecated Call {@link View#generateViewId()} directly.
      */
     @Deprecated
+    @ReplaceWith(expression = "View.generateViewId()")
     public static int generateViewId() {
         return View.generateViewId();
     }
@@ -5051,7 +5139,7 @@ public class ViewCompat {
                             // updated after the insets dispatch so we don't have the updated
                             // visible insets at that point. As a workaround, we re-apply the insets
                             // so we know that we'll have the right value the next time it's called.
-                            requestApplyInsets(view);
+                            view.requestApplyInsets();
                             // Keep a copy in case the insets haven't changed on the next call so we
                             // don't need to call the listener again.
 

--- a/core/core/src/main/java/androidx/core/view/ViewParentCompat.java
+++ b/core/core/src/main/java/androidx/core/view/ViewParentCompat.java
@@ -189,7 +189,7 @@ public final class ViewParentCompat {
      * nested scroll operation if appropriate.
      *
      * <p>This method will be called in response to a descendant view invoking
-     * {@link ViewCompat#startNestedScroll(View, int)}. Each parent up the view hierarchy will be
+     * {@link View#startNestedScroll(int)}. Each parent up the view hierarchy will be
      * given an opportunity to respond and claim the nested scrolling operation by returning
      * <code>true</code>.</p>
      *
@@ -358,7 +358,7 @@ public final class ViewParentCompat {
      * fully into view before the list itself begins scrolling.</p>
      *
      * <p><code>onNestedPreScroll</code> is called when a nested scrolling child invokes
-     * {@link ViewCompat#dispatchNestedPreScroll(View, int, int, int[], int[])}. The implementation
+     * {@link View#dispatchNestedPreScroll(int, int, int[], int[])}. The implementation
      * should report how any pixels of the scroll reported by dx, dy were consumed in the
      * <code>consumed</code> array. Index 0 corresponds to dx and index 1 corresponds to dy.
      * This parameter will never be null. Initial values for consumed[0] and consumed[1]

--- a/core/core/src/main/java/androidx/core/view/ViewStructureCompat.java
+++ b/core/core/src/main/java/androidx/core/view/ViewStructureCompat.java
@@ -25,7 +25,10 @@ import org.jspecify.annotations.NonNull;
  * <p>
  * Currently this helper class only has features for content capture usage. Other features for
  * Autofill are not available.
+ *
+ * @deprecated Use {@link ViewStructure} directly.
  */
+@Deprecated
 public class ViewStructureCompat {
 
     private final ViewStructure mWrappedObj;
@@ -35,7 +38,10 @@ public class ViewStructureCompat {
      *
      * @param contentCaptureSession platform class to wrap
      * @return wrapped class
+     *
+     * @deprecated This method is not needed anymore.
      */
+    @Deprecated
     public static @NonNull ViewStructureCompat toViewStructureCompat(
             @NonNull ViewStructure contentCaptureSession) {
         return new ViewStructureCompat(contentCaptureSession);
@@ -46,7 +52,10 @@ public class ViewStructureCompat {
      *
      * @return platform class object
      * @see ViewStructureCompat#toViewStructureCompat(ViewStructure)
+     *
+     * @deprecated This method is not needed anymore.
      */
+    @Deprecated
     public @NonNull ViewStructure toViewStructure() {
         return mWrappedObj;
     }
@@ -59,7 +68,10 @@ public class ViewStructureCompat {
      * Set the text that is associated with this view.  There is no selection
      * associated with the text.  The text may have style spans to supply additional
      * display and semantic information.
+     *
+     * @deprecated Call {@link ViewStructure#setText(CharSequence)} directly.
      */
+    @Deprecated
     public void setText(@NonNull CharSequence charSequence) {
         mWrappedObj.setText(charSequence);
     }
@@ -67,7 +79,10 @@ public class ViewStructureCompat {
     /**
      * Set the class name of the view, as per
      * {@link android.view.View#getAccessibilityClassName View.getAccessibilityClassName()}.
+     *
+     * @deprecated Call {@link ViewStructure#setClassName(String)} directly.
      */
+    @Deprecated
     public void setClassName(@NonNull String string) {
         mWrappedObj.setClassName(string);
     }
@@ -75,7 +90,10 @@ public class ViewStructureCompat {
     /**
      * Set the content description of the view, as per
      * {@link android.view.View#getContentDescription View.getContentDescription()}.
+     *
+     * @deprecated Call {@link ViewStructure#setContentDescription(CharSequence)} directly.
      */
+    @Deprecated
     public void setContentDescription(@NonNull CharSequence charSequence) {
         mWrappedObj.setContentDescription(charSequence);
     }
@@ -91,7 +109,10 @@ public class ViewStructureCompat {
      * not the total data width of a scrollable view.
      * @param height The view's visible height, in pixels.  This is the height visible on
      * screen, not the total data height of a scrollable view.
+     *
+     * @deprecated Call {@link ViewStructure#setDimens(int, int, int, int, int, int)} directly.
      */
+    @Deprecated
     public void setDimens(int left, int top, int scrollX, int scrollY, int width, int height) {
         mWrappedObj.setDimens(left, top, scrollX, scrollY, width, height);
     }

--- a/core/core/src/main/java/androidx/core/view/accessibility/AccessibilityEventCompat.java
+++ b/core/core/src/main/java/androidx/core/view/accessibility/AccessibilityEventCompat.java
@@ -110,7 +110,7 @@ public final class AccessibilityEventCompat {
      *     {@link android.app.Activity#setTitle(CharSequence)} and
      *     {@link androidx.core.view.ViewCompat#setAccessibilityPaneTitle(View, CharSequence)} )}.
      *     </li>
-     *     <li>Use {@link androidx.core.view.ViewCompat#setAccessibilityLiveRegion(View, int)}
+     *     <li>Use {@link View#setAccessibilityLiveRegion(int)}
      *     to inform the user of changes to critical views within the user interface. These
      *     should still be used sparingly as they may generate announcements every time a View is
      *     updated.</li>

--- a/core/core/src/main/java/androidx/core/view/accessibility/AccessibilityNodeInfoCompat.java
+++ b/core/core/src/main/java/androidx/core/view/accessibility/AccessibilityNodeInfoCompat.java
@@ -108,7 +108,7 @@ public class AccessibilityNodeInfoCompat {
      * </p>
      * <p class="note">
      * <strong>Note:</strong> Views which support these actions should invoke
-     * {@link ViewCompat#setImportantForAccessibility(View, int)} with
+     * {@link View#setImportantForAccessibility(int)} with
      * {@link ViewCompat#IMPORTANT_FOR_ACCESSIBILITY_YES} to ensure an
      * {@link android.accessibilityservice.AccessibilityService} can discover the set of supported
      * actions.
@@ -5082,7 +5082,7 @@ public class AccessibilityNodeInfoCompat {
      * @return The live region mode, or
      *         {@link ViewCompat#ACCESSIBILITY_LIVE_REGION_NONE} if the view is
      *         not a live region.
-     * @see ViewCompat#getAccessibilityLiveRegion(View)
+     * @see View#getAccessibilityLiveRegion()
      */
     public int getLiveRegion() {
         return mInfo.getLiveRegion();
@@ -5098,7 +5098,7 @@ public class AccessibilityNodeInfoCompat {
      * @param mode The live region mode, or
      *        {@link ViewCompat#ACCESSIBILITY_LIVE_REGION_NONE} if the view is
      *        not a live region.
-     * @see ViewCompat#setAccessibilityLiveRegion(View, int)
+     * @see View#setAccessibilityLiveRegion(int)
      */
     public void setLiveRegion(int mode) {
         mInfo.setLiveRegion(mode);
@@ -6422,7 +6422,7 @@ public class AccessibilityNodeInfoCompat {
      *
      * <p>
      * Testing or debugging tools should create this {@link AccessibilityNodeInfoCompat} node using
-     * {@link ViewCompat#onInitializeAccessibilityNodeInfo(View, AccessibilityNodeInfoCompat)}
+     * {@link View#onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo)}
      * or {@link AccessibilityNodeProviderCompat} and call this
      * method, then navigate and interact with the node tree by calling methods on the node.
      * Calling this method more than once on the same node is a no-op. After calling this method,

--- a/core/core/src/main/java/androidx/core/view/animation/PathInterpolatorCompat.java
+++ b/core/core/src/main/java/androidx/core/view/animation/PathInterpolatorCompat.java
@@ -20,12 +20,17 @@ import android.graphics.Path;
 import android.view.animation.Interpolator;
 import android.view.animation.PathInterpolator;
 
+import androidx.annotation.ReplaceWith;
+
 import org.jspecify.annotations.NonNull;
 
 /**
  * Helper for creating path-based {@link Interpolator} instances. The platform implementation will
  * be used.
+ *
+ * @deprecated Use {@link PathInterpolator} instead.
  */
+@Deprecated
 public final class PathInterpolatorCompat {
 
     private PathInterpolatorCompat() {
@@ -43,7 +48,14 @@ public final class PathInterpolatorCompat {
      *
      * @param path the {@link Path} to use to make the line representing the {@link Interpolator}
      * @return the {@link Interpolator} representing the {@link Path}
+     * @deprecated Call {@link PathInterpolator#PathInterpolator(Path) new PathInterpolator(Path)}
+     * directly.
      */
+    @Deprecated
+    @ReplaceWith(
+            expression = "new PathInterpolator(path)",
+            imports = "android.view.animation.PathInterpolator"
+    )
     public static @NonNull Interpolator create(@NonNull Path path) {
         return new PathInterpolator(path);
     }
@@ -55,7 +67,14 @@ public final class PathInterpolatorCompat {
      * @param controlX the x coordinate of the quadratic Bezier control point
      * @param controlY the y coordinate of the quadratic Bezier control point
      * @return the {@link Interpolator} representing the quadratic Bezier curve
+     * @deprecated Call {@link PathInterpolator#PathInterpolator(float, float) new
+     * PathInterpolator(float, float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(
+            expression = "new PathInterpolator(controlX, controlY)",
+            imports = "android.view.animation.PathInterpolator"
+    )
     public static @NonNull Interpolator create(float controlX, float controlY) {
         return new PathInterpolator(controlX, controlY);
     }
@@ -69,7 +88,14 @@ public final class PathInterpolatorCompat {
      * @param controlX2 the x coordinate of the second control point of the cubic Bezier
      * @param controlY2 the y coordinate of the second control point of the cubic Bezier
      * @return the {@link Interpolator} representing the cubic Bezier curve
+     * @deprecated Call {@link PathInterpolator#PathInterpolator(float, float, float, float)
+     * new PathInterpolator(float, float, float, float)} directly.
      */
+    @Deprecated
+    @ReplaceWith(
+            expression = "new PathInterpolator(controlX1, controlY1, controlX2, controlY2)",
+            imports = "android.view.animation.PathInterpolator"
+    )
     public static @NonNull Interpolator create(float controlX1, float controlY1,
             float controlX2, float controlY2) {
         return new PathInterpolator(controlX1, controlY1, controlX2, controlY2);

--- a/core/core/src/main/java/androidx/core/view/contentcapture/ContentCaptureSessionCompat.java
+++ b/core/core/src/main/java/androidx/core/view/contentcapture/ContentCaptureSessionCompat.java
@@ -126,7 +126,9 @@ public class ContentCaptureSessionCompat {
      * @param virtualId id of the virtual child, relative to the parent.
      *
      * @return a new {@link ViewStructure} that can be used for Content Capture purposes.
+     * @deprecated
      */
+    @Deprecated
     public @Nullable ViewStructureCompat newVirtualViewStructure(
             @NonNull AutofillId parentId, long virtualId) {
         if (SDK_INT >= 29) {

--- a/core/core/src/main/java/androidx/core/widget/AutoScrollHelper.java
+++ b/core/core/src/main/java/androidx/core/widget/AutoScrollHelper.java
@@ -26,8 +26,6 @@ import android.view.animation.AccelerateInterpolator;
 import android.view.animation.AnimationUtils;
 import android.view.animation.Interpolator;
 
-import androidx.core.view.ViewCompat;
-
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -511,7 +509,7 @@ public abstract class AutoScrollHelper implements View.OnTouchListener {
         mNeedsReset = true;
 
         if (!mAlreadyDelayed && mActivationDelay > 0) {
-            ViewCompat.postOnAnimationDelayed(mTarget, mRunnable, mActivationDelay);
+            mTarget.postOnAnimationDelayed(mRunnable, mActivationDelay);
         } else {
             mRunnable.run();
         }
@@ -716,7 +714,7 @@ public abstract class AutoScrollHelper implements View.OnTouchListener {
             scrollTargetBy(deltaX,  deltaY);
 
             // Keep going until the scroller has permanently stopped.
-            ViewCompat.postOnAnimation(mTarget, this);
+            mTarget.postOnAnimation(this);
         }
     }
 

--- a/core/core/src/main/java/androidx/core/widget/CheckedTextViewCompat.java
+++ b/core/core/src/main/java/androidx/core/widget/CheckedTextViewCompat.java
@@ -21,14 +21,17 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.widget.CheckedTextView;
 
-import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.annotation.ReplaceWith;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Helper for accessing {@link CheckedTextView}.
+ *
+ * @deprecated Use {@link CheckedTextView} directly.
  */
+@Deprecated
 public final class CheckedTextViewCompat {
 
     private CheckedTextViewCompat() {
@@ -40,12 +43,15 @@ public final class CheckedTextViewCompat {
      * <p>
      * Subsequent calls to {@link CheckedTextView#setCheckMarkDrawable(Drawable)} should
      * automatically mutate the drawable and apply the specified tint and tint
-     * mode using {@link DrawableCompat#setTintList(Drawable, ColorStateList)}.
+     * mode using {@link Drawable#setTintList(ColorStateList)}.
      *
      * @param textView CheckedTextView for which to apply the tint.
      * @param tint the tint to apply, may be {@code null} to clear tint
-     * @see #setCheckMarkTintList(CheckedTextView, ColorStateList)
+     * @see CheckedTextView#setCheckMarkTintList(ColorStateList)
+     * @deprecated Call {@link CheckedTextView#setCheckMarkTintList(ColorStateList)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "textView.setCheckMarkTintList(tint)")
     public static void setCheckMarkTintList(@NonNull CheckedTextView textView,
             @Nullable ColorStateList tint) {
         textView.setCheckMarkTintList(tint);
@@ -54,23 +60,29 @@ public final class CheckedTextViewCompat {
     /**
      * Returns the tint applied to the check mark drawable
      *
-     * @see #setCheckMarkTintList(CheckedTextView, ColorStateList)
+     * @see CheckedTextView#setCheckMarkTintList(ColorStateList)
+     * @deprecated Call {@link CheckedTextView#getCheckMarkTintList()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "textView.getCheckMarkTintList()")
     public static @Nullable ColorStateList getCheckMarkTintList(@NonNull CheckedTextView textView) {
         return textView.getCheckMarkTintList();
     }
 
     /**
      * Specifies the blending mode used to apply the tint specified by
-     * {@link #setCheckMarkTintList(CheckedTextView, ColorStateList)}} to the check mark drawable.
+     * {@link CheckedTextView#setCheckMarkTintList(ColorStateList)}} to the check mark drawable.
      * The default mode is {@link PorterDuff.Mode#SRC_IN}.
      *
      * @param textView CheckedTextView for which to apply the tint mode.
      * @param tintMode the blending mode used to apply the tint, may be
      *                 {@code null} to clear tint
-     * @see #getCheckMarkTintMode(CheckedTextView)
-     * @see DrawableCompat#setTintMode(Drawable, PorterDuff.Mode)
+     * @see CheckedTextView#getCheckMarkTintMode()
+     * @see Drawable#setTintMode(PorterDuff.Mode)
+     * @deprecated Call {@link CheckedTextView#setCheckMarkTintMode(PorterDuff.Mode)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "textView.setCheckMarkTintMode(tintMode)")
     public static void setCheckMarkTintMode(@NonNull CheckedTextView textView,
             PorterDuff.@Nullable Mode tintMode) {
         textView.setCheckMarkTintMode(tintMode);
@@ -79,8 +91,11 @@ public final class CheckedTextViewCompat {
     /**
      * @return the blending mode used to apply the tint to the check mark drawable
      * @attr name android:checkMarkTintMode
-     * @see #setCheckMarkTintMode(CheckedTextView, PorterDuff.Mode)
+     * @see CheckedTextView#setCheckMarkTintMode(PorterDuff.Mode)
+     * @deprecated Call {@link CheckedTextView#getCheckMarkTintMode()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "textView.getCheckMarkTintMode()")
     public static PorterDuff.@Nullable Mode getCheckMarkTintMode(
             @NonNull CheckedTextView textView) {
         return textView.getCheckMarkTintMode();
@@ -93,7 +108,7 @@ public final class CheckedTextViewCompat {
      * @deprecated Call {@link CheckedTextView#getCheckMarkDrawable()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.getCheckMarkDrawable()")
+    @ReplaceWith(expression = "textView.getCheckMarkDrawable()")
     public static @Nullable Drawable getCheckMarkDrawable(@NonNull CheckedTextView textView) {
         return textView.getCheckMarkDrawable();
     }

--- a/core/core/src/main/java/androidx/core/widget/CompoundButtonCompat.java
+++ b/core/core/src/main/java/androidx/core/widget/CompoundButtonCompat.java
@@ -21,14 +21,17 @@ import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.widget.CompoundButton;
 
-import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.annotation.ReplaceWith;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Helper for accessing {@link CompoundButton}.
+ *
+ * @deprecated Use {@link CompoundButton} directly.
  */
+@Deprecated
 public final class CompoundButtonCompat {
     private CompoundButtonCompat() {}
 
@@ -38,13 +41,15 @@ public final class CompoundButtonCompat {
      * <p>
      * Subsequent calls to {@link CompoundButton#setButtonDrawable(Drawable)} should
      * automatically mutate the drawable and apply the specified tint and tint
-     * mode using {@link DrawableCompat#setTintList(Drawable, ColorStateList)}.
+     * mode using {@link Drawable#setTintList(ColorStateList)}.
      *
      * @param button button for which to apply the tint.
      * @param tint the tint to apply, may be {@code null} to clear tint
-     *
-     * @see #setButtonTintList(CompoundButton, ColorStateList)
+     * @see CompoundButton#setButtonTintList(ColorStateList)
+     * @deprecated Call {@link CompoundButton#setButtonTintList(ColorStateList)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "button.setButtonTintList(tint)")
     public static void setButtonTintList(@NonNull CompoundButton button,
             @Nullable ColorStateList tint) {
         button.setButtonTintList(tint);
@@ -53,24 +58,29 @@ public final class CompoundButtonCompat {
     /**
      * Returns the tint applied to the button drawable
      *
-     * @see #setButtonTintList(CompoundButton, ColorStateList)
+     * @see CompoundButton#setButtonTintList(ColorStateList)
+     * @deprecated Call {@link CompoundButton#getButtonTintList()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "button.getButtonTintList()")
     public static @Nullable ColorStateList getButtonTintList(@NonNull CompoundButton button) {
         return button.getButtonTintList();
     }
 
     /**
      * Specifies the blending mode used to apply the tint specified by
-     * {@link #setButtonTintList(CompoundButton, ColorStateList)}} to the button drawable. The
+     * {@link CompoundButton#setButtonTintList(ColorStateList)}} to the button drawable. The
      * default mode is {@link PorterDuff.Mode#SRC_IN}.
      *
      * @param button button for which to apply the tint mode.
      * @param tintMode the blending mode used to apply the tint, may be
      *                 {@code null} to clear tint
-     *
-     * @see #getButtonTintMode(CompoundButton)
-     * @see DrawableCompat#setTintMode(Drawable, PorterDuff.Mode)
+     * @see CompoundButton#getButtonTintMode()
+     * @see Drawable#setTintMode(PorterDuff.Mode)
+     * @deprecated Call {@link CompoundButton#setButtonTintMode(PorterDuff.Mode)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "button.setButtonTintMode(tintMode)")
     public static void setButtonTintMode(@NonNull CompoundButton button,
             PorterDuff.@Nullable Mode tintMode) {
         button.setButtonTintMode(tintMode);
@@ -79,8 +89,11 @@ public final class CompoundButtonCompat {
     /**
      * @return the blending mode used to apply the tint to the button drawable
      * @attr name android:buttonTintMode
-     * @see #setButtonTintMode(CompoundButton, PorterDuff.Mode)
+     * @see CompoundButton#setButtonTintMode(PorterDuff.Mode)
+     * @deprecated Call {@link CompoundButton#getButtonTintMode()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "button.getButtonTintMode()")
     public static PorterDuff.@Nullable Mode getButtonTintMode(@NonNull CompoundButton button) {
         return button.getButtonTintMode();
     }
@@ -89,7 +102,10 @@ public final class CompoundButtonCompat {
      * Returns the drawable used as the compound button image
      *
      * @see CompoundButton#setButtonDrawable(Drawable)
+     * @deprecated Call {@link CompoundButton#getButtonDrawable()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "button.getButtonDrawable()")
     public static @Nullable Drawable getButtonDrawable(@NonNull CompoundButton button) {
         return button.getButtonDrawable();
     }

--- a/core/core/src/main/java/androidx/core/widget/ImageViewCompat.java
+++ b/core/core/src/main/java/androidx/core/widget/ImageViewCompat.java
@@ -20,23 +20,36 @@ import android.content.res.ColorStateList;
 import android.graphics.PorterDuff;
 import android.widget.ImageView;
 
+import androidx.annotation.ReplaceWith;
+
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
  * Helper for accessing features in {@link ImageView}.
+ *
+ * @deprecated Use {@link ImageView} directly.
  */
+@Deprecated
 public class ImageViewCompat {
     /**
      * Return the tint applied to the image drawable, if specified.
+     *
+     * @deprecated Call {@link ImageView#getImageTintList()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getImageTintList()")
     public static @Nullable ColorStateList getImageTintList(@NonNull ImageView view) {
         return view.getImageTintList();
     }
 
     /**
      * Applies a tint to the image drawable.
+     *
+     * @deprecated Call {@link ImageView#setImageTintList(ColorStateList)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setImageTintList(tintLint)")
     public static void setImageTintList(@NonNull ImageView view,
             @Nullable ColorStateList tintList) {
         view.setImageTintList(tintList);
@@ -44,16 +57,24 @@ public class ImageViewCompat {
 
     /**
      * Return the blending mode used to apply the tint to the image drawable, if specified.
+     *
+     * @deprecated Call {@link ImageView#getImageTintMode()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.getImageTintMode()")
     public static PorterDuff.@Nullable Mode getImageTintMode(@NonNull ImageView view) {
         return view.getImageTintMode();
     }
 
     /**
      * Specifies the blending mode used to apply the tint specified by
-     * {@link #setImageTintList(ImageView, ColorStateList)}
+     * {@link ImageView#setImageTintList(ColorStateList)}
      * to the image drawable. The default mode is {@link PorterDuff.Mode#SRC_IN}.
+     *
+     * @deprecated Call {@link ImageView#setImageTintMode(PorterDuff.Mode)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "view.setImageTintMode(mode)")
     public static void setImageTintMode(@NonNull ImageView view, PorterDuff.@Nullable Mode mode) {
         view.setImageTintMode(mode);
     }

--- a/core/core/src/main/java/androidx/core/widget/PopupWindowCompat.java
+++ b/core/core/src/main/java/androidx/core/widget/PopupWindowCompat.java
@@ -19,11 +19,16 @@ package androidx.core.widget;
 import android.view.View;
 import android.widget.PopupWindow;
 
+import androidx.annotation.ReplaceWith;
+
 import org.jspecify.annotations.NonNull;
 
 /**
  * Helper for accessing features in {@link PopupWindow}.
+ *
+ * @deprecated Use {@link android.view.Window} directly.
  */
+@Deprecated
 public final class PopupWindowCompat {
 
     private PopupWindowCompat() {
@@ -48,7 +53,7 @@ public final class PopupWindowCompat {
      * @deprecated Call {@link PopupWindow#showAsDropDown(View, int, int, int)} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "popup.showAsDropDown(anchor, xoff, yoff, gravity)")
+    @ReplaceWith(expression = "popup.showAsDropDown(anchor, xoff, yoff, gravity)")
     public static void showAsDropDown(@NonNull PopupWindow popup, @NonNull View anchor,
             int xoff, int yoff, int gravity) {
         popup.showAsDropDown(anchor, xoff, yoff, gravity);
@@ -60,7 +65,10 @@ public final class PopupWindowCompat {
      *
      * @param popupWindow popup window for which to set the anchor.
      * @param overlapAnchor Whether the popup should overlap its anchor.
+     * @deprecated Call {@link PopupWindow#setOverlapAnchor(boolean)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "popupWindow.setOverlapAnchor(overlapAnchor)")
     public static void setOverlapAnchor(@NonNull PopupWindow popupWindow, boolean overlapAnchor) {
         popupWindow.setOverlapAnchor(overlapAnchor);
     }
@@ -70,7 +78,10 @@ public final class PopupWindowCompat {
      * displayed as a drop-down.
      *
      * @return Whether the popup should overlap its anchor.
+     * @deprecated Call {@link PopupWindow#getOverlapAnchor()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "popupWindow.getOverlapAnchor()")
     public static boolean getOverlapAnchor(@NonNull PopupWindow popupWindow) {
         return popupWindow.getOverlapAnchor();
     }
@@ -82,9 +93,11 @@ public final class PopupWindowCompat {
      *
      * @param popupWindow popup window for which to set the layout type.
      * @param layoutType Layout type for this window.
-     *
      * @see android.view.WindowManager.LayoutParams#type
+     * @deprecated Call {@link PopupWindow#setWindowLayoutType(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "popupWindow.setWindowLayoutType(layoutType)")
     public static void setWindowLayoutType(@NonNull PopupWindow popupWindow, int layoutType) {
         popupWindow.setWindowLayoutType(layoutType);
     }
@@ -92,8 +105,11 @@ public final class PopupWindowCompat {
     /**
      * Returns the layout type for this window.
      *
-     * @see #setWindowLayoutType(PopupWindow popupWindow, int)
+     * @see PopupWindow#setWindowLayoutType(int)
+     * @deprecated Call {@link PopupWindow#getWindowLayoutType()} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "popupWindow.getWindowLayoutType()")
     public static int getWindowLayoutType(@NonNull PopupWindow popupWindow) {
         return popupWindow.getWindowLayoutType();
     }

--- a/core/core/src/main/java/androidx/core/widget/TextViewCompat.java
+++ b/core/core/src/main/java/androidx/core/widget/TextViewCompat.java
@@ -56,6 +56,7 @@ import androidx.annotation.FloatRange;
 import androidx.annotation.IntDef;
 import androidx.annotation.IntRange;
 import androidx.annotation.Px;
+import androidx.annotation.ReplaceWith;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.StyleRes;
@@ -120,7 +121,7 @@ public final class TextViewCompat {
      * directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.setCompoundDrawablesRelative(start, top, end, bottom)")
+    @ReplaceWith(expression = "textView.setCompoundDrawablesRelative(start, top, end, bottom)")
     public static void setCompoundDrawablesRelative(@NonNull TextView textView,
             @Nullable Drawable start, @Nullable Drawable top, @Nullable Drawable end,
             @Nullable Drawable bottom) {
@@ -150,7 +151,7 @@ public final class TextViewCompat {
      * } directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom)")
+    @ReplaceWith(expression = "textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom)")
     public static void setCompoundDrawablesRelativeWithIntrinsicBounds(@NonNull TextView textView,
             @Nullable Drawable start, @Nullable Drawable top, @Nullable Drawable end,
             @Nullable Drawable bottom) {
@@ -179,7 +180,7 @@ public final class TextViewCompat {
      * } directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom)")
+    @ReplaceWith(expression = "textView.setCompoundDrawablesRelativeWithIntrinsicBounds(start, top, end, bottom)")
     public static void setCompoundDrawablesRelativeWithIntrinsicBounds(@NonNull TextView textView,
             @DrawableRes int start, @DrawableRes int top, @DrawableRes int end,
             @DrawableRes int bottom) {
@@ -192,7 +193,7 @@ public final class TextViewCompat {
      * @deprecated Call {@link TextView#getMaxLines()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.getMaxLines()")
+    @ReplaceWith(expression = "textView.getMaxLines()")
     public static int getMaxLines(@NonNull TextView textView) {
         return textView.getMaxLines();
     }
@@ -203,7 +204,7 @@ public final class TextViewCompat {
      * @deprecated Call {@link TextView#getMinLines()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.getMinLines()")
+    @ReplaceWith(expression = "textView.getMinLines()")
     public static int getMinLines(@NonNull TextView textView) {
         return textView.getMinLines();
     }
@@ -216,7 +217,10 @@ public final class TextViewCompat {
      *
      * @param textView The TextView against which to invoke the method.
      * @param resId    The resource identifier of the style to apply.
+     * @deprecated Call {@link TextView#setTextAppearance(int)} directly.
      */
+    @Deprecated
+    @ReplaceWith(expression = "textView.setTextAppearance(resId)")
     public static void setTextAppearance(@NonNull TextView textView, @StyleRes int resId) {
         textView.setTextAppearance(resId);
     }
@@ -226,7 +230,7 @@ public final class TextViewCompat {
      * @deprecated Call {@link TextView#getCompoundDrawablesRelative()} directly.
      */
     @Deprecated
-    @androidx.annotation.ReplaceWith(expression = "textView.getCompoundDrawablesRelative()")
+    @ReplaceWith(expression = "textView.getCompoundDrawablesRelative()")
     public static Drawable @NonNull [] getCompoundDrawablesRelative(@NonNull TextView textView) {
         return textView.getCompoundDrawablesRelative();
     }

--- a/core/core/src/main/java/androidx/core/widget/TintableCheckedTextView.java
+++ b/core/core/src/main/java/androidx/core/widget/TintableCheckedTextView.java
@@ -68,8 +68,7 @@ public interface TintableCheckedTextView {
      *                 {@code null} to clear tint
      *
      * @see #getSupportCheckMarkTintMode()
-     * @see androidx.core.graphics.drawable.DrawableCompat#setTintMode(Drawable,
-     * PorterDuff.Mode)
+     * @see Drawable#setTintMode(PorterDuff.Mode)
      */
     void setSupportCheckMarkTintMode(PorterDuff.@Nullable Mode tintMode);
 

--- a/core/core/src/main/java/androidx/core/widget/TintableCompoundButton.java
+++ b/core/core/src/main/java/androidx/core/widget/TintableCompoundButton.java
@@ -61,8 +61,7 @@ public interface TintableCompoundButton {
      *                 {@code null} to clear tint
      *
      * @see #getSupportButtonTintMode()
-     * @see androidx.core.graphics.drawable.DrawableCompat#setTintMode(Drawable,
-     * PorterDuff.Mode)
+     * @see Drawable#setTintMode(PorterDuff.Mode)
      */
     void setSupportButtonTintMode(PorterDuff.@Nullable Mode tintMode);
 


### PR DESCRIPTION
## Proposed Changes

  - Deprecate proxy compat methods that simply call to the framework implementation.
  - Replace usages of the deprecated methods.
  - Add missing `@ReplaceWith` annotation.
  - Run `./gradlew updateApi`.

> [!NOTE]
> This PR focuses only on the files impacted by #793 and #795.

## Testing

Test: GitHub CI