### PR TITLE
Stable AIDL: Support android.aidlPackagedList & allow no imports on API 36+

### DIFF
--- a/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
+++ b/buildSrc/public/src/main/kotlin/androidx/build/SdkResourceGenerator.kt
@@ -61,7 +61,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
 
     @get:Input
     val rootProjectRelativePath: String =
-        project.rootProject.rootDir.toRelativeString(project.projectDir)
+        project.rootProject.rootDir.relativeTo(project.projectDir).invariantSeparatorsPath
 
     @get:Input
     @get:Optional
@@ -69,7 +69,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
         if (ProjectLayoutType.isPlayground(project)) {
             null
         } else {
-            project.getPrebuiltsRoot().toRelativeString(project.projectDir)
+            project.getPrebuiltsRoot().relativeTo(project.projectDir).invariantSeparatorsPath
         }
 
     @get:Input
@@ -78,7 +78,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
         if (ProjectLayoutType.isPlayground(project)) {
             null
         } else {
-            project.getGradlePrebuiltsPath().toRelativeString(project.projectDir)
+            project.getGradlePrebuiltsPath().relativeTo(project.projectDir).invariantSeparatorsPath
         }
 
     private val projectDir: File = project.projectDir
@@ -94,7 +94,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
             writer.write("tipOfTreeMavenRepoRelativePath=$tipOfTreeMavenRepoRelativePath\n")
             writer.write(
                 "debugKeystoreRelativePath=${
-                    debugKeystore.get().asFile.toRelativeString(projectDir)
+                    debugKeystore.get().asFile.relativeTo(projectDir).invariantSeparatorsPath
                 }\n"
             )
             writer.write("rootProjectRelativePath=$rootProjectRelativePath\n")
@@ -109,7 +109,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
             writer.write("kgpVersion=${kgpVersion.get()}\n")
             writer.write("kspVersion=${kspVersion.get()}\n")
             if (prebuiltsRelativePath != null) {
-                writer.write("prebuiltsRelativePath=$prebuiltsRelativePath\n")
+                writer.write("prebuiltsRelativePath=${prebuiltsRelativePath.replace("""\""", """\\""")}\n")
             }
             if (gradlePrebuiltsRelativePath != null) {
                 writer.write("gradlePrebuiltsRelativePath=$gradlePrebuiltsRelativePath\n")
@@ -138,7 +138,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
             val generatedDirectory = project.layout.buildDirectory.dir("generated/resources")
             return project.tasks.register(TASK_NAME, SdkResourceGenerator::class.java) {
                 it.tipOfTreeMavenRepoRelativePath =
-                    project.getRepositoryDirectory().toRelativeString(project.projectDir)
+                    project.getRepositoryDirectory().relativeTo(project.projectDir).invariantSeparatorsPath
                 it.debugKeystore.set(project.getKeystore())
                 it.outputDir.set(generatedDirectory)
                 it.buildToolsVersion.set(
@@ -160,7 +160,7 @@ abstract class SdkResourceGenerator : DefaultTask() {
                     project.repositories.filterIsInstance<MavenArtifactRepository>().map { repo ->
                         if (repo.url.scheme == "file") {
                             // Make file paths relative to projectDir
-                            File(repo.url.path).toRelativeString(project.projectDir)
+                            File(repo.url.path).relativeTo(project.projectDir).invariantSeparatorsPath
                         } else {
                             repo.url.toString()
                         }

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/StableAidlPlugin.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/StableAidlPlugin.kt
@@ -21,6 +21,7 @@ package androidx.stableaidl
 import androidx.stableaidl.api.StableAidlExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.dsl.SdkComponents
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.DslExtension
@@ -63,6 +64,7 @@ abstract class StableAidlPlugin : Plugin<Project> {
     // Suppress UnstableApiUsage for SdkComponents.getAidl(), Aidl, and DSL extension methods
     @Suppress("UnstableApiUsage")
     private fun applyToAndroidAfterAgp(project: Project, extension: StableAidlExtensionImpl) {
+        val android = project.extensions.getByType(CommonExtension::class.java)
         val androidComponents =
             project.extensions.findByType(AndroidComponentsExtension::class.java)
                 ?: throw GradleException("Stable AIDL plugin requires Android Gradle Plugin")
@@ -93,6 +95,7 @@ abstract class StableAidlPlugin : Plugin<Project> {
             val outputDir = project.layout.buildDirectory.dir("$GENERATED_PATH/${variant.name}")
             val packagedDir =
                 project.layout.buildDirectory.dir("$INTERMEDIATES_PATH/${variant.name}/out")
+            val packagedList = (android as? LibraryExtension)?.aidlPackagedList
 
             val apiDirName = "$API_DIR/aidl${variant.name.usLocaleCapitalize()}"
             val builtApiDir = project.layout.buildDirectory.dir(apiDirName)
@@ -137,6 +140,7 @@ abstract class StableAidlPlugin : Plugin<Project> {
                     aidlVersion,
                     sourceDir,
                     packagedDir,
+                    packagedList,
                     importsDir,
                     depImports,
                     outputDir,

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/StableAidlTasks.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/StableAidlTasks.kt
@@ -74,6 +74,7 @@ fun registerCompileAidlApi(
     aidlVersion: Provider<String>,
     sourceDir: SourceDirectories.Flat,
     packagedDir: Provider<Directory>,
+    packagedList: Collection<String>?,
     importsDir: SourceDirectories.Flat,
     depImports: List<FileCollection>,
     outputDir: Provider<Directory>,
@@ -91,6 +92,7 @@ fun registerCompileAidlApi(
             task.sourceDirs.set(sourceDir.all)
             task.sourceOutputDir.set(outputDir)
             task.packagedDir.set(packagedDir)
+            task.packagedList.set(packagedList)
             task.importDirs.addAll(importsDir.all)
             task.shadowFrameworkDir.set(shadowFramework)
             depImports.forEach { task.dependencyImportDirs.addAll(it.elements) }

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCheckApi.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCheckApi.kt
@@ -54,6 +54,7 @@ abstract class StableAidlCheckApi : DefaultTask() {
     @get:Internal abstract var variantName: String
 
     /** List of directories containing AIDL sources available as imports. */
+    @get:Optional
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val importDirs: ListProperty<Directory>
@@ -118,7 +119,8 @@ abstract class StableAidlCheckApi : DefaultTask() {
             return
         }
 
-        val projectImportList = importDirs.get().plusNotNull(shadowFrameworkDir.orNull)
+        val projectImportList = importDirs.getOrElse(mutableListOf())
+            .plusNotNull(shadowFrameworkDir.orNull)
 
         aidlCheckApiDelegate(
             workerExecutor,

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCompile.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCompile.kt
@@ -71,6 +71,7 @@ abstract class StableAidlCompile : DefaultTask() {
     abstract val sourceDirs: ListProperty<Directory>
 
     /** List of directories containing AIDL sources available as imports. */
+    @get:Optional
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val importDirs: ListProperty<Directory>
@@ -138,8 +139,9 @@ abstract class StableAidlCompile : DefaultTask() {
             FileUtils.cleanOutputDir(parcelableDir.asFile)
         }
 
-        val projectImportList =
-            sourceDirs.get().plus(importDirs.get()).plusNotNull(shadowFrameworkDir.orNull)
+        val projectImportList = sourceDirs.get()
+            .plus(importDirs.getOrElse(mutableListOf()))
+            .plusNotNull(shadowFrameworkDir.orNull)
         val sourceDirsAsFiles = sourceDirs.get().map { it.asFile }
 
         // When using AIDL from build tools version 33 and later, pass the variant's minimum SDK

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCompile.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlCompile.kt
@@ -61,6 +61,10 @@ abstract class StableAidlCompile : DefaultTask() {
 
     @get:Internal abstract var variantName: String
 
+    @get:Input
+    @get:Optional
+    abstract val packagedList: SetProperty<String>
+
     /** List of directories containing AIDL sources to be compiled. */
     @get:InputFiles
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -154,6 +158,7 @@ abstract class StableAidlCompile : DefaultTask() {
             aidlFrameworkProvider.orNull?.asFile,
             destinationDir,
             parcelableDir?.asFile,
+            packagedList.orNull,
             extraArgsWithSdk,
             sourceDirsAsFiles,
             projectImportList,
@@ -171,6 +176,7 @@ abstract class StableAidlCompile : DefaultTask() {
             abstract val importFolders: ConfigurableFileCollection
             abstract val sourceOutputDir: DirectoryProperty
             abstract val packagedOutputDir: DirectoryProperty
+            abstract val packagedList: SetProperty<String>
             abstract val dir: RegularFileProperty
             abstract val extraArgs: ListProperty<String>
         }
@@ -214,6 +220,7 @@ abstract class StableAidlCompile : DefaultTask() {
                     logger,
                     parameters.sourceOutputDir.get().asFile,
                     parameters.packagedOutputDir.orNull?.asFile,
+                    parameters.packagedList.orNull,
                     depFileProcessor,
                     request.root.toPath(),
                     request.file.toPath(),
@@ -230,6 +237,7 @@ abstract class StableAidlCompile : DefaultTask() {
             frameworkLocation: File?,
             destinationDir: File,
             parcelableDir: File?,
+            packagedList: Collection<String>?,
             extraArgs: List<String>,
             sourceFolders: Collection<File>,
             projectImportList: Collection<Directory>,
@@ -242,6 +250,7 @@ abstract class StableAidlCompile : DefaultTask() {
                     it.importFolders.from(projectImportList, dependencyImportList)
                     it.sourceOutputDir.set(destinationDir)
                     it.packagedOutputDir.set(parcelableDir)
+                    it.packagedList.set(packagedList)
                     it.extraArgs.set(extraArgs)
                     it.dir.set(dir)
                 }

--- a/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlProcessor.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/main/java/androidx/stableaidl/tasks/StableAidlProcessor.kt
@@ -39,10 +39,13 @@ fun callStableAidlProcessor(
     processOutputHandler: ProcessOutputHandler,
     sourceOutputDir: File? = null,
     packagedOutputDir: File? = null,
+    packagedList: Collection<String>? = null,
     dependencyFileProcessor: DependencyFileProcessor? = null,
     startDir: Path? = null,
     inputFilePath: Path? = null,
 ) {
+    val nonNullPackagedList = packagedList?.toSet() ?: emptySet()
+
     val builder = ProcessInfoBuilder()
     builder.setExecutable(aidlExecutable)
 
@@ -113,7 +116,8 @@ fun callStableAidlProcessor(
             }
         }
         if (inputFilePath != null && relativeInputFile != null) {
-            if (packagedOutputDir != null && isParcelable) {
+            val isPackaged = relativeInputFile in nonNullPackagedList
+            if (packagedOutputDir != null && isParcelable || isPackaged) {
                 // looks like a parcelable or is listed for packaging
                 // Store it in the secondary output of the DependencyData object.
                 val destFile = File(packagedOutputDir, relativeInputFile)

--- a/stableaidl/stableaidl-gradle-plugin/src/test/java/androidx/stableaidl/tasks/StableAidlCompileTest.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/test/java/androidx/stableaidl/tasks/StableAidlCompileTest.kt
@@ -77,6 +77,7 @@ class StableAidlCompileTest {
             fakeFramework,
             outputDir,
             null,
+            null,
             listOf("-x"),
             listOf(sourceFolder),
             listOf(),

--- a/stableaidl/stableaidl-gradle-plugin/src/test/java/androidx/stableaidl/tasks/StableAidlPackagedListTest.kt
+++ b/stableaidl/stableaidl-gradle-plugin/src/test/java/androidx/stableaidl/tasks/StableAidlPackagedListTest.kt
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2023 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.stableaidl.tasks
+
+import androidx.testutils.gradle.ProjectSetupRule
+import java.io.File
+import java.util.zip.ZipFile
+import kotlin.test.assertContains
+import kotlin.test.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class StableAidlPackagedListTest {
+    @get:Rule
+    val projectSetup = ProjectSetupRule()
+    private lateinit var gradleRunner: GradleRunner
+
+    @Before
+    fun setUp() {
+        gradleRunner =
+            GradleRunner.create().withProjectDir(projectSetup.rootDir).withPluginClasspath()
+    }
+
+    @Test
+    fun api_36() {
+        projectSetup.writeDefaultBuildGradle(
+            prefix =
+                """
+                plugins {
+                    id('com.android.library')
+                    id('androidx.stableaidl')
+                }
+            """
+                    .trimIndent(),
+            suffix =
+                """
+            android {
+                compileSdk 36
+                namespace 'androidx.stableaidl.testapp'
+                buildFeatures {
+                  aidl = true
+                }
+                buildTypes.all {
+                  stableAidl {
+                    version 1
+                  }
+                }
+                aidlPackagedList += 'android/os/IMyService.aidl'
+            }
+            """
+                    .trimIndent()
+        )
+
+        val myServiceAidlFile =
+            createFile("src/main/stableAidl/android/os/IMyService.aidl", projectSetup.rootDir)
+        myServiceAidlFile.writeText(
+            """
+            package android.os;
+            
+            import android.os.Bundle;
+            
+            interface IMyService {
+                Bundle getBundle() = 0;
+            }
+        """
+                .trimIndent()
+        )
+
+        gradleRunner
+            .withArguments(
+                "assembleRelease",
+                "--stacktrace",
+                "-Pstableaidl.compilesdk=36",
+            )
+            .build()
+
+        val aarFile = File(projectSetup.rootDir, "build/outputs/aar").listFiles().single()
+        ZipFile(aarFile).use { zip ->
+            val zipEntryNames = zip.getEntryNames()
+            assertContains(zipEntryNames, "aidl/android/os/IMyService.aidl")
+        }
+    }
+
+    @Test
+    fun pre_api_36_with_shadowFrameworkDir() {
+        projectSetup.writeDefaultBuildGradle(
+            prefix =
+                """
+                plugins {
+                    id('com.android.library')
+                    id('androidx.stableaidl')
+                }
+            """
+                    .trimIndent(),
+            suffix =
+                """
+            android {
+                compileSdk 35
+                namespace 'androidx.stableaidl.testapp'
+                buildFeatures {
+                  aidl = true
+                }
+                buildTypes.all {
+                  stableAidl {
+                    version 1
+                  }
+                }
+                aidlPackagedList += 'android/os/IMyService.aidl'
+            }
+            stableAidl {
+                shadowFrameworkDir = file("${
+                    File(
+                        projectSetup.props.rootProjectPath,
+                        "../../buildSrc/stableAidlImports"
+                    ).invariantSeparatorsPath
+                }")
+            }
+            """
+                    .trimIndent()
+        )
+
+        val myServiceAidlFile =
+            createFile("src/main/stableAidl/android/os/IMyService.aidl", projectSetup.rootDir)
+        myServiceAidlFile.writeText(
+            """
+            package android.os;
+            
+            import android.os.Bundle;
+            
+            interface IMyService {
+                Bundle getBundle() = 0;
+            }
+        """
+                .trimIndent()
+        )
+
+        gradleRunner
+            .withArguments(
+                "assembleRelease",
+                "--stacktrace",
+                "-Pstableaidl.compilesdk=35",
+            )
+            .build()
+
+        val aarFile = File(projectSetup.rootDir, "build/outputs/aar").listFiles().single()
+        ZipFile(aarFile).use { zip ->
+            val zipEntryNames = zip.getEntryNames()
+            assertContains(zipEntryNames, "aidl/android/os/IMyService.aidl")
+        }
+    }
+
+    @Test
+    fun pre_api_36_without_shadowFrameworkDir_with_framework_classes() {
+        projectSetup.writeDefaultBuildGradle(
+            prefix =
+                """
+                plugins {
+                    id('com.android.library')
+                    id('androidx.stableaidl')
+                }
+            """
+                    .trimIndent(),
+            suffix =
+                """
+            android {
+                compileSdk 35
+                namespace 'androidx.stableaidl.testapp'
+                buildFeatures {
+                  aidl = true
+                }
+                buildTypes.all {
+                  stableAidl {
+                    version 1
+                  }
+                }
+                aidlPackagedList += 'android/os/IMyService.aidl'
+            }
+            """
+                    .trimIndent()
+        )
+
+        val myServiceAidlFile =
+            createFile("src/main/stableAidl/android/os/IMyService.aidl", projectSetup.rootDir)
+        myServiceAidlFile.writeText(
+            """
+            package android.os;
+            
+            import android.os.Bundle;
+            
+            interface IMyService {
+                Bundle getBundle() = 0;
+            }
+        """
+                .trimIndent()
+        )
+
+        val output = gradleRunner
+            .withArguments(
+                "assembleRelease",
+                "--stacktrace",
+                "-Pstableaidl.compilesdk=35",
+            )
+            .buildAndFail()
+        assertTrue { output.output.contains("Couldn't find import for class android.os.Bundle.") }
+    }
+
+    @Test
+    fun pre_api_36_without_shadowFrameworkDir_without_framework_classes() {
+        projectSetup.writeDefaultBuildGradle(
+            prefix =
+                """
+                plugins {
+                    id('com.android.library')
+                    id('androidx.stableaidl')
+                }
+            """
+                    .trimIndent(),
+            suffix =
+                """
+            android {
+                compileSdk 35
+                namespace 'androidx.stableaidl.testapp'
+                buildFeatures {
+                  aidl = true
+                }
+                buildTypes.all {
+                  stableAidl {
+                    version 1
+                  }
+                }
+                aidlPackagedList += 'android/os/IMyService.aidl'
+            }
+            """
+                    .trimIndent()
+        )
+
+        val myServiceAidlFile =
+            createFile("src/main/stableAidl/android/os/IMyService.aidl", projectSetup.rootDir)
+        myServiceAidlFile.writeText(
+            """
+            package android.os;
+            
+            interface IMyService {
+            }
+        """
+                .trimIndent()
+        )
+
+        gradleRunner
+            .withArguments(
+                "assembleRelease",
+                "--stacktrace",
+                "-Pstableaidl.compilesdk=35",
+            )
+            .build()
+    }
+}

--- a/testutils/testutils-gradle-plugin/src/main/java/androidx/testutils/gradle/ProjectSetupRule.kt
+++ b/testutils/testutils-gradle-plugin/src/main/java/androidx/testutils/gradle/ProjectSetupRule.kt
@@ -235,7 +235,7 @@ data class ProjectProps(
 ) {
     companion object {
         private fun Properties.getCanonicalPath(key: String): String {
-            return File(getProperty(key)).canonicalPath
+            return File(getProperty(key)).canonicalFile.invariantSeparatorsPath
         }
 
         private fun Properties.getOptionalCanonicalPath(key: String): String? {


### PR DESCRIPTION
## Proposed Changes

  - Support `android.aidlPackagedList`
  - Fix building without any stable AIDL imports on API 36+
  - Make `SdkResourceGenerator` more compatible with Windows

## Testing

Test: ` .\gradlew stableaidl:stableaidl-gradle-plugin:test`

## Issues Fixed

N/A