### PR TITLE
Adapt build scan publication message parsing

### DIFF
--- a/development/build_log_simplifier/message-flakes.ignore
+++ b/development/build_log_simplifier/message-flakes.ignore
@@ -142,7 +142,7 @@ Could not read index from network cache: null
 Using custom version .* of AGP due to GRADLE_PLUGIN_VERSION being set\.
 Using custom version .* of Lint due to LINT_VERSION being set\.
 Using custom version .* of metalava due to METALAVA_VERSION being set\.
-Publishing Build Scan\.\.\.
+Publishing Build Scan to Develocity\.\.\.
 https://ge\.androidx\.dev/s/.*
 # androidx-demos:compileReleaseJavaWithJavac
 Note: \$SUPPORT/samples/AndroidXDemos/src/main/java/com/example/androidx/util/DiffUtilActivity\.java uses unchecked or unsafe operations\.

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         // upgrade protobuf to be compatible with AGP
         classpath("com.google.protobuf:protobuf-java:3.25.5")
-        classpath("com.gradle:develocity-gradle-plugin:4.1")
+        classpath("com.gradle:develocity-gradle-plugin:4.2")
         classpath("com.gradle:common-custom-user-data-gradle-plugin:2.3")
         classpath("androidx.build.gradle.gcpbuildcache:gcpbuildcache:1.0.0")
         classpath("com.google.cloud:google-cloud-secretmanager:2.67.0")


### PR DESCRIPTION
## Proposed Changes
The upcoming Develocity Gradle Plugin version 4.2 will output a slightly different Build Scan publication log message: `Publishing Build Scan to Develocity...` instead of `Publishing Build Scan...`

This PRs updates the message in the ignore list.

As the version is not out yet, the PR is created as a draft. 

## Testing
