### PR TITLE
compose/ui-graphics: Fix NPE when creating ImageBitmap from invalid ByteArray

### DIFF
--- a/compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/AndroidImageBitmap.android.kt
+++ b/compose/ui/ui-graphics/src/androidMain/kotlin/androidx/compose/ui/graphics/AndroidImageBitmap.android.kt
@@ -31,7 +31,9 @@ import androidx.compose.ui.graphics.colorspace.ColorSpaces
 fun Bitmap.asImageBitmap(): ImageBitmap = AndroidImageBitmap(this)
 
 internal actual fun createImageBitmap(bytes: ByteArray): ImageBitmap {
-    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size).asImageBitmap()
+    val bitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    require(bitmap != null) { "Failed to decode ImageBitmap from ByteArray: invalid or unsupported format" }
+    return bitmap.asImageBitmap()
 }
 
 internal actual fun ActualImageBitmap(


### PR DESCRIPTION
## Proposed Changes

Previously, `createImageBitmap` would pass null to the `AndroidImageBitmap` constructor if `BitmapFactory.decodeByteArray` returned null, leading to a NullPointerException later.

This change makes `createImageBitmap` throw an `IllegalArgumentException` immediately at the call site with a clear message:
"Failed to decode ImageBitmap from ByteArray: invalid or unsupported format"

According to the `BitmapFactory.decodeByteArray` documentation:
> Returns: The decoded bitmap, or null if the image could not be decoded.

So when it returns null, the input ByteArray is invalid or unsupported.

## Testing

Test: Tested manually.

```kotlin
fun doSmth(imageBitmap: ImageBitmap) {
    println(imageBitmap.height) // Previously: NullPointerException here
}

// Previously: No exception here
// Now: IllegalArgumentException here
val imageBitmap = ByteArray(0).decodeToImageBitmap()

doSmth(imageBitmap)
```