### PR TITLE
Change code examples in Room errors from Java to Kotlin

### DIFF
--- a/room3/room3-compiler/src/main/kotlin/androidx/room3/processor/ProcessorErrors.kt
+++ b/room3/room3-compiler/src/main/kotlin/androidx/room3/processor/ProcessorErrors.kt
@@ -1072,7 +1072,7 @@ object ProcessorErrors {
             or @DeleteColumn annotation to specify the change to be performed:
             1) RENAME:
                 @RenameColumn.Entries(
-                    @RenameColumn(
+                    RenameColumn(
                         tableName = "$tableName",
                         fromColumnName = "$columnName",
                         toColumnName = <NEW_COLUMN_NAME>
@@ -1080,7 +1080,7 @@ object ProcessorErrors {
                 )
             2) DELETE:
                 @DeleteColumn.Entries(
-                    @DeleteColumn(
+                    DeleteColumn(
                         tableName = "$tableName",
                         columnName = "$columnName"
                     )
@@ -1093,7 +1093,7 @@ object ProcessorErrors {
             change to be performed:
             1) RENAME:
                 @RenameColumn.Entries(
-                    @RenameColumn(
+                    RenameColumn(
                         tableName = "$tableName",
                         fromColumnName = "$columnName",
                         toColumnName = <NEW_COLUMN_NAME>
@@ -1101,7 +1101,7 @@ object ProcessorErrors {
                 )
             2) DELETE:
                 @DeleteColumn.Entries(
-                    @DeleteColumn(
+                    DeleteColumn(
                         tableName = "$tableName",
                         columnName = "$columnName"
                     )
@@ -1118,14 +1118,14 @@ object ProcessorErrors {
             annotation to specify the change to be performed:
             1) RENAME:
                 @RenameTable.Entries(
-                    @RenameTable(
+                    RenameTable(
                         fromTableName = "$tableName",
                         toTableName = <NEW_TABLE_NAME>
                     )
                 )
             2) DELETE:
                 @DeleteTable.Entries(
-                    @DeleteTable(
+                    DeleteTable(
                         tableName = "$tableName"
                     )
                 )
@@ -1137,14 +1137,14 @@ object ProcessorErrors {
             to be performed:
             1) RENAME:
                 @RenameTable.Entries(
-                    @RenameTable(
+                    RenameTable(
                         fromTableName = "$tableName",
                         toTableName = <NEW_TABLE_NAME>
                     )
                 )
             2) DELETE:
                 @DeleteTable.Entries(
-                    @DeleteTable(
+                    DeleteTable(
                         tableName = "$tableName"
                     )
                 )


### PR DESCRIPTION
## Proposed Changes
When I got this error from Room it confused me as I copied it into my project, but it didn't compile. It took me a minute to realise that the code in the error is for Java and not Kotlin. Considering the state of Kotlin usage on Android (and that Room is also available for KMP) I think it makes more sense for these example snippets to be in Kotlin

Valid Kotlin code
```kotlin
@RenameTable.Entries(
    RenameTable(fromTableName = "...", toTableName = "...")
)
@DeleteTable.Entries(
    DeleteTable(tableName = "...")
)
@RenameColumn.Entries(
    RenameColumn(tableName = "...", fromColumnName = "...", toColumnName = "...")
)
class KotlinMigration : AutoMigrationSpec
```

Valid Java code
```java
@RenameTable.Entries(
        @RenameTable(fromTableName = "...", toTableName = "...")
)
@DeleteTable.Entries(
        @DeleteTable(tableName = "...")
)
@RenameColumn.Entries(
        @RenameColumn(tableName = "...", fromColumnName = "...", toColumnName = "...")
)
public class JavaMigration implements AutoMigrationSpec {
}
```

## Testing

This PR is just updating documentation