### PR TITLE
docs: fix typo in OffsetMapping documentation (cusrsor → cursor)

### DIFF
--- a/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/OffsetMapping.kt
+++ b/compose/ui/ui-text/src/commonMain/kotlin/androidx/compose/ui/text/input/OffsetMapping.kt
@@ -34,7 +34,7 @@ interface OffsetMapping {
      * Convert offset in transformed text into the offset in original text.
      *
      * This function must be a monotonically non-decreasing function. In other words, if a cursor
-     * advances in the transformed text, the cusrsor in the original text must advance or stay
+     * advances in the transformed text, the cursor in the original text must advance or stay
      * there.
      *
      * @param offset offset in transformed text


### PR DESCRIPTION
## Proposed Changes
• Fix typo in OffsetMapping documentation
• Change “cusrsor” → “cursor” in transformedToOriginal KDoc

## Testing

Test: Describe how you tested your changes. Note that this line (with `Test:`) is required, your PR will not build without it!

## Issues Fixed

Fixes: [Optional] The bug on [https://issuetracker.google.com](https://issuetracker.google.com) being fixed
