### PR TITLE
fragment-ktx: fix grammar in createViewModelLazy KDoc

### DIFF
--- a/fragment/fragment-ktx/src/main/java/androidx/fragment/app/FragmentViewModelLazy.kt
+++ b/fragment/fragment-ktx/src/main/java/androidx/fragment/app/FragmentViewModelLazy.kt
@@ -209,10 +209,10 @@ public fun <VM : ViewModel> Fragment.createViewModelLazy(
 
 /**
  * Helper method for creation of [ViewModelLazy], that resolves `null` passed as [factoryProducer]
- * to default factory.
+ * to the default factory.
  *
- * This method also takes an [CreationExtras] produces that provides default extras to the created
- * view model.
+ * This method also takes a [CreationExtras] producer that provides default extras to the created
+ * [ViewModel].
  */
 @MainThread
 public fun <VM : ViewModel> Fragment.createViewModelLazy(


### PR DESCRIPTION
## Proposed Changes

- Fixed grammar in `createViewModelLazy` KDoc:
  - Changed "an [CreationExtras] produces … view model" → "a [CreationExtras] producer … [ViewModel]"

## Testing

Test: Built `:fragment:fragment-ktx` module successfully.  
Docs-only change, no runtime behavior affected.

## Issues Fixed

N/A – docs-only cleanup
