### PR TITLE
Fix SheetState Restoration for skipPartiallyExpanded

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SheetDefaults.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/SheetDefaults.kt
@@ -303,11 +303,17 @@ class SheetState(
             Saver<SheetState, SheetValue>(
                 save = { it.currentValue },
                 restore = { savedValue ->
+                    val newValue = if (skipPartiallyExpanded &&
+                        savedValue == PartiallyExpanded) {
+                        Expanded
+                    } else {
+                        savedValue
+                    }
                     SheetState(
                         skipPartiallyExpanded,
                         positionalThreshold,
                         velocityThreshold,
-                        savedValue,
+                        newValue,
                         confirmValueChange,
                         skipHiddenState,
                     )


### PR DESCRIPTION
## Proposed Changes

This PR addresses an issue in the SheetState restoration logic. When skipPartiallyExpanded is set to true (e.g., based on configuration such as landscape mode), attempting to restore a PartiallyExpanded state could lead to errors due to the mismatch between the saved state and the new configuration. This change ensures that if skipPartiallyExpanded is true, a saved PartiallyExpanded value is restored as Expanded, preventing potential errors during configuration changes, such as device orientation switches.

## Testing

To verify the changes, I tested the following scenario where a crash could occur:

```kotlin
val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
val sheetState = rememberModalBottomSheetState(
    skipPartiallyExpanded = isLandscape,
)
```
- Ensured the modal bottom sheet content was large enough to support a PartiallyExpanded state.
- Opened the modal bottom sheet in portrait mode `(isLandscape = false)`, allowing the sheet to be set to PartiallyExpanded.
- Rotated the device to landscape mode `(isLandscape = true)`, which sets skipPartiallyExpanded to true.
- Verified that the sheet state correctly restores to Expanded instead of crashing due to attempting to restore PartiallyExpanded.