### PR TITLE
Fix ComposableNamingDetector crash on internal functions

### DIFF
--- a/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
+++ b/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
@@ -56,7 +56,7 @@ class ComposableNamingDetector : Detector(), SourceCodeScanner {
                 // special case where a generic return type and a Unit type parameter is used.
                 if (node.findSuperMethods().isNotEmpty()) return
 
-                val name = node.nameFromSource
+                val name = node.nameFromSource ?: node.name
 
                 val capitalizedFunctionName = name.first().isUpperCase()
 

--- a/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
+++ b/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
@@ -30,7 +30,7 @@ import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
-import com.android.tools.lint.detector.api.nameFromSource
+import com.intellij.psi.PsiNamedElement
 import java.util.EnumSet
 import java.util.Locale
 import org.jetbrains.uast.UMethod
@@ -56,7 +56,7 @@ class ComposableNamingDetector : Detector(), SourceCodeScanner {
                 // special case where a generic return type and a Unit type parameter is used.
                 if (node.findSuperMethods().isNotEmpty()) return
 
-                val name = node.nameFromSource ?: node.name
+                val name = (node.sourcePsi as? PsiNamedElement)?.name ?: node.name
 
                 val capitalizedFunctionName = name.first().isUpperCase()
 

--- a/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
+++ b/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
@@ -56,6 +56,7 @@ class ComposableNamingDetector : Detector(), SourceCodeScanner {
                 // special case where a generic return type and a Unit type parameter is used.
                 if (node.findSuperMethods().isNotEmpty()) return
 
+                // NOTE: this is the inlined version of `UElement#nameFromSource` (available starting with Lint `31.10.0`)
                 val name = (node.sourcePsi as? PsiNamedElement)?.name ?: node.name
 
                 val capitalizedFunctionName = name.first().isUpperCase()

--- a/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
+++ b/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
@@ -56,7 +56,8 @@ class ComposableNamingDetector : Detector(), SourceCodeScanner {
                 // special case where a generic return type and a Unit type parameter is used.
                 if (node.findSuperMethods().isNotEmpty()) return
 
-                // NOTE: this is the inlined version of `UElement#nameFromSource` (available starting with Lint `31.10.0`)
+                // NOTE: this is the inlined version of `UElement#nameFromSource`
+                // (available starting with Lint `31.10.0`)
                 val name = (node.sourcePsi as? PsiNamedElement)?.name ?: node.name
 
                 val capitalizedFunctionName = name.first().isUpperCase()

--- a/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
+++ b/compose/runtime/runtime-lint/src/main/java/androidx/compose/runtime/lint/ComposableNamingDetector.kt
@@ -30,6 +30,7 @@ import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.nameFromSource
 import java.util.EnumSet
 import java.util.Locale
 import org.jetbrains.uast.UMethod
@@ -55,7 +56,7 @@ class ComposableNamingDetector : Detector(), SourceCodeScanner {
                 // special case where a generic return type and a Unit type parameter is used.
                 if (node.findSuperMethods().isNotEmpty()) return
 
-                val name = node.name
+                val name = node.nameFromSource
 
                 val capitalizedFunctionName = name.first().isUpperCase()
 

--- a/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
+++ b/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
@@ -252,12 +252,25 @@ Fix for src/androidx/compose/runtime/foo/test.kt line 7: Change to getInt:
             .run()
             .expect(
                 """
-todo
+src/androidx/compose/runtime/foo/Scope.kt:8: Warning: Composable functions that return Unit should start with an uppercase letter [ComposableNaming]
+                    internal fun button() {}
+                                 ~~~~~~
+src/androidx/compose/runtime/foo/Scope.kt:10: Warning: Composable functions with a return type should start with a lowercase letter [ComposableNaming]
+                    internal fun GetInt(): Int { return 5 }
+                                 ~~~~~~
+0 errors, 2 warnings
             """
             )
             .expectFixDiffs(
                 """
-todo
+Autofix for src/androidx/compose/runtime/foo/Scope.kt line 8: Change to Button:
+@@ -8 +8 @@
+-                    internal fun button() {}
++                    internal fun Button() {}
+Autofix for src/androidx/compose/runtime/foo/Scope.kt line 10: Change to getInt:
+@@ -10 +10 @@
+-                    internal fun GetInt(): Int { return 5 }
++                    internal fun getInt(): Int { return 5 }
                 """
             )
     }

--- a/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
+++ b/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
@@ -274,5 +274,4 @@ Autofix for src/androidx/compose/runtime/foo/Scope.kt line 10: Change to getInt:
                 """
             )
     }
-
 }

--- a/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
+++ b/compose/runtime/runtime-lint/src/test/java/androidx/compose/runtime/lint/ComposableNamingDetectorTest.kt
@@ -228,4 +228,38 @@ Fix for src/androidx/compose/runtime/foo/test.kt line 7: Change to getInt:
             .run()
             .expectClean()
     }
+
+    @Test
+    fun nestedAndInternalModifierIsSupported() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                package androidx.compose.runtime.foo
+
+                import androidx.compose.runtime.Composable
+
+                object Scope {
+                    @Composable
+                    internal fun button() {}
+                    @Composable
+                    internal fun GetInt(): Int { return 5 }
+                }
+            """
+                ),
+                Stubs.Composable,
+            )
+            .run()
+            .expect(
+                """
+todo
+            """
+            )
+            .expectFixDiffs(
+                """
+todo
+                """
+            )
+    }
+
 }


### PR DESCRIPTION
`Composable`s with internal modifiers inside a class/interface/object will crash the `ComposableNamingDetector`.

```kotlin
object Foo {
    @Composable
    internal fun Content(): @Composable () -> Unit = {}
}
```

The computed `UMethod#name` for this will be `Content$impl`, which is then used in the `LintFix` to replace a String that does not exist in the source code. Leading to this crash:

```
Couldn't compute fix edits for Change to content$impl
java.lang.IllegalArgumentException: Did not find "Content$impl" in "Content" in [...]
Consider calling ReplaceStringBuilder#range() to set a larger range to search than the default highlight range.
```


## Proposed Changes

Use `UElement#nameFromSource` instead

## Testing

Test: added a `nestedAndInternalModifierIsSupported()` test case

## Issues Fixed

Issue: https://issuetracker.google.com/issues/461736991
