### PR TITLE
Fix incorrect exception type in Recyclerview SnapHelper attachToRecyclerView Javadoc

### DIFF
--- a/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/SnapHelper.java
+++ b/recyclerview/recyclerview/src/main/java/androidx/recyclerview/widget/SnapHelper.java
@@ -85,7 +85,7 @@ public abstract class SnapHelper extends RecyclerView.OnFlingListener {
      *                     {@code null} if you want to remove SnapHelper from the current
      *                     RecyclerView.
      *
-     * @throws IllegalArgumentException if there is already a {@link RecyclerView.OnFlingListener}
+     * @throws IllegalStateException if there is already a {@link RecyclerView.OnFlingListener}
      * attached to the provided {@link RecyclerView}.
      *
      */


### PR DESCRIPTION
## Proposed Changes

The Javadoc for `attachToRecyclerView` in `SnapHelper.java` incorrectly states that it throws an `IllegalArgumentException`. The actual implementation throws an `IllegalStateException` when a `RecyclerView.OnFlingListener` is already attached.

## Testing

Test: This PR is just updating comment.
