### PR TITLE
Fix typo in `TabIndicatorScope.tabIndicatorOffset` documentation

### DIFF
--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TabRow.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/TabRow.kt
@@ -373,7 +373,7 @@ interface TabIndicatorScope {
      * A Modifier that follows the default offset and animation
      *
      * @param selectedTabIndex the index of the current selected tab
-     * @param matchContentSize this modifier can also animate the width of the indicator \ to match
+     * @param matchContentSize this modifier can also animate the width of the indicator to match
      *   the content size of the tab.
      */
     fun Modifier.tabIndicatorOffset(


### PR DESCRIPTION
## Proposed Changes

  - Removing extra `\` that was probably inserted by mistake when adding a new line

## Testing

Test: N/A