### PR TITLE
Don't intercept back navigation if navigation has only one entry

### DIFF
--- a/wear/compose/compose-navigation3/src/main/kotlin/androidx/wear/compose/navigation3/SwipeDismissableSceneStrategy.kt
+++ b/wear/compose/compose-navigation3/src/main/kotlin/androidx/wear/compose/navigation3/SwipeDismissableSceneStrategy.kt
@@ -112,7 +112,7 @@ public class SwipeDismissableSceneStrategy<T : Any>(
 ) : SceneStrategy<T> {
 
     override fun SceneStrategyScope<T>.calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
-        if (entries.isEmpty()) return null
+        if (entries.size < 2) return null
 
         val currentEntry = entries.last()
         val previousEntries = entries.dropLast(1)


### PR DESCRIPTION
Without this user can't exit the app.

Also proposed in https://android-review.googlesource.com/c/platform/frameworks/support/+/3900144

## Proposed Changes
This disables nav back interception if user hasn't navigated anywhere. It was needed on my opensource app that is using your yet not published rememberSwipeDismissableSceneStrategy here https://github.com/persian-calendar/persian-calendar/commit/83d41dc2cacb6eba6421710529aa4fe20fd6ef56

(cc: @claraf3)

The fix (the previous link) makes this UI test in my project to pass https://github.com/persian-calendar/persian-calendar/commit/81cb19e8e2664b627e127de8d29118065443903b 

## Testing

Before this change

https://github.com/user-attachments/assets/e8f3f9b4-4242-4d50-af87-017078b9498c

After this change

https://github.com/user-attachments/assets/a023722c-48f2-4d7b-beff-9f0e452952ad
