### PR TITLE
[nav3] Improve DialogSceneStrategy efficiency

### DIFF
--- a/navigation3/navigation3-ui/src/commonMain/kotlin/androidx/navigation3/scene/DialogScene.kt
+++ b/navigation3/navigation3-ui/src/commonMain/kotlin/androidx/navigation3/scene/DialogScene.kt
@@ -74,14 +74,15 @@ public class DialogSceneStrategy<T : Any>() : SceneStrategy<T> {
     public override fun SceneStrategyScope<T>.calculateScene(
         entries: List<NavEntry<T>>
     ): Scene<T>? {
+        val backgroundEntries = entries.dropLast(1)
         val lastEntry = entries.lastOrNull()
         val dialogProperties = lastEntry?.metadata?.get(DIALOG_KEY) as? DialogProperties
         return dialogProperties?.let { properties ->
             DialogScene(
                 key = lastEntry.contentKey,
                 entry = lastEntry,
-                previousEntries = entries.dropLast(1),
-                overlaidEntries = entries.dropLast(1),
+                previousEntries = backgroundEntries,
+                overlaidEntries = backgroundEntries,
                 dialogProperties = properties,
                 onBack = onBack,
             )


### PR DESCRIPTION
## Proposed Changes
Optimize DialogSceneStrategy by reducing redundant list allocations and improving metadata access.
Detailed Description

This change introduces an improvement to the navigation3-ui performance in calculateScene, the code previously called entries.dropLast(1) twice. Since dropLast creates a new list copy each time, I've refactored it to perform the operation once and reuse the result for both previousEntries and overlaidEntries.

Test: ./gradlew :navigation:navigation3:scene:test
Relnotes: Fixed minor performance overhead in DialogSceneStrategy.

## Testing

Test: None, just removed a code-duplication
