### PR TITLE
Fix race condition in LimitOffsetPagingSource

### DIFF
--- a/room3/room3-paging/src/androidDeviceTest/kotlin/androidx/room3/paging/LimitOffsetPagingSourceTest.kt
+++ b/room3/room3-paging/src/androidDeviceTest/kotlin/androidx/room3/paging/LimitOffsetPagingSourceTest.kt
@@ -555,9 +555,22 @@ class LimitOffsetPagingSourceTest {
     }
 
     @Test
+    fun delete_invalidatesPagerAfterRefresh() = runPagingSourceTest { pager, pagingSource ->
+        pager.refresh(initialKey = 10)
+        assertThat(pagingSource.invalid).isFalse()
+
+        dao.deleteTestItems(5, 15)
+        // Wait for the delete to finish.
+        countingTaskExecutorRule.drainTasks(500, TimeUnit.MILLISECONDS)
+        assertThat(pagingSource.invalid).isTrue()
+    }
+
+    @Test
     fun load_refreshKeyGreaterThanItemCount_lastPage() = runPagingSourceTest { pager, _ ->
         pager.refresh(initialKey = 70)
         dao.deleteTestItems(40, 100)
+        // Wait for the delete to finish.
+        countingTaskExecutorRule.drainTasks(500, TimeUnit.MILLISECONDS)
 
         // assume user was viewing last item of the refresh load with anchorPosition = 85,
         // initialLoadSize = 15. This mimics how getRefreshKey() calculates refresh key.
@@ -587,6 +600,8 @@ class LimitOffsetPagingSourceTest {
     fun load_refreshKeyOnLastPage() = runPagingSourceTest { pager, _ ->
         pager.refresh(initialKey = 70)
         dao.deleteTestItems(80, 100)
+        // Wait for the delete to finish.
+        countingTaskExecutorRule.drainTasks(500, TimeUnit.MILLISECONDS)
 
         // assume user was viewing last item of the refresh load with anchorPosition = 85,
         // initialLoadSize = 15. This mimics how getRefreshKey() calculates refresh key.
@@ -630,6 +645,8 @@ class LimitOffsetPagingSourceTest {
             assertThat(pagingSource.itemCount).isEqualTo(100)
             // items id 0 - 29 deleted (30 items removed)
             dao.deleteTestItems(0, 29)
+            // Wait for the delete to finish.
+            countingTaskExecutorRule.drainTasks(500, TimeUnit.MILLISECONDS)
 
             val pagingSource2 = LimitOffsetPagingSourceImpl(database)
             val pager2 = TestPager(CONFIG, pagingSource2)
@@ -658,6 +675,8 @@ class LimitOffsetPagingSourceTest {
             assertThat(pagingSource.itemCount).isEqualTo(100)
             // items id 0 - 94 deleted (95 items removed)
             dao.deleteTestItems(0, 94)
+            // Wait for the delete to finish.
+            countingTaskExecutorRule.drainTasks(500, TimeUnit.MILLISECONDS)
 
             val pagingSource2 = LimitOffsetPagingSourceImpl(database)
             val pager2 = TestPager(CONFIG, pagingSource2)

--- a/room3/room3-paging/src/commonMain/kotlin/androidx/room3/paging/LimitOffsetPagingSource.kt
+++ b/room3/room3-paging/src/commonMain/kotlin/androidx/room3/paging/LimitOffsetPagingSource.kt
@@ -31,6 +31,7 @@ import androidx.room3.paging.util.queryContext
 import androidx.room3.paging.util.queryDatabase
 import androidx.room3.paging.util.queryItemCount
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -74,6 +75,7 @@ internal class CommonLimitOffsetImpl<Value : Any>(
     internal val itemCount = AtomicInt(INITIAL_ITEM_COUNT)
 
     private val refreshComplete = AtomicBoolean(false)
+    private val collectorLatch = CompletableDeferred<Unit>()
 
     private var invalidationFlowJob: Job? = null
 
@@ -81,9 +83,16 @@ internal class CommonLimitOffsetImpl<Value : Any>(
         // register db listeners right away
         invalidationFlowJob =
             db.getCoroutineScope().launch {
-                db.invalidationTracker.createFlow(*tables, emitInitialState = false).collect {
+                db.invalidationTracker.createFlow(*tables, emitInitialState = true).collect {
+                    // Signal even before checking if we're still valid, to ensure the load function
+                    // doesn't block.
+                    val initialState = collectorLatch.complete(Unit)
                     if (pagingSource.invalid) {
                         throw CancellationException("PagingSource is invalid")
+                    }
+                    if (initialState) {
+                        // The first emit essentially just lets us know the flow has started.
+                        return@collect
                     }
                     if (refreshComplete.get()) {
                         pagingSource.invalidate()
@@ -96,10 +105,16 @@ internal class CommonLimitOffsetImpl<Value : Any>(
 
     suspend fun load(params: LoadParams<Int>): LoadResult<Int, Value> {
         val tempCount = itemCount.get()
-        // if itemCount is < 0, then it is initial load
+        // if itemCount is == INITIAL_ITEM_COUNT, then it is initial load
         return try {
+            // Wait until we know the collector has started, which means we're guaranteed to get an
+            // invalidation for any updates that happen after this point.
+            collectorLatch.await()
             if (tempCount == INITIAL_ITEM_COUNT) {
-                initialLoad(params).also { refreshComplete.compareAndSet(false, true) }
+                // Mark the load started for invalidation purposes; once we pass this point, we
+                // want to ensure we process any invalidations by the flow collector.
+                refreshComplete.compareAndSet(false, true)
+                initialLoad(params)
             } else {
                 nonInitialLoad(params, tempCount)
             }


### PR DESCRIPTION
## Proposed Changes

Fix two race conditions in LimitOffsetPagingSource:
  - Move the refreshComplete.compareAndSet to before the initialLoad so invalidations that happen while the initial read are occurring are handled.
  - Add a signal from the invalidation callback that the initial read waits on in order to ensure the read doesn't occur until after the invalidation flow is being collected.

## Testing

Test: Run LimitOffsetPagingSourceTest and LimitOffsetPagingSourceTestWithFilteringCoroutineDispatcher

## Issues Fixed

Fixes: The bug on [https://issuetracker.google.com/issues/473587154](https://issuetracker.google.com/issues/473587154) is fixed.

This may also address https://issuetracker.google.com/issues/192269858 but it wasn't clear to me if that bug was still relevant or earlier changes addressed it satisfactorily, so I opened a new bug.

Additionally, due to this being a race condition, it is difficult to robustly test in code. I have a repro app. If I can get guidance on building my repro app against a locally built room-paging library, I'm happy to hit it manually a bit too. The repro is not 100% but not too hard to hit with the repro app.
