### PR TITLE
Add spring overload that takes durationMillis and bounce

### DIFF
--- a/compose/animation/animation-core/api/current.txt
+++ b/compose/animation/animation-core/api/current.txt
@@ -155,6 +155,8 @@ package androidx.compose.animation.core {
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.RepeatableSpec! repeatable-91I0pcU$default(int, androidx.compose.animation.core.DurationBasedAnimationSpec!, androidx.compose.animation.core.RepeatMode!, long, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SnapSpec<T> snap(optional int delayMillis);
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SnapSpec! snap$default(int, int, Object!);
+    method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SpringSpec<T> spring(@IntRange(from=1) int durationMillis, @FloatRange(from=-1.0, to=1.0) float bounce, optional T? visibilityThreshold);
+    method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SpringSpec! spring$default(int, float, Object!, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SpringSpec<T> spring(optional float dampingRatio, optional float stiffness, optional T? visibilityThreshold);
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SpringSpec! spring$default(float, float, Object!, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.TweenSpec<T> tween(optional int durationMillis, optional int delayMillis, optional androidx.compose.animation.core.Easing easing);
@@ -982,4 +984,3 @@ package androidx.compose.animation.core {
   }
 
 }
-

--- a/compose/animation/animation-core/api/restricted_current.txt
+++ b/compose/animation/animation-core/api/restricted_current.txt
@@ -155,6 +155,8 @@ package androidx.compose.animation.core {
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.RepeatableSpec! repeatable-91I0pcU$default(int, androidx.compose.animation.core.DurationBasedAnimationSpec!, androidx.compose.animation.core.RepeatMode!, long, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SnapSpec<T> snap(optional int delayMillis);
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SnapSpec! snap$default(int, int, Object!);
+    method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SpringSpec<T> spring(@IntRange(from=1) int durationMillis, @FloatRange(from=-1.0, to=1.0) float bounce, optional T? visibilityThreshold);
+    method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SpringSpec! spring$default(int, float, Object!, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.SpringSpec<T> spring(optional float dampingRatio, optional float stiffness, optional T? visibilityThreshold);
     method @BytecodeOnly @androidx.compose.runtime.Stable public static androidx.compose.animation.core.SpringSpec! spring$default(float, float, Object!, int, Object!);
     method @androidx.compose.runtime.Stable public static <T> androidx.compose.animation.core.TweenSpec<T> tween(optional int durationMillis, optional int delayMillis, optional androidx.compose.animation.core.Easing easing);
@@ -992,4 +994,3 @@ package androidx.compose.animation.core {
   }
 
 }
-

--- a/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
+++ b/compose/animation/animation-core/src/commonMain/kotlin/androidx/compose/animation/core/AnimationSpec.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.util.fastRoundToInt
+import kotlin.math.PI
 import kotlin.math.abs
 
 public object AnimationConstants {
@@ -810,6 +811,33 @@ public fun <T> spring(
     stiffness: Float = Spring.StiffnessMedium,
     visibilityThreshold: T? = null,
 ): SpringSpec<T> = SpringSpec(dampingRatio, stiffness, visibilityThreshold)
+
+/**
+ * Creates a [SpringSpec] with a [durationMillis] and [bounce].
+ *
+ * Positive [bounce] values produce under-damped springs (bouncy), `0f` is critically damped, and
+ * negative values produce over-damped springs (no overshoot).
+ *
+ * @param durationMillis desired spring duration in milliseconds. Must be positive.
+ * @param bounce controls how bouncy the spring is. Must be in the range `(-1, 1]`.
+ * @param visibilityThreshold optionally specifies the visibility threshold.
+ */
+@Stable
+public fun <T> spring(
+    @IntRange(from = 1) durationMillis: Int,
+    @FloatRange(from = -1.0, to = 1.0) bounce: Float,
+    visibilityThreshold: T? = null,
+): SpringSpec<T> {
+    requirePrecondition(durationMillis > 0) { "Spring durationMillis must be positive." }
+    requirePrecondition(bounce > -1f && bounce <= 1f) { "Spring bounce must be in (-1, 1]." }
+
+    val durationSeconds = durationMillis / 1000f
+    val naturalFrequency = (2.0 * PI / durationSeconds).toFloat()
+    val stiffness = naturalFrequency * naturalFrequency
+    val dampingRatio = if (bounce > 0f) 1f - bounce else 1f / (bounce + 1f)
+
+    return SpringSpec(dampingRatio, stiffness, visibilityThreshold)
+}
 
 /**
  * Creates a [KeyframesSpec] animation, initialized with [init]. For example:

--- a/compose/animation/animation-core/src/commonTest/kotlin/androidx/compose/animation/core/PhysicsAnimationTest.kt
+++ b/compose/animation/animation-core/src/commonTest/kotlin/androidx/compose/animation/core/PhysicsAnimationTest.kt
@@ -17,9 +17,11 @@
 package androidx.compose.animation.core
 
 import androidx.kruth.assertThat
+import kotlin.math.PI
 import kotlin.math.sign
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class PhysicsAnimationTest {
@@ -89,6 +91,27 @@ class PhysicsAnimationTest {
 
         assertThat(resultValue).isEqualTo(expectedValue)
         assertThat(resultVelocity).isEqualTo(expectedVelocity)
+    }
+
+    @Test
+    fun springFromDurationAndBounceProducesExpectedParameters() {
+        val underDampedSpec = spring<Float>(durationMillis = 500, bounce = 0.25f, visibilityThreshold = 1f)
+        val expectedUnderDampedStiffness = (4.0 * PI * PI / (0.5 * 0.5)).toFloat()
+        assertEquals(expectedUnderDampedStiffness, underDampedSpec.stiffness, absoluteTolerance = 0.001f)
+        assertEquals(0.75f, underDampedSpec.dampingRatio, absoluteTolerance = 0.001f)
+        assertEquals(1f, underDampedSpec.visibilityThreshold)
+
+        val overDampedSpec = spring<Float>(durationMillis = 400, bounce = -0.5f)
+        val expectedOverDampedStiffness = (4.0 * PI * PI / (0.4 * 0.4)).toFloat()
+        assertEquals(expectedOverDampedStiffness, overDampedSpec.stiffness, absoluteTolerance = 0.001f)
+        assertEquals(2f, overDampedSpec.dampingRatio, absoluteTolerance = 0.001f)
+    }
+
+    @Test
+    fun springFromDurationAndBounceRejectsInvalidArguments() {
+        assertFailsWith<IllegalArgumentException> { spring<Float>(durationMillis = 0, bounce = 0f) }
+        assertFailsWith<IllegalArgumentException> { spring<Float>(durationMillis = 500, bounce = 1.1f) }
+        assertFailsWith<IllegalArgumentException> { spring<Float>(durationMillis = 500, bounce = -1f) }
     }
 
     @Test


### PR DESCRIPTION
Disclaimer: I'm not super sure if this is valid on GitHub or I should send to Gerrit, please let me know. Hopefully it is a small enough PR that is valid for GitHub.

Issue: https://issuetracker.google.com/issues/488385577

Motivation:

[SwiftUI](https://developer.apple.com/documentation/SwiftUI/Spring) has spring based on time (it even appears before the mass/stiffness/etc in their docs), [Flutter now has](https://github.com/flutter/flutter/blob/c09a1c85d26751a34c0a5a65d435541024a2b539/packages/flutter/lib/src/physics/spring_simulation.dart#L70) spring based on time and I wish Compose had it too. I think it is useful, it reduces the cognitive workload and is much simpler. Instead of knowing what is mass, what is damping, you just say: I expect the animation to take ~500ms and be very bouncy, or not very bouncy.

## Summary
- adds a new `spring(durationMillis, bounce, visibilityThreshold)` overload in `animation-core`
- converts duration+bounce to spring `stiffness` and `dampingRatio` using the same mapping used by Flutter's new spring API
- validates input (`durationMillis > 0`, `bounce in (-1, 1]`)
- adds coverage in `PhysicsAnimationTest` and updates `api/current.txt` + `api/restricted_current.txt`

## Test
- `:compose:animation:animation-core:testAndroidHostTest --tests androidx.compose.animation.core.PhysicsAnimationTest.springFromDurationAndBounceProducesExpectedParameters --tests androidx.compose.animation.core.PhysicsAnimationTest.springFromDurationAndBounceRejectsInvalidArguments`
- `:compose:animation:animation-core:jvmStubsTest`