### PR TITLE
Add filterTouchesWhenObscured attribute to custom dialog

### DIFF
--- a/core/core/src/main/res/layout/custom_dialog.xml
+++ b/core/core/src/main/res/layout/custom_dialog.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_height="fill_parent"
+    android:filterTouchesWhenObscured="true">
 
     <Button
         android:id="@+id/dialog_button"


### PR DESCRIPTION
fix(android): Add filterTouchesWhenObscured to prevent Tapjacking

Proposed Changes

Added android:filterTouchesWhenObscured="true" to views in custom_dialog.xml.

Prevents touch input when the view is obscured by another window, mitigating overlay/tapjacking attacks (CWE-1021).

Testing

Test: Verified the feedback dialog ignores touch events when an overlay is present and works normally otherwise.

