### PR TITLE
Fix baseline profile plugin creating dirs at configuration time

### DIFF
--- a/benchmark/baseline-profile-gradle-plugin/src/main/kotlin/androidx/baselineprofile/gradle/consumer/BaselineProfileConsumerPlugin.kt
+++ b/benchmark/baseline-profile-gradle-plugin/src/main/kotlin/androidx/baselineprofile/gradle/consumer/BaselineProfileConsumerPlugin.kt
@@ -408,7 +408,7 @@ private class BaselineProfileConsumerAgpPlugin(private val project: Project) :
                 // output is src/main/baseline-prof.txt.
                 if (!forceOutputInSrcMain) {
 
-                    val srcOutputDirPath = srcOutputDir.asFile.apply { mkdirs() }.absolutePath
+                    val srcOutputDirPath = srcOutputDir.asFile.absolutePath
                     fun applySourceSets(variant: Variant) {
                         variant.sources.baselineProfiles?.addStaticSourceDirectory(srcOutputDirPath)
                     }

--- a/benchmark/baseline-profile-gradle-plugin/src/test/kotlin/androidx/baselineprofile/gradle/consumer/BaselineProfileConsumerPluginTest.kt
+++ b/benchmark/baseline-profile-gradle-plugin/src/test/kotlin/androidx/baselineprofile/gradle/consumer/BaselineProfileConsumerPluginTest.kt
@@ -2115,4 +2115,55 @@ class BaselineProfileConsumerPluginTestWithFtl(agpVersion: TestAgpVersion) {
         assertThat(projectSetup.baselineProfileFile("release").exists()).isFalse()
         assertThat(projectSetup.startupProfileFile("release").exists()).isFalse()
     }
+
+    @Test
+    fun testBaselineProfileOutputDirNotCreatedDuringConfiguration() {
+        projectSetup.consumer.setup(
+            androidPlugin = ANDROID_APPLICATION_PLUGIN,
+            flavors = true,
+            baselineProfileBlock =
+                """
+                saveInSrc = true
+                automaticGenerationDuringBuild = true
+            """
+                    .trimIndent(),
+        )
+        projectSetup.producer.setupWithFreeAndPaidFlavors(
+            freeReleaseProfileLines = listOf(Fixtures.CLASS_1_METHOD_1, Fixtures.CLASS_1),
+            paidReleaseProfileLines = listOf(Fixtures.CLASS_2_METHOD_1, Fixtures.CLASS_2),
+        )
+
+        val freeReleaseOutputDir =
+            File(
+                projectSetup.consumer.rootDir,
+                "src/freeRelease/$EXPECTED_PROFILE_FOLDER"
+            )
+        val paidReleaseOutputDir =
+            File(
+                projectSetup.consumer.rootDir,
+                "src/paidRelease/$EXPECTED_PROFILE_FOLDER"
+            )
+
+        // Ensure dirs don't exist before the build
+        freeReleaseOutputDir.deleteRecursively()
+        paidReleaseOutputDir.deleteRecursively()
+
+        // Store the configuration cache entry without executing tasks.
+        gradleRunner.build(
+            "generateFreeReleaseBaselineProfile", "--configuration-cache", "--dry-run"
+        ) {}
+
+        // Verify configuration cache is reused and output is correct.
+        gradleRunner.build(
+            "generateFreeReleaseBaselineProfile", "--configuration-cache"
+        ) {
+            assertThat(it).contains("Reusing configuration cache")
+            assertThat(readBaselineProfileFileContent("freeRelease"))
+                .containsExactly(Fixtures.CLASS_1, Fixtures.CLASS_1_METHOD_1)
+        }
+
+        assertWithMessage(
+            "Output dir should be created at execution time"
+        ).that(freeReleaseOutputDir.exists()).isTrue()
+    }
 }


### PR DESCRIPTION
The baseline profile consumer plugin calls `mkdirs()` at configuration time when registering source directories, which creates `src/<variant>/generated/baselineProfiles` for every variant. This causes Gradle's configuration cache to track these directories as file system inputs, leading to unnecessary cache invalidations when the directories are later removed (e.g. by clean tasks or git operations).

The fix removes the `mkdirs()` call since Gradle already creates the directory at execution time via the `@OutputDirectory` annotation on the copy task's `baselineProfileDir` property.

Test: BaselineProfileConsumerPluginTest#testBaselineProfileOutputDirNotCreatedDuringConfiguration