### PR TITLE
Fix typo in WireBuffer Javadocs

### DIFF
--- a/compose/remote/remote-core/src/main/java/androidx/compose/remote/core/WireBuffer.java
+++ b/compose/remote/remote-core/src/main/java/androidx/compose/remote/core/WireBuffer.java
@@ -75,7 +75,7 @@ public class WireBuffer {
     }
 
     /**
-     * get the wire buffer's underlying byte array. Note the array will be bigger that the used
+     * get the wire buffer's underlying byte array. Note the array will be bigger than the used
      * portion
      *
      * @return byte array of the wire buffer


### PR DESCRIPTION
Replaces "that" with "than" in a WireBuffer comment.

## Proposed Changes

  - Fix typo in WireBuffer Javadocs.
  - No behavior changes.

## Testing

Test: Not run; documentation-only change.

## Issues Fixed

Fixes: N/A