### PR TITLE
Animate ModalBottomSheet hide on composition removal

### DIFF
--- a/compose/material3/material3/src/androidMain/kotlin/androidx/compose/material3/ModalBottomSheet.android.kt
+++ b/compose/material3/material3/src/androidMain/kotlin/androidx/compose/material3/ModalBottomSheet.android.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -64,6 +65,7 @@ import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.findViewTreeSavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import java.util.UUID
+import kotlinx.coroutines.NonCancellable
 
 // Logic forked from androidx.compose.ui.window.DialogProperties. Removed dismissOnClickOutside
 // and usePlatformDefaultWidth as they are not relevant for fullscreen experience.
@@ -226,6 +228,7 @@ internal actual fun ModalBottomSheetDialog(
     onDismissRequest: () -> Unit,
     contentColor: Color,
     properties: ModalBottomSheetProperties,
+    animateToHidden: suspend () -> Unit,
     content: @Composable () -> Unit,
 ) {
     val view = LocalView.current
@@ -234,6 +237,8 @@ internal actual fun ModalBottomSheetDialog(
     val composition = rememberCompositionContext()
     val currentContent by rememberUpdatedState(content)
     val dialogId = rememberSaveable { UUID.randomUUID() }
+    val coroutineScope = rememberCoroutineScope()
+
     val dialog =
         remember(view, density) {
             ModalBottomSheetDialogWrapper(
@@ -256,8 +261,13 @@ internal actual fun ModalBottomSheetDialog(
         dialog.show()
 
         onDispose {
-            dialog.dismiss()
-            dialog.disposeComposition()
+            coroutineScope.launch(context = NonCancellable) {
+                dialog.disposeComposition()
+
+                animateToHidden()
+
+                dialog.dismiss()
+            }
         }
     }
 

--- a/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ModalBottomSheet.kt
+++ b/compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ModalBottomSheet.kt
@@ -137,6 +137,7 @@ fun ModalBottomSheet(
         properties = properties,
         contentColor = contentColor,
         onDismissRequest = settleToDismiss,
+        animateToHidden = { sheetState.hide() },
     ) {
         Box(modifier = Modifier.fillMaxSize().semantics { isTraversalGroup = true }) {
             val sheetWindowInsets = remember(sheetState) { SheetWindowInsets(sheetState) }
@@ -277,6 +278,9 @@ internal class SheetWindowInsets(private val state: SheetState) : WindowInsets {
  * @param contentColor The content color of this dialog. Used to inform the default behavior of the
  *   windows' system bars and content.
  * @param properties [ModalBottomSheetProperties] for further customization of this dialog.
+ * @param animateToHidden Suspend hook invoked once the dialog is being removed from the composition
+ *   hierarchy. Runs the bottom sheet exit animation before the underlying window is dismissed, so
+ *   the sheet does not disappear abruptly when its host is removed (e.g. during navigation).
  * @param content The content displayed in this [ModalBottomSheetDialog]. Usually [BottomSheet].
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -285,5 +289,6 @@ internal expect fun ModalBottomSheetDialog(
     onDismissRequest: () -> Unit = {},
     contentColor: Color = contentColorFor(BottomSheetDefaults.ContainerColor),
     properties: ModalBottomSheetProperties = ModalBottomSheetProperties(),
+    animateToHidden: suspend () -> Unit = {},
     content: @Composable () -> Unit,
 )

--- a/compose/material3/material3/src/commonStubsMain/kotlin/androidx/compose/material3/ModalBottomSheet.commonStubs.kt
+++ b/compose/material3/material3/src/commonStubsMain/kotlin/androidx/compose/material3/ModalBottomSheet.commonStubs.kt
@@ -52,5 +52,6 @@ internal actual fun ModalBottomSheetDialog(
     onDismissRequest: () -> Unit,
     contentColor: Color,
     properties: ModalBottomSheetProperties,
+    animateToHidden: suspend () -> Unit,
     content: @Composable () -> Unit,
 ): Unit = implementedInJetBrainsFork()


### PR DESCRIPTION
## Proposed Changes
When `ModalBottomSheet` is removed from the composition hierarchy, its underlying dialog window is dismissed immediately, and the sheet disappears abruptly, without playing the exit animation.

This is particularly noticeable with Navigation 3, where `ModalBottomSheet` is hosted as a separate scene and may be removed by navigation stack changes rather than by user dismissal. In this case, the sheet vanishes instantly rather than sliding out smoothly.

This change defers dismissal of the dialog window until the sheet has finished animating to `Hidden`. Internally, `ModalBottomSheetDialog` gains a new `animateToHidden` suspend hook that `ModalBottomSheet` wires to `sheetState.hide()`. On composition removal, the dialog waits for a one-shot signal, runs the exit animation inside the dialog's own composition, and only then dismisses the window and disposes the composition. The closing behavior now matches that of an explicit `onDismissRequest`.