### PR TITLE
Add @Language("RoomSql") to Room's Query annotation to enable IDE syntax highlighting

### DIFF
--- a/room3/room3-common/build.gradle
+++ b/room3/room3-common/build.gradle
@@ -48,6 +48,10 @@ androidXMultiplatform {
             api("androidx.annotation:annotation:1.9.1")
         }
 
+        jvmMain.dependencies {
+            compileOnly(libs.intellijAnnotations)
+        }
+
         commonTest.dependencies {
             implementation(project(":kruth:kruth"))
             implementation(libs.kotlinTest)

--- a/room3/room3-common/src/commonMain/kotlin/androidx/room3/Language.kt
+++ b/room3/room3-common/src/commonMain/kotlin/androidx/room3/Language.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room3
+
+@OptIn(ExperimentalMultiplatform::class)
+@OptionalExpectation
+@Target(
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.LOCAL_VARIABLE,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.ANNOTATION_CLASS,
+)
+@Retention(AnnotationRetention.BINARY)
+internal expect annotation class Language(
+    val value: String,
+    val prefix: String = "",
+    val suffix: String = "",
+)

--- a/room3/room3-common/src/commonMain/kotlin/androidx/room3/Query.kt
+++ b/room3/room3-common/src/commonMain/kotlin/androidx/room3/Query.kt
@@ -159,5 +159,6 @@ public annotation class Query(
      *
      * @return The query to be run.
      */
+    @Language("RoomSql")
     val value: String
 )

--- a/room3/room3-common/src/jvmMain/kotlin/androidx/room3/Language.jvm.kt
+++ b/room3/room3-common/src/jvmMain/kotlin/androidx/room3/Language.jvm.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.room3
+
+@Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT")
+internal actual typealias Language = org.intellij.lang.annotations.Language


### PR DESCRIPTION


## Proposed Changes

Add org.intellij.lang.annotations.Language annotation to androidx.room3.Query.value

## Testing

Test: Checked queries in DependencyDao from kotlintestapp
