### PR TITLE
Fix PointerInteropFilter to treat non-touch generic motion events as …

### DIFF
--- a/compose/ui/ui/src/androidDeviceTest/kotlin/androidx/compose/ui/input/pointer/PointerInteropFilterTest.kt
+++ b/compose/ui/ui/src/androidDeviceTest/kotlin/androidx/compose/ui/input/pointer/PointerInteropFilterTest.kt
@@ -19,9 +19,11 @@ package androidx.compose.ui.input.pointer
 import android.view.MotionEvent
 import android.view.MotionEvent.ACTION_CANCEL
 import android.view.MotionEvent.ACTION_DOWN
+import android.view.MotionEvent.ACTION_HOVER_MOVE
 import android.view.MotionEvent.ACTION_MOVE
 import android.view.MotionEvent.ACTION_POINTER_DOWN
 import android.view.MotionEvent.ACTION_POINTER_UP
+import android.view.MotionEvent.ACTION_SCROLL
 import android.view.MotionEvent.ACTION_UP
 import android.view.MotionEvent.TOOL_TYPE_UNKNOWN
 import androidx.compose.ui.Modifier
@@ -3155,6 +3157,111 @@ class PointerInteropFilterTest {
     }
 
     // Verification of correct passes being used
+
+    @Test
+    fun onPointerEvent_hoverDispatchedDuringInitialPassAfterTouchNotDispatching() {
+        val down = down(1, 2, 3f, 4f)
+        val downMotionEvent =
+            MotionEvent(
+                2,
+                ACTION_DOWN,
+                1,
+                0,
+                arrayOf(PointerProperties(0)),
+                arrayOf(PointerCoords(3f, 4f)),
+            )
+        val hover = down.up(5)
+        val hoverMotionEvent =
+            MotionEvent(
+                5,
+                ACTION_HOVER_MOVE,
+                1,
+                0,
+                arrayOf(PointerProperties(0)),
+                arrayOf(PointerCoords(6f, 7f)),
+            )
+
+        // Make touch stream transition to NotDispatching.
+        retVal = false
+        pointerInteropFilter.pointerInputFilter::onPointerEvent.invokeOverAllPasses(
+            pointerEventOf(down, motionEvent = downMotionEvent)
+        )
+        dispatchedMotionEvents.clear()
+        retVal = true
+
+        pointerInteropFilter.pointerInputFilter::onPointerEvent.invokeOverPass(
+            pointerEventOf(hover, motionEvent = hoverMotionEvent),
+            PointerEventPass.Initial,
+        )
+
+        assertThat(dispatchedMotionEvents).containsExactly(hoverMotionEvent)
+        PointerInputChangeSubject.assertThat(hover).changeConsumed()
+    }
+
+    @Test
+    fun onPointerEvent_scrollDispatchedDuringInitialPassAfterTouchNotDispatching() {
+        val down = down(1, 2, 3f, 4f)
+        val downMotionEvent =
+            MotionEvent(
+                2,
+                ACTION_DOWN,
+                1,
+                0,
+                arrayOf(PointerProperties(0)),
+                arrayOf(PointerCoords(3f, 4f)),
+            )
+        val scroll = down.up(5)
+        val scrollMotionEvent =
+            MotionEvent(
+                5,
+                ACTION_SCROLL,
+                1,
+                0,
+                arrayOf(PointerProperties(0)),
+                arrayOf(PointerCoords(6f, 7f)),
+            )
+
+        // Make touch stream transition to NotDispatching.
+        retVal = false
+        pointerInteropFilter.pointerInputFilter::onPointerEvent.invokeOverAllPasses(
+            pointerEventOf(down, motionEvent = downMotionEvent)
+        )
+        dispatchedMotionEvents.clear()
+        retVal = false
+
+        pointerInteropFilter.pointerInputFilter::onPointerEvent.invokeOverPass(
+            pointerEventOf(scroll, motionEvent = scrollMotionEvent),
+            PointerEventPass.Initial,
+        )
+
+        assertThat(dispatchedMotionEvents).containsExactly(scrollMotionEvent)
+        PointerInputChangeSubject.assertThat(scroll).changeNotConsumed()
+    }
+
+    @Test
+    fun onPointerEvent_genericPointerEventNotDispatchedAfterInitialPass() {
+        val hover = down(1, 2, 3f, 4f).up(5)
+        val hoverMotionEvent =
+            MotionEvent(
+                5,
+                ACTION_HOVER_MOVE,
+                1,
+                0,
+                arrayOf(PointerProperties(0)),
+                arrayOf(PointerCoords(6f, 7f)),
+            )
+        val event = pointerEventOf(hover, motionEvent = hoverMotionEvent)
+
+        pointerInteropFilter.pointerInputFilter::onPointerEvent.invokeOverPasses(
+            event,
+            PointerEventPass.Initial,
+            PointerEventPass.Main,
+            PointerEventPass.Final,
+        )
+
+        assertThat(dispatchedMotionEvents).containsExactly(hoverMotionEvent)
+        PointerInputChangeSubject.assertThat(hover).changeConsumed()
+    }
 
     @Test
     fun onPointerEvent_1PointerDown_dispatchedDuringInitialTunnel() {

--- a/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/input/pointer/PointerInteropFilter.android.kt
+++ b/compose/ui/ui/src/androidMain/kotlin/androidx/compose/ui/input/pointer/PointerInteropFilter.android.kt
@@ -219,6 +219,11 @@ internal class PointerInteropFilter : PointerInputModifier {
             ) {
                 val changes = pointerEvent.changes
 
+                if (!pointerEvent.isTouchStreamEvent()) {
+                    dispatchGenericPointerEvent(pointerEvent, pass)
+                    return
+                }
+
                 val isMoveEvent =
                     changes.fastAll {
                         !it.changedToDownIgnoreConsumed() && !it.changedToUpIgnoreConsumed()
@@ -303,6 +308,33 @@ internal class PointerInteropFilter : PointerInputModifier {
             }
 
             /**
+             * Dispatches a non-touch generic [MotionEvent] (e.g. hover, scroll) as a stateless
+             * event. Unlike events in the touch stream, generic events are not influenced by the
+             * [DispatchToViewState.NotDispatching] state, they don't trigger [stopDispatching] /
+             * [ACTION_CANCEL], and they are delivered only during [PointerEventPass.Initial] with
+             * the original [MotionEvent]'s return value used to decide whether to consume the
+             * associated pointer input changes.
+             */
+            private fun dispatchGenericPointerEvent(
+                pointerEvent: PointerEvent,
+                pass: PointerEventPass,
+            ) {
+                if (pass != PointerEventPass.Initial) return
+
+                val changes = pointerEvent.changes
+                if (changes.fastAny { it.isConsumed }) return
+
+                pointerEvent.toMotionEventScope(
+                    this.layoutCoordinates?.localToRoot(Offset.Zero)
+                        ?: error("layoutCoordinates not set")
+                ) { motionEvent ->
+                    if (onTouchEvent(motionEvent)) {
+                        changes.fastForEach { it.consume() }
+                    }
+                }
+            }
+
+            /**
              * Dispatches to the Android View.
              *
              * Also consumes aspects of [pointerEvent] and updates our [state] accordingly.
@@ -361,6 +393,20 @@ internal class PointerInteropFilter : PointerInputModifier {
                     }
                 }
                 state = DispatchToViewState.NotDispatching
+            }
+
+            private fun PointerEvent.isTouchStreamEvent(): Boolean {
+                return when (motionEvent?.actionMasked) {
+                    null,
+                    ACTION_DOWN,
+                    ACTION_POINTER_DOWN,
+                    ACTION_MOVE,
+                    ACTION_POINTER_UP,
+                    ACTION_UP,
+                    ACTION_CANCEL,
+                    ACTION_OUTSIDE -> true
+                    else -> false
+                }
             }
         }
 }


### PR DESCRIPTION
# Dispatch ACTION_HOVER_* / ACTION_SCROLL as stateless events in PointerInteropFilter
Context: Non-touch generic motion events ( ACTION_HOVER_ENTER , ACTION_HOVER_MOVE , ACTION_HOVER_EXIT , ACTION_SCROLL , ACTION_BUTTON_PRESS / RELEASE ) are currently piped through the same DispatchToViewState state machine used for the touch stream. As a consequence, once any earlier event causes the filter to flip into NotDispatching (e.g. because Compose consumed a hover change in a later pass), all subsequent generic pointer events are silently dropped until the next ACTION_DOWN resets the state. Hover and scroll events are not part of an ongoing touch stream and should be dispatched as stateless events.

Goal of this change: Dispatch ACTION_HOVER_* and ACTION_SCROLL events to the underlying onTouchEvent handler during PointerEventPass.Initial , regardless of the current DispatchToViewState.NotDispatching state. Also avoid treating such events as part of the touch stream so that the interceptor cannot cause subsequent generic pointer events to be silently dropped.



## Proposed Changes
- PointerInteropFilter.android.kt — Introduce a generic-pointer-event fast path at the top of onPointerEvent :
 
  - New helper PointerEvent.isTouchStreamEvent() classifies events: only ACTION_DOWN / ACTION_POINTER_DOWN / ACTION_MOVE / ACTION_POINTER_UP / ACTION_UP / ACTION_CANCEL / ACTION_OUTSIDE (and null MotionEvents) are considered part of the touch stream. Everything else is dispatched as a stateless generic event.
  - New private method dispatchGenericPointerEvent(pointerEvent, pass) forwards the event to the View only during PointerEventPass.Initial , bails out if the changes are already consumed, and consumes the PointerInputChange s iff the underlying onTouchEvent returns true . The method deliberately never mutates state , never calls stopDispatching() , and never synthesizes an ACTION_CANCEL .
  - The existing DispatchToViewState.Unknown / Dispatching / NotDispatching touch-stream machine is unchanged for real touch events, preserving behavior for click / drag / long-press flows.
- PointerInteropFilter.android.kt — Guard the state mutation and stopDispatching() logic so it only runs for touch-stream events (implicitly handled by the early-return above), so a Compose consumer cannot poison the generic pointer pipeline by consuming a hover change.


## Testing
- PointerInteropFilterTest.kt — Added three regression @Test methods under // Verification of correct passes being used :
  
  - onPointerEvent_hoverDispatchedDuringInitialPassAfterTouchNotDispatching
  - onPointerEvent_scrollDispatchedDuringInitialPassAfterTouchNotDispatching
  - onPointerEvent_genericPointerEventNotDispatchedAfterInitialPass
  These tests first drive the filter into NotDispatching via a touch DOWN whose onTouchEvent returns false , and then verify that hover / scroll / generic events:
  
  1. still reach onTouchEvent during Initial ;
  2. are only dispatched once ( Initial ), never again in Main / Final ;
  3. have their PointerInputChange s consumed iff the View returns true .

## Issues Fixed
Fixes: https://issuetracker.google.com/issues/526074807