### PR TITLE
[Core] Add `LocationCompat.isComplete()` (b/514413542)

### DIFF
--- a/core/core/src/androidTest/java/androidx/core/location/LocationCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/location/LocationCompatTest.java
@@ -24,6 +24,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import android.location.Location;
+import android.location.LocationManager;
 import android.os.SystemClock;
 
 import androidx.test.filters.SmallTest;
@@ -125,5 +126,19 @@ public class LocationCompatTest {
         assertTrue(LocationCompat.isMock(location));
         LocationCompat.setMock(location, false);
         assertFalse(LocationCompat.isMock(location));
+    }
+
+    @Test
+    public void testIsComplete() {
+        Location location = new Location((String) null);
+        assertFalse(LocationCompat.isComplete(location)); // No provider
+        location.setProvider(LocationManager.GPS_PROVIDER);
+        assertFalse(LocationCompat.isComplete(location)); // No accuracy
+        location.setAccuracy(5f);
+        assertFalse(LocationCompat.isComplete(location)); // No time
+        location.setTime(System.currentTimeMillis());
+        assertFalse(LocationCompat.isComplete(location)); // No elapsed real time
+        location.setElapsedRealtimeNanos(SystemClock.elapsedRealtimeNanos());
+        assertTrue(LocationCompat.isComplete(location));
     }
 }

--- a/core/core/src/main/java/androidx/core/location/LocationCompat.java
+++ b/core/core/src/main/java/androidx/core/location/LocationCompat.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import android.annotation.SuppressLint;
 import android.location.Location;
+import android.location.LocationManager;
 import android.os.Build.VERSION;
 import android.os.Bundle;
 
@@ -510,6 +511,24 @@ public final class LocationCompat {
             }
     }
 
+    /**
+     * Return true if this location is considered complete. A location is considered complete if it
+     * has a non-null provider, accuracy, and non-zero time and elapsed realtime. The exact
+     * definition of completeness may change over time.
+     *
+     * <p>All locations supplied by the {@link LocationManager} are guaranteed to be complete.
+     */
+    public static boolean isComplete(@NonNull Location location) {
+        if (VERSION.SDK_INT >= 33) {
+            return Api33Impl.isComplete(location);
+        } else {
+            return location.getProvider() != null
+                    && location.hasAccuracy()
+                    && location.getTime() != 0
+                    && location.getElapsedRealtimeNanos() != 0;
+        }
+    }
+
     @RequiresApi(34)
     private static class Api34Impl {
 
@@ -565,6 +584,10 @@ public final class LocationCompat {
 
         static void removeBearingAccuracy(Location location) {
             location.removeBearingAccuracy();
+        }
+
+        static boolean isComplete(Location location) {
+            return location.isComplete();
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

- Add `LocationCompat.isComplete()`. The fallback implementation is based on [`Location.isComplete()`](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/location/Location.java;l=856-858).

## Testing

Test: I've added a test to cover the new method.

## Issues Fixed

Fixes: [b/514413542](https://issuetracker.google.com/issues/514413542).
