### PR TITLE
Fix Room Index name docs markdown swallowing underscores

### DIFF
--- a/room3/room3-common/src/commonMain/kotlin/androidx/room3/Index.kt
+++ b/room3/room3-common/src/commonMain/kotlin/androidx/room3/Index.kt
@@ -76,9 +76,9 @@ public annotation class Index(
     val orders: Array<Order> = [],
 
     /**
-     * Name of the index. If not set, Room will set it to the list of columns joined by '_' and
-     * prefixed by "index_${tableName}". So if you have a table with name "Foo" and with an index of
-     * "bar" and "baz", generated index name will be "index_Foo_bar_baz". If you need to specify the
+     * Name of the index. If not set, Room will set it to the list of columns joined by `_` and
+     * prefixed by `index_${tableName}_`. So if you have a table with name `Foo` and with an index of
+     * `bar` and `baz`, generated index name will be `index_Foo_bar_baz`. If you need to specify the
      * index in a query, you should never rely on this name, instead, specify a name for your index
      * via this annotation value.
      *


### PR DESCRIPTION
https://developer.android.com/reference/androidx/room#getName()

In the resulting documentation page, the underscores used in the description were interpreted as markdown and thus not displayed as characters documenting the generated index name. Use of backticks preserves them and will display as intended when run through the markdown converter.

Additionally, a correction (assuming the worked example is correct) is included when describing the prefix.

## Proposed Changes

  - Use backticks in the method description to preserve underscore literals in output HTML
  - Add missing underscore in the described prefix after table name

## Testing

Test: None; this is a documentation change.

