### PR TITLE
Remove empty `println()` statement in KspType.kt

### DIFF
--- a/room3/room3-compiler-processing/src/main/java/androidx/room3/compiler/processing/ksp/KspType.kt
+++ b/room3/room3-compiler-processing/src/main/java/androidx/room3/compiler/processing/ksp/KspType.kt
@@ -200,7 +200,6 @@ internal abstract class KspType(
             emptyList()
         } else {
             val typeArguments = ksType.arguments.map { env.wrap(it) }
-            println()
             if (ksType.isSuspendFunctionType || typeElement?.isValueClass() == true) {
                 // For inline value and suspend function types the Java and Kotlin TypeName isn't
                 // guaranteed to be the same shape. For example, SuspendFunction1<P1, R> translates


### PR DESCRIPTION
This was probably used as a debugging call [during development](https://android-review.googlesource.com/c/platform/frameworks/support/+/4067261/16/room3/room3-compiler-processing/src/main/java/androidx/room3/compiler/processing/ksp/KspType.kt#203), but it currently produces hundreds of empty log lines on large projects during ksp compilation task.

## Proposed Changes

  - Removed the empty `println()` call

## Issues Fixed

Fixes: https://issuetracker.google.com/issues/532893031
Test: n/a