### PR TITLE
Add SavedState optimization for collections of nullable CharSequence/Parcelable

### DIFF
--- a/savedstate/savedstate/src/androidHostTest/kotlin/androidx/savedstate/SavedStateCodecAndroidTest.android.kt
+++ b/savedstate/savedstate/src/androidHostTest/kotlin/androidx/savedstate/SavedStateCodecAndroidTest.android.kt
@@ -663,6 +663,26 @@ internal class SavedStateCodecAndroidTest : RobolectricTest() {
                     )
             }
 
+        arrayOf<CharSequence?>("foo", null, "bar").encodeDecode {
+            assertThat(size()).isEqualTo(1)
+            assertThat(getCharSequenceArray(""))
+                .isEqualTo(arrayOf<CharSequence?>("foo", null, "bar"))
+        }
+        arrayOf<Parcelable?>(MyParcelable(3, "foo", 3.14), null).encodeDecode {
+            assertThat(size()).isEqualTo(1)
+            assertThat(getParcelableArray<Parcelable>(""))
+                .isEqualTo(arrayOf<Parcelable?>(MyParcelable(3, "foo", 3.14), null))
+        }
+        listOf<CharSequence?>("foo", null, "bar").encodeDecode {
+            assertThat(size()).isEqualTo(1)
+            assertThat(getCharSequenceList("")).isEqualTo(listOf<CharSequence?>("foo", null, "bar"))
+        }
+        listOf<Parcelable?>(MyParcelable(3, "foo", 3.14), null).encodeDecode {
+            assertThat(size()).isEqualTo(1)
+            assertThat(getParcelableList<Parcelable>(""))
+                .isEqualTo(listOf<Parcelable?>(MyParcelable(3, "foo", 3.14), null))
+        }
+
         SparseArray<Parcelable?>()
             .apply {
                 append(1, MyParcelable(3, "foo", 3.14))

--- a/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateCodecUtils.android.kt
+++ b/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateCodecUtils.android.kt
@@ -43,20 +43,30 @@ internal val parcelableArrayDescriptor = ArraySerializer(DefaultParcelableSerial
 @OptIn(ExperimentalSerializationApi::class)
 internal val polymorphicParcelableArrayDescriptor =
     ArraySerializer(PolymorphicSerializer(Parcelable::class)).descriptor
+@OptIn(ExperimentalSerializationApi::class)
+internal val nullablePolymorphicParcelableArrayDescriptor =
+    ArraySerializer(PolymorphicSerializer(Parcelable::class).nullable).descriptor
 
 internal val parcelableListDescriptor = ListSerializer(DefaultParcelableSerializer).descriptor
 internal val polymorphicParcelableListDescriptor =
     ListSerializer(PolymorphicSerializer(Parcelable::class)).descriptor
+internal val nullablePolymorphicParcelableListDescriptor =
+    ListSerializer(PolymorphicSerializer(Parcelable::class).nullable).descriptor
 
 @OptIn(ExperimentalSerializationApi::class)
 internal val charSequenceArrayDescriptor = ArraySerializer(CharSequenceSerializer).descriptor
 @OptIn(ExperimentalSerializationApi::class)
 internal val polymorphicCharSequenceArrayDescriptor =
     ArraySerializer(PolymorphicSerializer(CharSequence::class)).descriptor
+@OptIn(ExperimentalSerializationApi::class)
+internal val nullablePolymorphicCharSequenceArrayDescriptor =
+    ArraySerializer(PolymorphicSerializer(CharSequence::class).nullable).descriptor
 
 internal val charSequenceListDescriptor = ListSerializer(CharSequenceSerializer).descriptor
 internal val polymorphicCharSequenceListDescriptor =
     ListSerializer(PolymorphicSerializer(CharSequence::class)).descriptor
+internal val nullablePolymorphicCharSequenceListDescriptor =
+    ListSerializer(PolymorphicSerializer(CharSequence::class).nullable).descriptor
 
 internal val sparseParcelableArrayDescriptor =
     SparseArraySerializer(DefaultParcelableSerializer).descriptor

--- a/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateDecoder.android.kt
+++ b/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateDecoder.android.kt
@@ -45,17 +45,23 @@ internal actual fun <T> SavedStateDecoder.decodeFormatSpecificTypesOnPlatform(
         polymorphicJavaSerializableDescriptor -> DefaultJavaSerializableSerializer.deserialize(this)
         polymorphicIBinderDescriptor -> IBinderSerializer.deserialize(this)
         charSequenceArrayDescriptor,
-        polymorphicCharSequenceArrayDescriptor -> CharSequenceArraySerializer.deserialize(this)
+        polymorphicCharSequenceArrayDescriptor,
+        nullablePolymorphicCharSequenceArrayDescriptor ->
+            CharSequenceArraySerializer.deserialize(this)
         charSequenceListDescriptor,
-        polymorphicCharSequenceListDescriptor -> CharSequenceListSerializer.deserialize(this)
+        polymorphicCharSequenceListDescriptor,
+        nullablePolymorphicCharSequenceListDescriptor ->
+            CharSequenceListSerializer.deserialize(this)
         parcelableArrayDescriptor -> {
             val parcelableArr = ParcelableArraySerializer.deserialize(this)
             val arrayKClass = getArrayKClass(strategy)
             Arrays.copyOf(parcelableArr, parcelableArr.size, arrayKClass.java)
         }
-        polymorphicParcelableArrayDescriptor -> ParcelableArraySerializer.deserialize(this)
+        polymorphicParcelableArrayDescriptor,
+        nullablePolymorphicParcelableArrayDescriptor -> ParcelableArraySerializer.deserialize(this)
         parcelableListDescriptor,
-        polymorphicParcelableListDescriptor -> ParcelableListSerializer.deserialize(this)
+        polymorphicParcelableListDescriptor,
+        nullablePolymorphicParcelableListDescriptor -> ParcelableListSerializer.deserialize(this)
         sparseParcelableArrayDescriptor,
         polymorphicSparseParcelableArrayDescriptor,
         nullablePolymorphicSparseParcelableArrayDescriptor ->

--- a/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateEncoder.android.kt
+++ b/savedstate/savedstate/src/androidMain/kotlin/androidx/savedstate/serialization/SavedStateEncoder.android.kt
@@ -44,16 +44,20 @@ internal actual fun <T> SavedStateEncoder.encodeFormatSpecificTypesOnPlatform(
             DefaultJavaSerializableSerializer.serialize(this, value as JavaSerializable)
         polymorphicIBinderDescriptor -> IBinderSerializer.serialize(this, value as IBinder)
         charSequenceArrayDescriptor,
-        polymorphicCharSequenceArrayDescriptor ->
+        polymorphicCharSequenceArrayDescriptor,
+        nullablePolymorphicCharSequenceArrayDescriptor ->
             CharSequenceArraySerializer.serialize(this, value as Array<CharSequence>)
         charSequenceListDescriptor,
-        polymorphicCharSequenceListDescriptor ->
+        polymorphicCharSequenceListDescriptor,
+        nullablePolymorphicCharSequenceListDescriptor ->
             CharSequenceListSerializer.serialize(this, value as List<CharSequence>)
         parcelableArrayDescriptor,
-        polymorphicParcelableArrayDescriptor ->
+        polymorphicParcelableArrayDescriptor,
+        nullablePolymorphicParcelableArrayDescriptor ->
             ParcelableArraySerializer.serialize(this, value as Array<Parcelable>)
         parcelableListDescriptor,
-        polymorphicParcelableListDescriptor ->
+        polymorphicParcelableListDescriptor,
+        nullablePolymorphicParcelableListDescriptor ->
             ParcelableListSerializer.serialize(this, value as List<Parcelable>)
         sparseParcelableArrayDescriptor,
         polymorphicSparseParcelableArrayDescriptor,


### PR DESCRIPTION
## Proposed Changes

- Add four internal serial descriptors for `Array<CharSequence?>`, `List<CharSequence?>`, `Array<Parcelable?>` and `List<Parcelable?>` in `SavedStateCodecUtils.android.kt`, mirroring the existing `nullablePolymorphicSparseParcelableArrayDescriptor` pattern used for `SparseArray<Parcelable?>`
- Route the new descriptors to the existing built-in serializers (`CharSequenceArraySerializer`, `CharSequenceListSerializer`, `ParcelableArraySerializer`, `ParcelableListSerializer`) in `SavedStateEncoder.android.kt` and `SavedStateDecoder.android.kt`, so these types get the direct single-entry representation instead of falling back to the generic collection encoding
- Add round-trip test cases for all four types to `SavedStateCodecAndroidTest.canUseBuiltInSerializersAutomatically`, verifying the single-entry representation and null element preservation

The underlying `SavedState`/`Bundle` APIs already preserve null elements, so no serializer changes are needed. All added declarations are internal; there are no public API changes.

## Testing

Test: ./gradlew :savedstate:savedstate:testAndroidHostTest

Full savedstate host test suite passes (424 tests, 0 failures). The new test cases fail against the previous implementation (the collections were encoded generically as one entry per element) and pass with this change (single direct entry, nulls preserved).

## Issues Fixed

Fixes: b/400696665
