### PR TITLE
Run SavedStateTest through platform parceling via platformEncodeDecode

### DIFF
--- a/savedstate/savedstate/src/androidDeviceTest/kotlin/androidx/savedstate/ParceledSavedStateTest.android.kt
+++ b/savedstate/savedstate/src/androidDeviceTest/kotlin/androidx/savedstate/ParceledSavedStateTest.android.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.savedstate
+
+import androidx.savedstate.serialization.platformEncodeDecode
+
+/**
+ * Runs all of [SavedStateTest] with every state under test additionally routed through the
+ * platform's parceling and unparceling logic, to simulate real-world behavior.
+ */
+internal class ParceledSavedStateTest : SavedStateTest() {
+    override fun postProcessCreated(savedState: SavedState): SavedState =
+        platformEncodeDecode(savedState)
+}

--- a/savedstate/savedstate/src/androidHostTest/kotlin/androidx/savedstate/ParceledSavedStateTest.android.kt
+++ b/savedstate/savedstate/src/androidHostTest/kotlin/androidx/savedstate/ParceledSavedStateTest.android.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package androidx.savedstate
+
+import androidx.savedstate.serialization.platformEncodeDecode
+
+/**
+ * Runs all of [SavedStateTest] with every state under test additionally routed through the
+ * platform's parceling and unparceling logic, to simulate real-world behavior.
+ */
+internal class ParceledSavedStateTest : SavedStateTest() {
+    override fun postProcessCreated(savedState: SavedState): SavedState =
+        platformEncodeDecode(savedState)
+}

--- a/savedstate/savedstate/src/commonTest/kotlin/androidx/savedstate/SavedStateTest.kt
+++ b/savedstate/savedstate/src/commonTest/kotlin/androidx/savedstate/SavedStateTest.kt
@@ -23,14 +23,39 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.serializer
 
 @IgnoreWebTarget
-internal class SavedStateTest : RobolectricTest() {
+internal open class SavedStateTest : RobolectricTest() {
+
+    /**
+     * Post-processes a [SavedState] under test right after it is created. The default
+     * implementation returns the state unchanged. Platform-specific subclasses can override this to
+     * simulate real-world behavior, e.g. routing the state through parceling on Android.
+     */
+    protected open fun postProcessCreated(savedState: SavedState): SavedState = savedState
+
+    /**
+     * Shadows the top-level [androidx.savedstate.savedState] factory inside this class so that
+     * every state under test is routed through [postProcessCreated].
+     */
+    protected fun savedState(
+        initialState: Map<String, Any?> = emptyMap(),
+        builderAction: SavedStateWriter.() -> Unit = {},
+    ): SavedState = postProcessCreated(androidx.savedstate.savedState(initialState, builderAction))
+
+    /**
+     * Shadows the top-level [androidx.savedstate.savedState] factory inside this class so that
+     * every state under test is routed through [postProcessCreated].
+     */
+    protected fun savedState(
+        initialState: SavedState,
+        builderAction: SavedStateWriter.() -> Unit = {},
+    ): SavedState = postProcessCreated(androidx.savedstate.savedState(initialState, builderAction))
 
     @Test
     fun factory_withMap_hasInitialState() {
-        val oldState = createDefaultSavedState().read { toMap() }
-        val newState = savedState(oldState).read { toMap() }
+        val oldState = createDefaultSavedState()
+        val newState = savedState(oldState.read { toMap() })
 
-        assertThat(newState).isEqualTo(oldState)
+        assertThat(newState.read { contentDeepEquals(oldState) }).isTrue()
     }
 
     @Test
@@ -318,8 +343,11 @@ internal class SavedStateTest : RobolectricTest() {
 
         val actual = parentState.read { toMap() }
 
-        val expected = mapOf(KEY_1 to Int.MAX_VALUE, KEY_2 to null, KEY_3 to sharedState)
-        assertThat(actual).containsExactlyEntriesIn(expected)
+        assertThat(actual.keys).containsExactly(KEY_1, KEY_2, KEY_3)
+        assertThat(actual[KEY_1]).isEqualTo(Int.MAX_VALUE)
+        assertThat(actual[KEY_2]).isNull()
+        val actualSharedState = actual[KEY_3] as SavedState
+        assertThat(actualSharedState.read { contentDeepEquals(sharedState) }).isTrue()
     }
 
     // region getters and setters
@@ -818,7 +846,10 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedStateList(KEY_1, expected) }
         val actual = underTest.read { getSavedStateList(KEY_1) }
 
-        assertThat(actual).isEqualTo(expected)
+        assertThat(actual.size).isEqualTo(expected.size)
+        for (index in expected.indices) {
+            assertThat(actual[index].read { contentDeepEquals(expected[index]) }).isTrue()
+        }
     }
 
     @Test
@@ -840,7 +871,11 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedStateList(KEY_1, expected) }
         val actual = underTest.read { getSavedStateListOrNull(KEY_1) }
 
-        assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isNotNull()
+        assertThat(actual!!.size).isEqualTo(expected.size)
+        for (index in expected.indices) {
+            assertThat(actual[index].read { contentDeepEquals(expected[index]) }).isTrue()
+        }
     }
 
     @Test
@@ -1286,7 +1321,10 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedStateArray(KEY_1, expected) }
         val actual = underTest.read { getSavedStateArray(KEY_1) }
 
-        assertThat(actual).isEqualTo(expected)
+        assertThat(actual.size).isEqualTo(expected.size)
+        for (index in expected.indices) {
+            assertThat(actual[index].read { contentDeepEquals(expected[index]) }).isTrue()
+        }
     }
 
     @Test
@@ -1308,7 +1346,11 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedStateArray(KEY_1, expected) }
         val actual = underTest.read { getSavedStateArrayOrNull(KEY_1) }
 
-        assertThat(actual).isEqualTo(expected)
+        assertThat(actual).isNotNull()
+        assertThat(actual!!.size).isEqualTo(expected.size)
+        for (index in expected.indices) {
+            assertThat(actual[index].read { contentDeepEquals(expected[index]) }).isTrue()
+        }
     }
 
     @Test
@@ -1386,7 +1428,7 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedState(KEY_1, SAVED_STATE_VALUE) }
         val actual = underTest.read { getSavedState(KEY_1) }
 
-        assertThat(actual).isEqualTo(SAVED_STATE_VALUE)
+        assertThat(actual.read { contentDeepEquals(SAVED_STATE_VALUE) }).isTrue()
     }
 
     @Test
@@ -1406,7 +1448,8 @@ internal class SavedStateTest : RobolectricTest() {
         val underTest = savedState { putSavedState(KEY_1, SAVED_STATE_VALUE) }
         val actual = underTest.read { getSavedStateOrNull(KEY_1) }
 
-        assertThat(actual).isEqualTo(SAVED_STATE_VALUE)
+        assertThat(actual).isNotNull()
+        assertThat(actual!!.read { contentDeepEquals(SAVED_STATE_VALUE) }).isTrue()
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

- Route every state under test in `SavedStateTest` through an overridable `postProcessCreated` hook (a no-op by default) by shadowing the top-level `savedState` factories inside the test class
- Add a `ParceledSavedStateTest` subclass (in androidHostTest and androidDeviceTest) that overrides the hook with the existing `platformEncodeDecode` from `SavedStateCodecTestUtils`, so all 187 tests additionally run against a state that went through Parcel writing, byte marshalling, and unparceling, matching the treatment the serialization tests already get
- Convert 8 assertions from reference equality to `contentDeepEquals`-based structural comparison. The parceled run uncovered that these relied on reference equality of values without structural equals (`SavedState`/`Bundle` instances, and arrays inside maps) and only passed because the reader returns the stored instances when no parceling is involved. This matches the approach already used by `factory_withSavedState_hasInitialState` and the codec tests

## Testing

Test: ./gradlew :savedstate:savedstate:testAndroidHostTest

`SavedStateTest` (187 tests) and `ParceledSavedStateTest` (187 tests) both pass; full module host suite: 611 tests, 0 failures. The androidDeviceTest sources compile as well.

## Issues Fixed

Fixes: b/402141515