### PR TITLE
Flag Isolated Projects violations on build service registrations

### DIFF
--- a/lint/lint-gradle/src/main/java/androidx/lint/gradle/DiscouragedGradleMethodDetector.kt
+++ b/lint/lint-gradle/src/main/java/androidx/lint/gradle/DiscouragedGradleMethodDetector.kt
@@ -27,6 +27,8 @@ import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiWildcardType
+import com.intellij.psi.util.PsiUtil
 import org.jetbrains.kotlin.psi.KtSimpleNameStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.uast.UBinaryExpression
@@ -48,6 +50,7 @@ class DiscouragedGradleMethodDetector : Detector(), Detector.UastScanner {
         object : UElementHandler() {
             override fun visitCallExpression(node: UCallExpression) {
                 checkForConfigurationToConfigurableFileCollection(node)
+                checkForBuildServiceRegistrationsAccess(node)
                 val methodName = node.methodName
                 val potentialReplacements = REPLACEMENTS[methodName] ?: return
                 val method = node.resolve() ?: return
@@ -117,6 +120,69 @@ class DiscouragedGradleMethodDetector : Detector(), Detector.UastScanner {
                                 "configuration.incoming.artifactView {}.files to wrap the " +
                                 "configuration making it lazy."
                         )
+                        .scope(node)
+                context.report(incident)
+            }
+
+            /**
+             * Checks for calls on `BuildServiceRegistry.getRegistrations()`. When Isolated Projects
+             * is enabled Gradle reports a violation for every method called on the registrations
+             * collection except `findByName(String)`.
+             */
+            private fun checkForBuildServiceRegistrationsAccess(node: UCallExpression) {
+                val methodName = node.methodName ?: return
+                if (methodName == "findByName") return
+                val receiverType = node.receiverType as? PsiClassType ?: return
+                val receiverClass = receiverType.resolve() ?: return
+                if (!receiverClass.isInstanceOf(NAMED_DOMAIN_OBJECT_COLLECTION)) return
+                // Resolves the collection's element type: the type argument substituted for the
+                // T in NamedDomainObjectCollection<T>, computed through the receiver's type
+                // hierarchy (e.g. BuildServiceRegistration<?, ?> for a receiver typed as
+                // NamedDomainObjectSet<BuildServiceRegistration<?, ?>>). eraseTypeParameter is
+                // false because erasure only applies when substitution returns null (raw types);
+                // wildcard type arguments are returned as-is either way and unwrapped below.
+                val elementType =
+                    PsiUtil.substituteTypeParameter(
+                        receiverType,
+                        NAMED_DOMAIN_OBJECT_COLLECTION,
+                        0,
+                        false,
+                    )
+                val elementClass =
+                    when (elementType) {
+                        is PsiWildcardType -> (elementType.bound as? PsiClassType)?.resolve()
+                        is PsiClassType -> elementType.resolve()
+                        else -> null
+                    } ?: return
+                if (!elementClass.isInstanceOf(BUILD_SERVICE_REGISTRATION)) return
+                // Only flag methods of the collection itself, not unrelated extension functions
+                // such as Kotlin scope functions.
+                val containingClassName = node.resolve()?.containingClass?.qualifiedName ?: return
+                if (!receiverClass.isInstanceOf(containingClassName)) return
+
+                val recommendedReplacement =
+                    if (methodName in REGISTRATIONS_NAME_LOOKUP_METHODS) "findByName" else null
+                val fix =
+                    recommendedReplacement?.let {
+                        fix()
+                            .replace()
+                            .with(it)
+                            .reformat(true)
+                            // Don't auto-fix from the command line because findByName has a
+                            // nullable return type, so the fixed code likely won't compile.
+                            .autoFix(robot = false, independent = false)
+                            .build()
+                    }
+                val target = "on the build service registrations collection"
+                val message =
+                    recommendedReplacement?.let { "Use $it instead of $methodName $target" }
+                        ?: "Avoid using method $methodName $target"
+                val incident =
+                    Incident(context)
+                        .issue(PROJECT_ISOLATION_ISSUE)
+                        .location(context.getNameLocation(node))
+                        .message(message)
+                        .fix(fix)
                         .scope(node)
                 context.report(incident)
             }
@@ -197,6 +263,8 @@ class DiscouragedGradleMethodDetector : Detector(), Detector.UastScanner {
         private const val TASK_PROVIDER = "org.gradle.api.tasks.TaskProvider"
         private const val DOMAIN_OBJECT_COLLECTION = "org.gradle.api.DomainObjectCollection"
         private const val TASK_COLLECTION = "org.gradle.api.tasks.TaskCollection"
+        private const val BUILD_SERVICE_REGISTRATION =
+            "org.gradle.api.services.BuildServiceRegistration"
         private const val NAMED_DOMAIN_OBJECT_COLLECTION =
             "org.gradle.api.NamedDomainObjectCollection"
         private const val PROVIDER = "org.gradle.api.provider.Provider"
@@ -276,6 +344,10 @@ class DiscouragedGradleMethodDetector : Detector(), Detector.UastScanner {
                 Severity.ERROR,
                 Implementation(DiscouragedGradleMethodDetector::class.java, Scope.JAVA_FILE_SCOPE),
             )
+
+        // Name-based lookup methods on BuildServiceRegistry.getRegistrations() that have
+        // findByName as a direct replacement.
+        private val REGISTRATIONS_NAME_LOOKUP_METHODS = setOf("getAt", "getByName", "named")
 
         // A map from eager method name to the containing class of the method and the name of the
         // replacement method, if there is a direct equivalent.

--- a/lint/lint-gradle/src/test/java/androidx/lint/gradle/ProjectIsolationIssueTest.kt
+++ b/lint/lint-gradle/src/test/java/androidx/lint/gradle/ProjectIsolationIssueTest.kt
@@ -175,4 +175,169 @@ class ProjectIsolationIssueTest :
 
         check(input).expect(expected)
     }
+
+    @Test
+    fun `Test usage of getAt on build service registrations`() {
+        val input =
+            kotlin(
+                """
+                import org.gradle.api.invocation.Gradle
+
+                fun getService(gradle: Gradle) {
+                    gradle.sharedServices.registrations.getAt("example")
+                }
+                """
+                    .trimIndent()
+            )
+
+        val expected =
+            """
+            src/test.kt:4: Error: Use findByName instead of getAt on the build service registrations collection [GradleProjectIsolation]
+                gradle.sharedServices.registrations.getAt("example")
+                                                    ~~~~~
+            1 errors, 0 warnings
+            """
+                .trimIndent()
+        val expectedFixDiffs =
+            """
+            Fix for src/test.kt line 4: Replace with findByName:
+            @@ -4 +4
+            -     gradle.sharedServices.registrations.getAt("example")
+            +     gradle.sharedServices.registrations.findByName("example")
+            """
+                .trimIndent()
+
+        check(input).expect(expected).expectFixDiffs(expectedFixDiffs)
+    }
+
+    @Test
+    fun `Test usage of named on build service registrations`() {
+        val input =
+            kotlin(
+                """
+                import org.gradle.api.invocation.Gradle
+
+                fun getService(gradle: Gradle) {
+                    gradle.sharedServices.registrations.named("example")
+                }
+                """
+                    .trimIndent()
+            )
+
+        val expected =
+            """
+            src/test.kt:4: Error: Use findByName instead of named on the build service registrations collection [GradleProjectIsolation]
+                gradle.sharedServices.registrations.named("example")
+                                                    ~~~~~
+            1 errors, 0 warnings
+            """
+                .trimIndent()
+        val expectedFixDiffs =
+            """
+            Fix for src/test.kt line 4: Replace with findByName:
+            @@ -4 +4
+            -     gradle.sharedServices.registrations.named("example")
+            +     gradle.sharedServices.registrations.findByName("example")
+            """
+                .trimIndent()
+
+        check(input).expect(expected).expectFixDiffs(expectedFixDiffs)
+    }
+
+    @Test
+    fun `Test usage of getByName on build service registrations`() {
+        val input =
+            kotlin(
+                """
+                import org.gradle.api.invocation.Gradle
+
+                fun getService(gradle: Gradle) {
+                    gradle.sharedServices.registrations.getByName("example")
+                }
+                """
+                    .trimIndent()
+            )
+
+        val expected =
+            """
+            src/test.kt:4: Error: Use findByName instead of getByName on the build service registrations collection [GradleProjectIsolation]
+                gradle.sharedServices.registrations.getByName("example")
+                                                    ~~~~~~~~~
+            1 errors, 0 warnings
+            """
+                .trimIndent()
+        val expectedFixDiffs =
+            """
+            Fix for src/test.kt line 4: Replace with findByName:
+            @@ -4 +4
+            -     gradle.sharedServices.registrations.getByName("example")
+            +     gradle.sharedServices.registrations.findByName("example")
+            """
+                .trimIndent()
+
+        check(input).expect(expected).expectFixDiffs(expectedFixDiffs)
+    }
+
+    @Test
+    fun `Test usage of findAll on build service registrations`() {
+        val input =
+            kotlin(
+                """
+                import groovy.lang.Closure
+                import org.gradle.api.invocation.Gradle
+
+                fun findServices(gradle: Gradle, closure: Closure) {
+                    gradle.sharedServices.registrations.findAll(closure)
+                }
+                """
+                    .trimIndent()
+            )
+
+        val expected =
+            """
+            src/test.kt:5: Error: Avoid using method findAll on the build service registrations collection [GradleProjectIsolation]
+                gradle.sharedServices.registrations.findAll(closure)
+                                                    ~~~~~~~
+            1 errors, 0 warnings
+            """
+                .trimIndent()
+
+        check(input).expect(expected)
+    }
+
+    @Test
+    fun `Test allowed usages of build service registrations`() {
+        val input =
+            kotlin(
+                """
+                import org.gradle.api.invocation.Gradle
+
+                fun configureServices(gradle: Gradle) {
+                    gradle.sharedServices.registerIfAbsent("example", Any::class.java)
+                    gradle.sharedServices.registrations.findByName("example")
+                    gradle.sharedServices.registrations.let { }
+                }
+                """
+                    .trimIndent()
+            )
+
+        check(input).expectClean()
+    }
+
+    @Test
+    fun `Test getAt on other collections is not a project isolation violation`() {
+        val input =
+            kotlin(
+                """
+                import org.gradle.api.Project
+
+                fun configure(project: Project) {
+                    project.tasks.getAt("example")
+                }
+                """
+                    .trimIndent()
+            )
+
+        check(input).expectClean()
+    }
 }

--- a/lint/lint-gradle/src/test/java/androidx/lint/gradle/Stubs.kt
+++ b/lint/lint-gradle/src/test/java/androidx/lint/gradle/Stubs.kt
@@ -67,8 +67,8 @@ internal val STUBS =
                 fun remove(task: Task) = Unit
             }
 
-            interface TaskCollection<T : Task> {
-                fun getAt(name: String) = Unit
+            interface TaskCollection<T : Task> : NamedDomainObjectCollection<T> {
+                override fun getAt(name: String): T
                 fun matching(closure: Closure) = Unit
             }
             interface TaskProvider<T : Task> : Provider<T>
@@ -135,9 +135,14 @@ internal val STUBS =
             }
 
             interface NamedDomainObjectCollection<T> : Collection<T>, DomainObjectCollection<T>, Iterable<T> {
-                fun findByName(name: String) = Unit
+                fun findByName(name: String): T? = null
                 fun findAll(closure: Closure) = Unit
+                fun getAt(name: String): T
+                fun getByName(name: String): T
+                fun named(name: String): Any = Unit
             }
+
+            interface NamedDomainObjectSet<T> : NamedDomainObjectCollection<T>
 
             interface DomainObjectCollection<T> {
                 fun all(action: Action<in T>)
@@ -167,6 +172,38 @@ internal val STUBS =
             package groovy.lang
 
             class Closure
+            """
+                .trimIndent()
+        ),
+        kotlin(
+            """
+            package org.gradle.api.services
+
+            import org.gradle.api.NamedDomainObjectSet
+            import org.gradle.api.provider.Provider
+
+            interface BuildService<P>
+
+            interface BuildServiceRegistration<T, P> {
+                fun getService(): Provider<T>
+            }
+
+            interface BuildServiceRegistry {
+                val registrations: NamedDomainObjectSet<BuildServiceRegistration<*, *>>
+                fun registerIfAbsent(name: String, implementationType: Class<*>): Provider<*>
+            }
+            """
+                .trimIndent()
+        ),
+        kotlin(
+            """
+            package org.gradle.api.invocation
+
+            import org.gradle.api.services.BuildServiceRegistry
+
+            interface Gradle {
+                val sharedServices: BuildServiceRegistry
+            }
             """
                 .trimIndent()
         ),


### PR DESCRIPTION
## Proposed Changes

Add new lint check for isolated projects violations on `BuildServiceRegistry`

Since Gradle 9.7 only `findByName` is permitted on `BuildServiceRegistry.getRegistrations()` when Isolated Projects is enabled (see gradle/gradle#37622). Report all other method calls under `GradleProjectIsolation` and suggest `findByName` for name lookups.

## Testing

Test: Integration tests are included
