### PR TITLE
Using sdkmanager NDK installed in playground

### DIFF
--- a/.github/actions/build-single-project/action.yml
+++ b/.github/actions/build-single-project/action.yml
@@ -49,7 +49,7 @@ runs:
       shell: bash
       run: |
         set -x
-        NDK_VERSION=$(grep "ndkVersion" buildSrc/ndk.gradle | awk -F "=" '{gsub(/"| /, ""); print $2}')
+        NDK_VERSION=$(grep "androidx.ndkVersion" gradle.properties | awk -F "=" '{gsub(/"| /, ""); print $2}')
         echo "yes" | $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;$NDK_VERSION"
     - name: "Install Android SDK Build-Tools"
       shell: bash

--- a/buildSrc-tests/src/test/java/androidx/build/clang/BaseClangTest.kt
+++ b/buildSrc-tests/src/test/java/androidx/build/clang/BaseClangTest.kt
@@ -48,6 +48,18 @@ abstract class BaseClangTest {
         // ensure that kotlin doesn't try to download prebuilts
         extension.set("kotlin.native.distribution.downloadFromMaven", "false")
         extension.set("supportRootFolder", File(projectSetup.props.rootProjectPath))
+
+        val rootProjectPath = File(projectSetup.props.rootProjectPath)
+        val gradlePropertiesFile = rootProjectPath.resolve("gradle.properties")
+        if (gradlePropertiesFile.exists()) {
+            val properties = java.util.Properties()
+            gradlePropertiesFile.inputStream().use { properties.load(it) }
+            val ndkVersion = properties.getProperty("androidx.ndkVersion")
+            if (ndkVersion != null) {
+                extension.set("androidx.ndkVersion", ndkVersion)
+            }
+        }
+
         project.pluginManager.apply(KotlinMultiplatformPluginWrapper::class.java)
         clangExtension = AndroidXClang(project)
         KonanPrebuiltsSetup.configureKonanDirectory(project)

--- a/buildSrc/ndk.gradle
+++ b/buildSrc/ndk.gradle
@@ -1,3 +1,3 @@
 android {
-    ndkVersion = "27.0.12077973"
+    ndkVersion = providers.gradleProperty("androidx.ndkVersion").get()
 }

--- a/buildSrc/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/AndroidXGradleProperties.kt
@@ -115,6 +115,9 @@ const val FORCE_BENCHMARK_AOT_COMPILATION = "androidx.benchmark.forceaotcompilat
 
 const val ALLOW_LOCKFILE_MISMATCH = "androidx.allowLockfileMismatch"
 
+/** NDK version to use */
+const val NDK_VERSION = "androidx.ndkVersion"
+
 val ALL_ANDROIDX_PROPERTIES =
     setOf(
         ADD_GROUP_CONSTRAINTS,
@@ -145,7 +148,15 @@ val ALL_ANDROIDX_PROPERTIES =
         YARN_OFFLINE_MODE,
         FORCE_BENCHMARK_AOT_COMPILATION,
         ALLOW_LOCKFILE_MISMATCH,
+        NDK_VERSION,
     ) + AndroidConfigImpl.GRADLE_PROPERTIES
+
+/** Returns the NDK version to use for Android native compilation. */
+fun Project.getNdkVersion(): String {
+    val ndkVersionString = project.findProperty(NDK_VERSION)?.toString()
+    check(ndkVersionString != null) { "$NDK_VERSION is unset" }
+    return ndkVersionString
+}
 
 /**
  * Whether to enable constraints for projects in same-version groups See the property definition for

--- a/buildSrc/private/src/main/kotlin/androidx/build/clang/NdkResolvers.kt
+++ b/buildSrc/private/src/main/kotlin/androidx/build/clang/NdkResolvers.kt
@@ -18,11 +18,19 @@ package androidx.build.clang
 
 import androidx.build.OperatingSystem
 import androidx.build.getSdkPath
+import androidx.build.getNdkVersion
 import java.io.File
 import org.gradle.api.Project
 
 /** Resolves the NDK directory. */
 internal fun Project.getNdkDirectory(): File? {
+    // Try versioned NDK directory first (playground and sdkmanager install location)
+    val ndkVersion = getNdkVersion()
+    val versionedNdkDir = getSdkPath().resolve("ndk/$ndkVersion")
+    if (versionedNdkDir.exists()) {
+        return versionedNdkDir
+    }
+    // Try bundled directory as fallback, repo checkout with prebuilt.
     val ndkBundleDir = getSdkPath().resolve("ndk-bundle")
     return if (ndkBundleDir.exists()) ndkBundleDir else null
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -53,6 +53,8 @@ androidx.latestStableCompileSdk=37
 androidx.latestStableMinorApiLevel=0
 androidx.targetSdkVersion=36
 
+androidx.ndkVersion=27.0.12077973
+
 # Disable features we do not use
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false


### PR DESCRIPTION
Also moved the ndkVersion used in androidx to a Gradle property so it is accessible from buildSrc.

Bug: 537276977
Test: Github runner