### PR TITLE
Add key support to ComponentActivity viewModels

### DIFF
--- a/activity/activity/api/current.txt
+++ b/activity/activity/api/current.txt
@@ -8,6 +8,7 @@ package androidx.activity {
   }
 
   public final class ActivityViewModelLazyKt {
+    method @KotlinOnly @MainThread public static inline <reified T extends androidx.lifecycle.ViewModel> kotlin.Lazy<T> viewModels(androidx.activity.ComponentActivity, String key, optional kotlin.jvm.functions.Function0<androidx.lifecycle.viewmodel.CreationExtras>? extrasProducer, optional kotlin.jvm.functions.Function0<androidx.lifecycle.ViewModelProvider.Factory>? factoryProducer);
     method @KotlinOnly @MainThread public static inline <reified VM extends androidx.lifecycle.ViewModel> kotlin.Lazy<VM> viewModels(androidx.activity.ComponentActivity, optional kotlin.jvm.functions.Function0<androidx.lifecycle.viewmodel.CreationExtras>? extrasProducer, optional kotlin.jvm.functions.Function0<androidx.lifecycle.ViewModelProvider.Factory>? factoryProducer);
   }
 

--- a/activity/activity/api/restricted_current.txt
+++ b/activity/activity/api/restricted_current.txt
@@ -8,6 +8,7 @@ package androidx.activity {
   }
 
   public final class ActivityViewModelLazyKt {
+    method @KotlinOnly @MainThread public static inline <reified T extends androidx.lifecycle.ViewModel> kotlin.Lazy<T> viewModels(androidx.activity.ComponentActivity, String key, optional kotlin.jvm.functions.Function0<androidx.lifecycle.viewmodel.CreationExtras>? extrasProducer, optional kotlin.jvm.functions.Function0<androidx.lifecycle.ViewModelProvider.Factory>? factoryProducer);
     method @KotlinOnly @MainThread public static inline <reified VM extends androidx.lifecycle.ViewModel> kotlin.Lazy<VM> viewModels(androidx.activity.ComponentActivity, optional kotlin.jvm.functions.Function0<androidx.lifecycle.viewmodel.CreationExtras>? extrasProducer, optional kotlin.jvm.functions.Function0<androidx.lifecycle.ViewModelProvider.Factory>? factoryProducer);
   }
 

--- a/activity/activity/src/androidTest/java/androidx/activity/ActivityViewModelLazyTest.kt
+++ b/activity/activity/src/androidTest/java/androidx/activity/ActivityViewModelLazyTest.kt
@@ -48,13 +48,27 @@ class ActivityViewModelLazyTest {
         assertThat(activity.savedStateViewModel.defaultValue).isEqualTo("value")
     }
 
+    @UiThreadTest
+    @Test
+    fun keyedVmInitialization() {
+        val activity = activityRule.activity
+        assertThat(activity.keyedVM).isSameInstanceAs(activity.sameKeyedVM)
+        assertThat(activity.keyedVM).isNotSameInstanceAs(activity.otherKeyedVM)
+        assertThat(activity.keyedVM).isNotSameInstanceAs(activity.vm)
+        assertThat(activity.keyedSavedStateViewModel.defaultValue).isEqualTo("value")
+    }
+
     class TestActivity : ComponentActivity() {
         val vm: TestViewModel by viewModels()
+        val keyedVM: TestViewModel by viewModels(key = "one")
+        val sameKeyedVM: TestViewModel by viewModels(key = "one")
+        val otherKeyedVM: TestViewModel by viewModels(key = "two")
         val factoryVM: TestFactorizedViewModel by viewModels { VMFactory("activity") }
         lateinit var injectedFactory: ViewModelProvider.Factory
         val daggerPoorCopyVM: TestDaggerViewModel by viewModels { injectedFactory }
         val savedStateViewModel: TestSavedStateViewModel by
             viewModels(extrasProducer = { defaultViewModelCreationExtras })
+        val keyedSavedStateViewModel: TestSavedStateViewModel by viewModels(key = "saved-state")
 
         override fun onCreate(savedInstanceState: Bundle?) {
             injectedFactory = VMFactory("dagger")

--- a/activity/activity/src/main/java/androidx/activity/ActivityViewModelLazy.kt
+++ b/activity/activity/src/main/java/androidx/activity/ActivityViewModelLazy.kt
@@ -80,3 +80,35 @@ public inline fun <reified VM : ViewModel> ComponentActivity.viewModels(
         { extrasProducer?.invoke() ?: this.defaultViewModelCreationExtras },
     )
 }
+
+/**
+ * Returns a [Lazy] delegate for this [ComponentActivity]'s [ViewModel] identified by [key].
+ *
+ * Delegates with the same [key] and [ViewModel] type share the same instance. Different keys allow
+ * multiple instances of the same [ViewModel] type in this activity.
+ *
+ * ```
+ * class MyComponentActivity : ComponentActivity() {
+ *     val primaryViewModel: MyViewModel by viewModels(key = "primary")
+ *     val secondaryViewModel: MyViewModel by viewModels(key = "secondary")
+ * }
+ * ```
+ *
+ * This property can be accessed only after the Activity is attached to the Application. Access
+ * before that results in an [IllegalArgumentException].
+ *
+ * @param key identifier used to store and retrieve the [ViewModel]
+ * @param extrasProducer producer of the [CreationExtras] used to create the [ViewModel]
+ * @param factoryProducer producer of the [Factory] used to create the [ViewModel]
+ */
+@MainThread
+public inline fun <reified T : ViewModel> ComponentActivity.viewModels(
+    key: String,
+    noinline extrasProducer: (() -> CreationExtras)? = null,
+    noinline factoryProducer: (() -> Factory)? = null,
+): Lazy<T> =
+    lazy(LazyThreadSafetyMode.NONE) {
+        val factory = factoryProducer?.invoke() ?: defaultViewModelProviderFactory
+        val extras = extrasProducer?.invoke() ?: defaultViewModelCreationExtras
+        ViewModelProvider(viewModelStore, factory, extras)[key, T::class.java]
+    }


### PR DESCRIPTION
Add key support to `ComponentActivity.viewModels`.

This adds a required `key: String` overload so callers can retain multiple `ViewModel` instances of the same type in a `ComponentActivity`'s `ViewModelStore`. Existing delegate signatures remain unchanged, while the new overload preserves the default `CreationExtras` and factory behavior and documents keyed usage.

The instrumentation coverage verifies that the same key returns the same instance, different and default keys return distinct instances, and keyed `SavedStateHandle` creation continues to receive the activity's default extras.

Test: `./gradlew :activity:activity:connectedReleaseAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=androidx.activity.ActivityViewModelLazyTest`
Test: `./gradlew :activity:activity:lintRelease :activity:activity:testReleaseUnitTest :activity:activity:ktCheck`
Test: `./gradlew :activity:activity:checkApi`
Fixes: b/133130644
