### PR TITLE
Fix FragmentNavigator transition completion when a Fragment has no view

### DIFF
--- a/navigation/navigation-fragment/src/main/java/androidx/navigation/fragment/FragmentNavigator.kt
+++ b/navigation/navigation-fragment/src/main/java/androidx/navigation/fragment/FragmentNavigator.kt
@@ -93,8 +93,21 @@ public open class FragmentNavigator(
         get() = state.backStack
 
     private val fragmentObserver = LifecycleEventObserver { source, event ->
-        if (event == Lifecycle.Event.ON_DESTROY) {
-            val fragment = source as Fragment
+        val fragment = source as Fragment
+        if (event == Lifecycle.Event.ON_RESUME && fragment.view == null) {
+            val entry =
+                state.transitionsInProgress.value.lastOrNull { entry -> entry.id == fragment.tag }
+            if (entry != null && state.backStack.value.contains(entry)) {
+                if (isLoggingEnabled(Log.VERBOSE)) {
+                    Log.v(
+                        TAG,
+                        "Marking transition complete for entry $entry " +
+                            "due to viewless fragment $source lifecycle reaching RESUMED",
+                    )
+                }
+                state.markTransitionComplete(entry)
+            } 
+        } else if (event == Lifecycle.Event.ON_DESTROY) {
             val entry =
                 state.transitionsInProgress.value.lastOrNull { entry -> entry.id == fragment.tag }
             if (entry != null) {


### PR DESCRIPTION
## Proposed Changes

This PR addresses an issue in `FragmentNavigator`'s transition completion logic. An entry's upward
transition is only ever completed from the view lifecycle: `attachObservers` can add
`fragmentViewObserver` only inside `fragment.viewLifecycleOwnerLiveData.observe(...)`, and
`Fragment.performCreateView` publishes that LiveData only when `mView != null`. A destination whose
Fragment returns `null` from `onCreateView` therefore never has its transition completed until the
Fragment is destroyed.

The entry stays in `transitionsInProgress` for the Fragment's entire life with `maxLifecycle` capped
at `STARTED`, so it never reaches `RESUMED` — observable through `NavBackStackEntry.lifecycle`,
`currentBackStackEntryFlow` and `visibleEntries`. It also leaves the navigator's bookkeeping out of
step with the `FragmentManager`, which can surface later as a spurious "unknown to the
FragmentNavigator" crash.

`Fragment.onCreateView` is `@Nullable` and `performCreateView` has an explicit branch for the null
case, so a viewless destination is legal. This change falls back to the Fragment's own `ON_RESUME`
when the Fragment has no view. 

## Testing

Test: I tested the following scenario, which could cause:

> The fragment ... is unknown to the FragmentNavigator. Please use the navigate() function to add fragments to the FragmentNavigator managed FragmentManager.


Given a `singleTop` `MainActivity`:

1. Navigate from Fragment A to Fragment B, where Fragment B is viewless (returns `null` from
   `onCreateView`).
2. Fragment B starts another Activity.
3. Use a deeplink to navigate to Fragment C inside `MainActivity`.

The back stack is now:



Fragment A -> Fragment B (viewless) -> Fragment C


Pressing back should return to Fragment B, but instead it crashes reporting that **Fragment A** is
unknown to the `FragmentNavigator` — caused by Fragment B's transition never having completed, which
leaves the navigator's back stack out of step with the `FragmentManager`.

This change fixes the issue: Fragment B's transition completes on its own `ON_RESUME`, and pressing
back returns to Fragment B as expected.

