### PR TITLE
[Core] Add ProcessCompat.isIsolatedUid and ProcessCompat.isSdkSandboxUid

### DIFF
--- a/core/core/api/current.txt
+++ b/core/core/api/current.txt
@@ -2603,6 +2603,8 @@ package androidx.core.os {
 
   public final class ProcessCompat {
     method public static boolean isApplicationUid(int);
+    method public static boolean isIsolatedUid(int);
+    method public static boolean isSdkSandboxUid(int);
   }
 
   public final class Profiling {

--- a/core/core/api/restricted_current.txt
+++ b/core/core/api/restricted_current.txt
@@ -3022,6 +3022,8 @@ package androidx.core.os {
 
   public final class ProcessCompat {
     method public static boolean isApplicationUid(int);
+    method public static boolean isIsolatedUid(int);
+    method public static boolean isSdkSandboxUid(int);
   }
 
   public final class Profiling {

--- a/core/core/src/androidTest/java/androidx/core/os/ProcessCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/os/ProcessCompatTest.java
@@ -35,4 +35,22 @@ public class ProcessCompatTest {
         assertFalse("Test process is not an application",
                 ProcessCompat.isApplicationUid(1000));
     }
+
+    @Test
+    public void testIsIsolatedUid() {
+        assertFalse("Test process is not an isolated uid",
+                ProcessCompat.isIsolatedUid(Process.myUid()));
+        assertTrue("Isolated uid in range",
+                ProcessCompat.isIsolatedUid(99000));
+        assertFalse("System uid is not an isolated uid",
+                ProcessCompat.isIsolatedUid(1000));
+    }
+
+    @Test
+    public void testIsSdkSandboxUid() {
+        assertFalse("Test process is not an sdk sandbox uid",
+                ProcessCompat.isSdkSandboxUid(Process.myUid()));
+        assertFalse("System uid is not an sdk sandbox uid",
+                ProcessCompat.isSdkSandboxUid(1000));
+    }
 }

--- a/core/core/src/main/java/androidx/core/os/ProcessCompat.java
+++ b/core/core/src/main/java/androidx/core/os/ProcessCompat.java
@@ -57,6 +57,69 @@ public final class ProcessCompat {
         }
     }
 
+    /**
+     * Returns whether the given {@code uid} belongs to an isolated process.
+     *
+     * Compatibility behavior:
+     * <ul>
+     * <li>SDK 28 and above, this method matches platform behavior.
+     * <li>SDK 27 and earlier, this method checks if the uid is in the isolated UID range.
+     * </ul>
+     *
+     * @param uid a kernel uid
+     * @return {@code true} if the uid corresponds to an isolated process, {@code false} otherwise
+     */
+    public static boolean isIsolatedUid(int uid) {
+        if (Build.VERSION.SDK_INT >= 28) {
+            return Api28Impl.isIsolatedUid(uid);
+        } else {
+            int appId = uid % 100000;
+            return appId >= 99000 && appId <= 99999;
+        }
+    }
+
+    /**
+     * Returns whether the given {@code uid} belongs to an SDK sandbox process.
+     *
+     * Compatibility behavior:
+     * <ul>
+     * <li>SDK 33 and above, this method matches platform behavior.
+     * <li>SDK 32 and earlier, returns {@code false} as SDK sandbox processes did not exist.
+     * </ul>
+     *
+     * @param uid a kernel uid
+     * @return {@code true} if the uid corresponds to an SDK sandbox process, {@code false} otherwise
+     */
+    public static boolean isSdkSandboxUid(int uid) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            return Api33Impl.isSdkSandboxUid(uid);
+        } else {
+            return false;
+        }
+    }
+
+    @RequiresApi(33)
+    static class Api33Impl {
+        private Api33Impl() {
+            // This class is non-instantiable.
+        }
+
+        static boolean isSdkSandboxUid(int uid) {
+            return Process.isSdkSandboxUid(uid);
+        }
+    }
+
+    @RequiresApi(28)
+    static class Api28Impl {
+        private Api28Impl() {
+            // This class is non-instantiable.
+        }
+
+        static boolean isIsolatedUid(int uid) {
+            return Process.isIsolatedUid(uid);
+        }
+    }
+
     @RequiresApi(24)
     static class Api24Impl {
 


### PR DESCRIPTION
## Proposed Changes

- Add `ProcessCompat.isIsolatedUid(int uid)` with platform delegation on API 28+ via `Api28Impl` and UID range fallback on earlier API levels.
- Add `ProcessCompat.isSdkSandboxUid(int uid)` with platform delegation on API 33+ via `Api33Impl` and `false` fallback on earlier API levels.
- Update public and restricted API signature files (`current.txt` and `restricted_current.txt`).

## Testing

Test: Added `testIsIsolatedUid` and `testIsSdkSandboxUid` to `ProcessCompatTest`.