### PR TITLE
[Core] Add ftp to PatternsCompat PROTOCOL to match platform Patterns

### DIFF
--- a/core/core/src/androidTest/java/androidx/core/util/PatternsCompatTest.java
+++ b/core/core/src/androidTest/java/androidx/core/util/PatternsCompatTest.java
@@ -150,8 +150,15 @@ public class PatternsCompatTest {
     }
 
     @Test
-    public void testWebUrl_doesNotMatchValidUrlWithInvalidProtocol() throws Exception {
+    public void testWebUrl_matchesValidUrlWithFtpProtocol() throws Exception {
         String url = "ftp://www.example.com";
+        assertTrue("Should match URL with ftp protocol",
+                PatternsCompat.WEB_URL.matcher(url).matches());
+    }
+
+    @Test
+    public void testWebUrl_doesNotMatchValidUrlWithInvalidProtocol() throws Exception {
+        String url = "gopher://www.example.com";
         assertFalse("Should not match URL with invalid protocol",
                 PatternsCompat.WEB_URL.matcher(url).matches());
     }
@@ -330,8 +337,15 @@ public class PatternsCompatTest {
     }
 
     @Test
-    public void testAutoLinkWebUrl_doesNotMatchValidUrlWithInvalidProtocol() throws Exception {
+    public void testAutoLinkWebUrl_matchesValidUrlWithFtpProtocol() throws Exception {
         String url = "ftp://www.example.com";
+        assertTrue("Should match URL with ftp protocol",
+                PatternsCompat.AUTOLINK_WEB_URL.matcher(url).matches());
+    }
+
+    @Test
+    public void testAutoLinkWebUrl_doesNotMatchValidUrlWithInvalidProtocol() throws Exception {
+        String url = "gopher://www.example.com";
         assertFalse("Should not match URL with invalid protocol",
                 PatternsCompat.AUTOLINK_WEB_URL.matcher(url).matches());
     }
@@ -382,7 +396,7 @@ public class PatternsCompatTest {
 
     @Test
     public void testAutoLinkWebUrl_doesNotPartiallyMatchUnknownProtocol() throws Exception {
-        String url = "ftp://foo.bar/baz";
+        String url = "gopher://foo.bar/baz";
         assertFalse("Should not partially match URL with unknown protocol",
                 PatternsCompat.AUTOLINK_WEB_URL.matcher(url).find());
     }

--- a/core/core/src/main/java/androidx/core/util/PatternsCompat.java
+++ b/core/core/src/main/java/androidx/core/util/PatternsCompat.java
@@ -255,7 +255,7 @@ public final class PatternsCompat {
     public static final Pattern DOMAIN_NAME
             = Pattern.compile("(" + HOST_NAME + "|" + IP_ADDRESS + ")");
 
-    private static final String PROTOCOL = "(?i:http|https|rtsp)://";
+    private static final String PROTOCOL = "(?i:http|https|rtsp|ftp)://";
 
     /* A word boundary or end of input.  This is to stop foo.sure from matching as foo.su */
     private static final String WORD_BOUNDARY = "(?:\\b|$|^)";


### PR DESCRIPTION
## Proposed Changes

- Add `ftp` to `PatternsCompat.PROTOCOL`, matching [`android.util.Patterns`](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/util/Patterns.java), which added it in Android 12. This affects `PatternsCompat.WEB_URL` and `PatternsCompat.AUTOLINK_WEB_URL`, both of which currently fail to match `ftp://` URLs that the platform matches on API 31+.
- `PatternsCompatTest` used `ftp://` as its example of an invalid protocol in three places. Those are retargeted to `gopher://`, which the platform also rejects, so the negative coverage is preserved:
  - `testWebUrl_doesNotMatchValidUrlWithInvalidProtocol`
  - `testAutoLinkWebUrl_doesNotMatchValidUrlWithInvalidProtocol`
  - `testAutoLinkWebUrl_doesNotPartiallyMatchUnknownProtocol`
- Added positive `ftp://` tests for both `WEB_URL` and `AUTOLINK_WEB_URL`.

`PROTOCOL` is private, so there is no public API signature change.

## Testing

Test: `./gradlew :core:core:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=androidx.core.util.PatternsCompatTest`

The full `PatternsCompatTest` class passes: **104 tests, 0 failures**, on a device running Android 14 (API 34).

## Issues Fixed

Fixes: [b/553614964](https://issuetracker.google.com/issues/553614964)

I filed the issue asking whether this should be aligned before sending a PR. Opening it anyway so the proposed change is concrete and reviewable — happy to close it if the divergence turns out to be intentional.
