### PR TITLE
Support ISO-8601 date/time strings in A2uiFormatDateFunction

### DIFF
--- a/a2ui/a2ui-model/src/main/kotlin/androidx/a2ui/model/catalog/functions/A2uiFormatDateFunction.kt
+++ b/a2ui/a2ui-model/src/main/kotlin/androidx/a2ui/model/catalog/functions/A2uiFormatDateFunction.kt
@@ -25,8 +25,10 @@ import androidx.a2ui.model.schema.A2uiObjectSchema
 import androidx.a2ui.model.schema.A2uiSchema
 import androidx.a2ui.model.schema.commontypes.A2uiDynamicStringSchema
 import androidx.a2ui.model.schema.commontypes.A2uiDynamicValueSchema
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.Locale
 import java.util.TimeZone
 
 /**
@@ -93,17 +95,10 @@ public constructor(private val localeProvider: A2uiLocaleProvider = A2uiLocalePr
      * @return the formatted date string, or null if required values are missing
      */
     override fun execute(args: Map<String, Any>, executionContext: A2uiExecutionContext): Any? {
-        val value = A2uiFunctionArgParser.getLongArg(args, ARG_VALUE_KEY)
         val format = A2uiFunctionArgParser.getStringArg(args, ARG_FORMAT_KEY)
-
         val locale = localeProvider.getLocale()
 
-        val timeInMillis =
-            if (value < MAX_EPOCH_SECONDS) {
-                value * 1000L
-            } else {
-                value
-            }
+        val timeInMillis = parseValueToEpochMillis(A2uiFunctionArgParser.getArg(args, ARG_VALUE_KEY))
         val date = Date(timeInMillis)
 
         return if (format == FORMAT_ISO) {
@@ -125,6 +120,52 @@ public constructor(private val localeProvider: A2uiLocaleProvider = A2uiLocalePr
         }
     }
 
+    /**
+     * Resolves the raw `value` argument to epoch milliseconds.
+     *
+     * Accepts a numeric epoch timestamp (in seconds or milliseconds, disambiguated via
+     * [MAX_EPOCH_SECONDS]), a numeric string, or an ISO-8601 date/time string (e.g.
+     * `"2025-12-15T10:15:00Z"` or `"2025-12-15"`), matching the value types agents commonly send
+     * for date data (see [ISO_DATE_TIME_PATTERNS]).
+     *
+     * @throws A2uiException.A2uiValidationException if [raw] cannot be interpreted as either.
+     */
+    private fun parseValueToEpochMillis(raw: Any): Long {
+        val epochValue =
+            when (raw) {
+                is Number -> raw.toLong()
+                is String -> raw.toLongOrNull() ?: return parseIsoStringToEpochMillis(raw)
+                else -> throw invalidValueException()
+            }
+        return if (epochValue < MAX_EPOCH_SECONDS) epochValue * 1000L else epochValue
+    }
+
+    /** Parses an ISO-8601-style date/time [value] to epoch milliseconds (interpreted as UTC). */
+    private fun parseIsoStringToEpochMillis(value: String): Long {
+        for (pattern in ISO_DATE_TIME_PATTERNS) {
+            val parser =
+                SimpleDateFormat(pattern, Locale.US).apply {
+                    timeZone = TimeZone.getTimeZone("UTC")
+                    isLenient = false
+                }
+            try {
+                parser.parse(value)?.let {
+                    return it.time
+                }
+            } catch (e: ParseException) {
+                // Not a match for this pattern; try the next one.
+            }
+        }
+        throw invalidValueException()
+    }
+
+    private fun invalidValueException(): A2uiException =
+        A2uiException.A2uiValidationException(
+            "Invalid '$ARG_VALUE_KEY' argument, expected an epoch timestamp (seconds or " +
+                "milliseconds) or an ISO-8601 date/time string",
+            "/$ARG_VALUE_KEY",
+        )
+
     public companion object {
         @JvmField public val INSTANCE: A2uiFormatDateFunction = A2uiFormatDateFunction()
 
@@ -133,5 +174,18 @@ public constructor(private val localeProvider: A2uiLocaleProvider = A2uiLocalePr
         private const val FORMAT_ISO: String = "ISO"
         private const val ISO_FORMAT_PATTERN: String = "yyyy-MM-dd'T'HH:mm:ss'Z'"
         private const val MAX_EPOCH_SECONDS: Long = 10_000_000_000L
+
+        // Mirrors the pattern list used by
+        // androidx.a2ui.compose.ui.catalog.parseIsoDateTimeToUtcMillis for consistent ISO-8601
+        // parsing behavior across the A2UI catalog.
+        private val ISO_DATE_TIME_PATTERNS =
+            arrayOf(
+                "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+                "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                "yyyy-MM-dd'T'HH:mm:ssX",
+                "yyyy-MM-dd'T'HH:mm:ss",
+                "yyyy-MM-dd'T'HH:mm",
+                "yyyy-MM-dd",
+            )
     }
 }

--- a/a2ui/a2ui-model/src/test/kotlin/androidx/a2ui/model/catalog/functions/A2uiFormatDateFunctionTest.kt
+++ b/a2ui/a2ui-model/src/test/kotlin/androidx/a2ui/model/catalog/functions/A2uiFormatDateFunctionTest.kt
@@ -154,6 +154,47 @@ class A2uiFormatDateFunctionTest {
         }
     }
 
+    // ISO-8601 String Tests: `value` may also arrive as an ISO-8601 date/date-time string (as
+    // agents commonly send for date data), not just an epoch timestamp.
+    @Test
+    fun execute_isoDateOnlyStringValue_evaluatesCorrectly() {
+        assertThat(
+                A2uiFormatDateFunction.INSTANCE.execute(
+                    mapOf(ARG_VALUE to "2025-12-15", ARG_FORMAT to "yyyy-MM-dd")
+                )
+            )
+            .isEqualTo("2025-12-15")
+    }
+
+    @Test
+    fun execute_isoInstantStringValue_evaluatesCorrectly() {
+        assertThat(
+                A2uiFormatDateFunction.INSTANCE.execute(
+                    mapOf(ARG_VALUE to "2025-12-15T10:15:00Z", ARG_FORMAT to "yyyy-MM-dd HH:mm")
+                )
+            )
+            .isEqualTo("2025-12-15 10:15")
+    }
+
+    @Test
+    fun execute_isoStringWithMillis_evaluatesCorrectly() {
+        assertThat(
+                A2uiFormatDateFunction.INSTANCE.execute(
+                    mapOf(ARG_VALUE to "2025-12-15T10:15:00.500Z", ARG_FORMAT to "yyyy-MM-dd HH:mm:ss")
+                )
+            )
+            .isEqualTo("2025-12-15 10:15:00")
+    }
+
+    @Test
+    fun execute_nonDateNonNumericStringValue_throwsValidationException() {
+        assertThrows(A2uiException.A2uiValidationException::class.java) {
+            A2uiFormatDateFunction.INSTANCE.execute(
+                mapOf(ARG_VALUE to "not-a-timestamp-or-date", ARG_FORMAT to "yyyy-MM-dd")
+            )
+        }
+    }
+
     private companion object {
         private const val ARG_VALUE = "value"
         private const val ARG_FORMAT = "format"


### PR DESCRIPTION
A2uiFormatDateFunction.execute() only accepted the `value` argument as an epoch timestamp (a Number, or a numeric String), via A2uiFunctionArgParser.getLongArg(). Canonical A2UI examples send date fields as ISO-8601 strings -- e.g. `specification/v1_0/catalogs/basic/examples/01_flight-status.json` in a2ui-project/a2ui sends `"date": "2025-12-15"` and `"departureTime": "2025-12-15T10:15:00Z"` -- which threw `A2uiException.A2uiValidationException` ("Invalid 'value' argument, expected long").

This adds ISO-8601 date/date-time string parsing as a fallback when `value` isn't numeric, supporting date-only and date-time values (minute/second/millisecond precision, with or without a trailing `Z`). It reuses the same pattern list already used by `androidx.a2ui.compose.ui.catalog.parseIsoDateTimeToUtcMillis` (used for `DateTimeInput` components) so both catalog surfaces parse ISO date/time strings consistently.

Non-date, non-numeric values still throw `A2uiException.A2uiValidationException`, unchanged.

On the separate 'validation exception crashes the app' concern raised alongside this bug: I traced `A2uiCoreExecutionContext.executeFunction()` (a2ui-engine) and `A2uiComponentScopeImpl.resolvePayload()` (compose-runtime) -- both already wrap function execution in try/catch and route `A2uiException`/generic `Exception` to `dispatchError()`/`reportError()` instead of propagating. So a thrown `A2uiValidationException` from `formatDate` does not crash the app through those paths; it is reported back to the agent as intended. No change was needed there.

Test: Ported the upstream `A2uiFormatDateFunctionTest` unmodified into a standalone Kotlin/JVM harness (extracted a2ui-model sources, JUnit4 + Truth, since the sandbox available to prepare this change has no Android SDK / full Gradle build) and ran it against both the old and new implementation:
- Before the fix: ISO-8601 string values threw `A2uiValidationException` as described in the bug report.
- After the fix: all 13 pre-existing tests still pass unmodified (locale handling, all numeric value types, ISO output format, all-tokens pattern, all 4 existing exception-throwing cases), plus 4 new tests added to `A2uiFormatDateFunctionTest.kt` covering ISO date-only, ISO instant, ISO instant with milliseconds, and confirming non-date garbage strings still throw `A2uiValidationException`. 17/17 pass.

Please re-run `./gradlew :a2ui:a2ui-model:test` in CI/Treehugger to confirm on the real Android toolchain.